### PR TITLE
Support Python 2.6

### DIFF
--- a/pipdeptree.py
+++ b/pipdeptree.py
@@ -33,7 +33,7 @@ def top_pkg_name(pkg):
     :rtype: string
 
     """
-    return '{}=={}'.format(pkg.project_name, pkg.version)
+    return '{0}=={1}'.format(pkg.project_name, pkg.version)
 
 
 def non_top_pkg_name(req, pkg):
@@ -57,8 +57,8 @@ def non_top_pkg_name(req, pkg):
         vers.append(('installed', pkg.version))
     if not vers:
         return req.key
-    ver_str = ', '.join(['{}: {}'.format(k, v) for k, v in vers])
-    return '{} [{}]'.format(pkg.project_name, ver_str)
+    ver_str = ', '.join(['{0}: {1}'.format(k, v) for k, v in vers])
+    return '{0} [{1}]'.format(pkg.project_name, ver_str)
 
 
 def top_pkg_src(pkg):
@@ -127,8 +127,8 @@ def render_tree(pkgs, pkg_index, req_map, list_all,
     :rtype: str
 
     """
-    pkg_index = {p.key: p for p in pkgs}
-    req_map = {p: p.requires() for p in pkgs}
+    pkg_index = dict((p.key, p) for p in pkgs)
+    req_map = dict((p, p.requires()) for p in pkgs)
     non_top = set(r.key for r in flatten(req_map.values()))
     top = [p for p in pkgs if p.key not in non_top]
 
@@ -185,8 +185,8 @@ def main():
     pkgs = pip.get_installed_distributions(local_only=args.local_only,
                                            skip=skip)
 
-    pkg_index = {p.key: p for p in pkgs}
-    req_map = {p: p.requires() for p in pkgs}
+    pkg_index = dict((p.key, p) for p in pkgs)
+    req_map = dict((p, p.requires()) for p in pkgs)
 
     # show warnings about possibly confusing deps if found and
     # warnings are enabled
@@ -198,7 +198,7 @@ def main():
                 for i, (p, d) in enumerate(xs):
                     pkg = top_pkg_name(p)
                     req = non_top_pkg_name(d, pkg_index[d.key])
-                    tmpl = '  {} -> {}' if i > 0 else '* {} -> {}'
+                    tmpl = '  {0} -> {1}' if i > 0 else '* {0} -> {1}'
                     print(tmpl.format(pkg, req), file=sys.stderr)
             print('-'*72, file=sys.stderr)
 

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,14 @@
+import sys
+
 from setuptools import setup
 
 
 with open('./README.rst') as f:
     long_desc = f.read()
 
+install_requires = ["pip >= 1.4.1"]
+if sys.version_info < (2, 7):
+    install_requires.append('argparse')
 
 setup(
     name='pipdeptree',
@@ -14,7 +19,7 @@ setup(
     license='MIT License',
     description='Command line utility to show dependency tree of packages',
     long_description=long_desc,
-    install_requires=["pip >= 1.4.1"],
+    install_requires=install_requires,
     py_modules=['pipdeptree'],
     entry_points={
         'console_scripts': [

--- a/tests/pipdeptree_tests.py
+++ b/tests/pipdeptree_tests.py
@@ -9,8 +9,8 @@ with open('tests/pkgs.pickle', 'rb') as f:
     pkgs = pickle.load(f)
 
 
-pkg_index = {p.key: p for p in pkgs}
-req_map = {p: p.requires() for p in pkgs}
+pkg_index = dict([(p.key, p) for p in pkgs])  # {p.key: p for p in pkgs}
+req_map = dict([(p, p.requires()) for p in pkgs])  # {p: p.requires() for p in pkgs}
 
 
 def find_req(req, parent):

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py32
+envlist = py26, py27, py32
 
 [testenv]
 commands = nosetests tests/


### PR DESCRIPTION
Unfortunately I can't get the tests to pass because of https://github.com/naiquevin/pipdeptree/issues/3

```
 ❯ tox -e py26
GLOB sdist-make: /Users/marca/dev/git-repos/pipdeptree/setup.py
py26 create: /Users/marca/dev/git-repos/pipdeptree/.tox/py26
py26 installdeps: nose
py26 inst: /Users/marca/dev/git-repos/pipdeptree/.tox/dist/pipdeptree-0.3.zip
py26 runtests: commands[0] | nosetests tests/
EEFFF
======================================================================
ERROR: pipdeptree_tests.test_req_version
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marca/dev/git-repos/pipdeptree/.tox/py26/lib/python2.6/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/marca/dev/git-repos/pipdeptree/tests/pipdeptree_tests.py", line 28, in test_req_version
    sqlalchemy = find_req('sqlalchemy', 'alembic')
  File "/Users/marca/dev/git-repos/pipdeptree/tests/pipdeptree_tests.py", line 24, in find_req
    return [r for r in pkg_index[parent].requires() if r.key == req][0]
IndexError: list index out of range

======================================================================
ERROR: pipdeptree_tests.test_non_top_pkg_name
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marca/dev/git-repos/pipdeptree/.tox/py26/lib/python2.6/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/marca/dev/git-repos/pipdeptree/tests/pipdeptree_tests.py", line 36, in test_non_top_pkg_name
    flask_r = find_req('flask', 'flask-script')
  File "/Users/marca/dev/git-repos/pipdeptree/tests/pipdeptree_tests.py", line 24, in find_req
    return [r for r in pkg_index[parent].requires() if r.key == req][0]
IndexError: list index out of range

======================================================================
FAIL: pipdeptree_tests.test_render_tree_only_top
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marca/dev/git-repos/pipdeptree/.tox/py26/lib/python2.6/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/marca/dev/git-repos/pipdeptree/tests/pipdeptree_tests.py", line 52, in test_render_tree_only_top
    assert '  - SQLAlchemy [required: >=0.7.3, installed: 0.9.1]' in lines
AssertionError

======================================================================
FAIL: pipdeptree_tests.test_render_tree_list_all
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marca/dev/git-repos/pipdeptree/.tox/py26/lib/python2.6/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/marca/dev/git-repos/pipdeptree/tests/pipdeptree_tests.py", line 62, in test_render_tree_list_all
    assert '  - SQLAlchemy [required: >=0.7.3, installed: 0.9.1]' in lines
AssertionError

======================================================================
FAIL: pipdeptree_tests.test_render_tree_freeze
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marca/dev/git-repos/pipdeptree/.tox/py26/lib/python2.6/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/marca/dev/git-repos/pipdeptree/tests/pipdeptree_tests.py", line 72, in test_render_tree_freeze
    assert '  - SQLAlchemy==0.9.1' in lines
AssertionError

----------------------------------------------------------------------
Ran 5 tests in 1.044s

FAILED (errors=2, failures=3)
ERROR: InvocationError: '/Users/marca/dev/git-repos/pipdeptree/.tox/py26/bin/nosetests tests/'
___________________________________________________________________________________ summary ____________________________________________________________________________________
ERROR:   py26: commands failed
```
