### PR TITLE
Add .travis.yml for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+env:
+  - TOXENV=py27
+  - TOXENV=py33
+  - TOXENV=py34
+install:
+  - travis_retry pip install tox==1.6.1
+script:
+  - travis_retry tox


### PR DESCRIPTION
This adds a `.travis.yml` for Travis CI.

For instructions on setting up Travis CI, see http://docs.travis-ci.com/user/getting-started/
