### PR TITLE
Add script for creating test virtualenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 build/
 dist/
 .tox/
+tests/virtualenvs/equimapper/

--- a/tests/pipdeptree_tests.py
+++ b/tests/pipdeptree_tests.py
@@ -5,7 +5,7 @@ from pipdeptree import (req_version, render_tree,
                         top_pkg_src, non_top_pkg_src)
 
 
-with open('tests/pkgs.pickle', 'rb') as f:
+with open('tests/virtualenvs/dummy.pickle', 'rb') as f:
     pkgs = pickle.load(f)
 
 
@@ -70,5 +70,5 @@ def test_render_tree_freeze():
     lines = set(tree_str.split('\n'))
     assert 'Flask-Script==0.6.6' in lines
     assert '  - SQLAlchemy==0.9.1' in lines
-    assert '-e git+git@github.com:naiquevin/lookupy.git@cdbe30c160e1c29802df75e145ea4ad903c05386#egg=Lookupy-master' in lines
+    assert '-e git+https://github.com/naiquevin/lookupy.git@cdbe30c160e1c29802df75e145ea4ad903c05386#egg=Lookupy-master' in lines
     assert 'itsdangerous==0.23' not in lines

--- a/tests/virtualenvs/dummy.pickle
+++ b/tests/virtualenvs/dummy.pickle
@@ -30,7 +30,7 @@ sS'platform'
 p14
 NsS'location'
 p15
-S'/home/vineet/.virtualenvs/equimapper/src/lookupy'
+S'.tox/dummy/src/lookupy'
 p16
 sS'py_version'
 p17
@@ -45,7 +45,7 @@ p21
 g16
 sS'egg_info'
 p22
-S'/home/vineet/.virtualenvs/equimapper/src/lookupy/Lookupy.egg-info'
+S'.tox/dummy/src/lookupy/Lookupy.egg-info'
 p23
 sbsbag1
 (g2
@@ -66,7 +66,7 @@ S'2.5.2'
 p29
 sg14
 Nsg15
-S'/home/vineet/.virtualenvs/equimapper/lib/python2.7/site-packages'
+S'.tox/dummy/lib/python2.7/site-packages'
 p30
 sg17
 S'2.7'
@@ -79,7 +79,7 @@ p32
 g21
 g30
 sg22
-S'/home/vineet/.virtualenvs/equimapper/lib/python2.7/site-packages/psycopg2-2.5.2-py2.7.egg-info'
+S'.tox/dummy/lib/python2.7/site-packages/psycopg2-2.5.2-py2.7.egg-info'
 p34
 sbsbag1
 (g2
@@ -112,7 +112,7 @@ p42
 g21
 g30
 sg22
-S'/home/vineet/.virtualenvs/equimapper/lib/python2.7/site-packages/Werkzeug-0.9.4-py2.7.egg-info'
+S'.tox/dummy/lib/python2.7/site-packages/Werkzeug-0.9.4-py2.7.egg-info'
 p44
 sbsbag1
 (g2
@@ -145,7 +145,7 @@ p52
 g21
 g30
 sg22
-S'/home/vineet/.virtualenvs/equimapper/lib/python2.7/site-packages/Flask-0.10.1-py2.7.egg-info'
+S'.tox/dummy/lib/python2.7/site-packages/Flask-0.10.1-py2.7.egg-info'
 p54
 sbsbag1
 (g2
@@ -178,7 +178,7 @@ p62
 g21
 g30
 sg22
-S'/home/vineet/.virtualenvs/equimapper/lib/python2.7/site-packages/Mako-0.9.1-py2.7.egg-info'
+S'.tox/dummy/lib/python2.7/site-packages/Mako-0.9.1-py2.7.egg-info'
 p64
 sbsbag1
 (g2
@@ -211,7 +211,7 @@ p72
 g21
 g30
 sg22
-S'/home/vineet/.virtualenvs/equimapper/lib/python2.7/site-packages/MarkupSafe-0.18-py2.7.egg-info'
+S'.tox/dummy/lib/python2.7/site-packages/MarkupSafe-0.18-py2.7.egg-info'
 p74
 sbsbag1
 (g2
@@ -244,7 +244,7 @@ p82
 g21
 g30
 sg22
-S'/home/vineet/.virtualenvs/equimapper/lib/python2.7/site-packages/Flask_Script-0.6.6-py2.7.egg-info'
+S'.tox/dummy/lib/python2.7/site-packages/Flask_Script-0.6.6-py2.7.egg-info'
 p84
 sbsbag1
 (g2
@@ -277,7 +277,7 @@ p92
 g21
 g30
 sg22
-S'/home/vineet/.virtualenvs/equimapper/lib/python2.7/site-packages/alembic-0.6.2-py2.7.egg-info'
+S'.tox/dummy/lib/python2.7/site-packages/alembic-0.6.2-py2.7.egg-info'
 p94
 sbsbag1
 (g2
@@ -1360,7 +1360,7 @@ p501
 g21
 g30
 sg22
-S'/home/vineet/.virtualenvs/equimapper/lib/python2.7/site-packages/ipython-2.0.0-py2.7.egg-info'
+S'.tox/dummy/lib/python2.7/site-packages/ipython-2.0.0-py2.7.egg-info'
 p503
 sbsbag1
 (g2
@@ -1393,7 +1393,7 @@ p511
 g21
 g30
 sg22
-S'/home/vineet/.virtualenvs/equimapper/lib/python2.7/site-packages/itsdangerous-0.23-py2.7.egg-info'
+S'.tox/dummy/lib/python2.7/site-packages/itsdangerous-0.23-py2.7.egg-info'
 p513
 sbsbag1
 (g2
@@ -1426,7 +1426,7 @@ p521
 g21
 g30
 sg22
-S'/home/vineet/.virtualenvs/equimapper/lib/python2.7/site-packages/SQLAlchemy-0.9.1-py2.7.egg-info'
+S'.tox/dummy/lib/python2.7/site-packages/SQLAlchemy-0.9.1-py2.7.egg-info'
 p523
 sbsbag1
 (g2
@@ -1459,7 +1459,7 @@ p531
 g21
 g30
 sg22
-S'/home/vineet/.virtualenvs/equimapper/lib/python2.7/site-packages/slugify-0.0.1-py2.7.egg-info'
+S'.tox/dummy/lib/python2.7/site-packages/slugify-0.0.1-py2.7.egg-info'
 p533
 sbsbag1
 (g2
@@ -1492,7 +1492,7 @@ p541
 g21
 g30
 sg22
-S'/home/vineet/.virtualenvs/equimapper/lib/python2.7/site-packages/Jinja2-2.7.2-py2.7.egg-info'
+S'.tox/dummy/lib/python2.7/site-packages/Jinja2-2.7.2-py2.7.egg-info'
 p543
 sbsbag1
 (g2
@@ -1525,6 +1525,6 @@ p551
 g21
 g30
 sg22
-S'/home/vineet/.virtualenvs/equimapper/lib/python2.7/site-packages/redis-2.9.1-py2.7.egg-info'
+S'.tox/dummy/lib/python2.7/site-packages/redis-2.9.1-py2.7.egg-info'
 p553
 sbsba.

--- a/tests/virtualenvs/dummy_requirements.txt
+++ b/tests/virtualenvs/dummy_requirements.txt
@@ -1,0 +1,16 @@
+Flask==0.10.1
+Flask-Script==0.6.6
+Jinja2==2.7.2
+-e git+https://github.com/naiquevin/lookupy.git@cdbe30c160e1c29802df75e145ea4ad903c05386#egg=Lookupy
+Mako==0.9.1
+MarkupSafe==0.18
+SQLAlchemy==0.9.1
+Werkzeug==0.9.4
+alembic==0.6.2
+gnureadline==6.3.3
+ipython==2.0.0
+itsdangerous==0.23
+psycopg2==2.5.2
+redis==2.9.1
+slugify==0.0.1
+wsgiref==0.1.2

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,20 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py32
+envlist = dummy, py27, py32
 
 [testenv]
 commands = nosetests tests/
 deps =
     nose
+
+
+# ---------------------------------------------------------------------------
+# Dummy virtualenvs that get created and used by the tests
+# These have no test commands
+# These virtualenvs simply get created and use in other testenvs
+# ---------------------------------------------------------------------------
+
+[testenv:dummy]
+deps = -r{toxinidir}/tests/virtualenvs/dummy_requirements.txt
+commands =


### PR DESCRIPTION
so that tests are not reliant on `/home/vineet/.virtualenvs/equimapper`

This fixes for me all but one of the test failures in https://github.com/naiquevin/pipdeptree/issues/3

```
$ python tests/create_test_virtualenv.py
Creating test virtualenv: tests/virtualenvs/equimapper
New python executable in tests/virtualenvs/equimapper/bin/python
Installing setuptools, pip...done.
Downloading/unpacking Flask==0.10.1 (from -r tests/virtualenvs/equimapper/../equimapper_requirements.txt (line 1))
...
Successfully installed Flask Flask-Script Jinja2 Lookupy-master Mako MarkupSafe SQLAlchemy Werkzeug alembic gnureadline ipython itsdangerous psycopg2 redis slugify
Cleaning up...
```

```
$ tox -e py27
GLOB sdist-make: /Users/marca/dev/git-repos/pipdeptree/setup.py
py27 inst-nodeps: /Users/marca/dev/git-repos/pipdeptree/.tox/dist/pipdeptree-0.3.zip
py27 runtests: commands[0] | nosetests tests/
....F
======================================================================
FAIL: pipdeptree_tests.test_render_tree_freeze
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marca/dev/git-repos/pipdeptree/.tox/py27/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/marca/dev/git-repos/pipdeptree/tests/pipdeptree_tests.py", line 73, in test_render_tree_freeze
    assert '-e git+git@github.com:naiquevin/lookupy.git@cdbe30c160e1c29802df75e145ea4ad903c05386#egg=Lookupy-master' in lines
AssertionError

----------------------------------------------------------------------
Ran 5 tests in 0.245s

FAILED (failures=1)
ERROR: InvocationError: '/Users/marca/dev/git-repos/pipdeptree/.tox/py27/bin/nosetests tests/'
___________________________________________________________________________________ summary ____________________________________________________________________________________
ERROR:   py27: commands failed
```

So only one failure now instead of five!
