### PR TITLE
Fix infinite recursion for circular dependency

### DIFF
--- a/pipdeptree.py
+++ b/pipdeptree.py
@@ -131,6 +131,7 @@ def render_tree(pkgs, pkg_index, req_map, list_all,
     req_map = {p: p.requires() for p in pkgs}
     non_top = set(r.key for r in flatten(req_map.values()))
     top = [p for p in pkgs if p.key not in non_top]
+    pkgs_processed = set()
 
     def aux(pkg, indent=0):
         # In this function, pkg can either be a Distribution or
@@ -150,8 +151,9 @@ def render_tree(pkgs, pkg_index, req_map, list_all,
 
         # FixMe! in case of some pkg not present in list of all
         # packages, eg. `testresources`, this will fail
-        if pkg.key in pkg_index:
+        if pkg.key in pkg_index and pkg not in pkgs_processed:
             pkg_deps = pkg_index[pkg.key].requires()
+            pkgs_processed.add(pkg)
             result += list(flatten([aux(d, indent=indent+2)
                                     for d in pkg_deps]))
         return result


### PR DESCRIPTION
Infinite recursion occurs if package A depends on package B and package B depends on package A.

For example:

I happen to have two internal packages on our internal package index that depend on each other (circular dependency).

Running `pipdeptree` in this virtualenv results in:

``` python
  File "/opt/ci/build/jobs/ProfileSvc/workspace/TOXENV/py27/.tox/py27/local/lib/python2.7/site-packages/pipdeptree.py", line 156, in aux
    for d in pkg_deps]))
  File "/opt/ci/build/jobs/ProfileSvc/workspace/TOXENV/py27/.tox/py27/local/lib/python2.7/site-packages/pipdeptree.py", line 156, in aux
    for d in pkg_deps]))
  File "/opt/ci/build/jobs/ProfileSvc/workspace/TOXENV/py27/.tox/py27/local/lib/python2.7/site-packages/pipdeptree.py", line 156, in aux
    for d in pkg_deps]))
  File "/opt/ci/build/jobs/ProfileSvc/workspace/TOXENV/py27/.tox/py27/local/lib/python2.7/site-packages/pipdeptree.py", line 156, in aux
    for d in pkg_deps]))
  File "/opt/ci/build/jobs/ProfileSvc/workspace/TOXENV/py27/.tox/py27/local/lib/python2.7/site-packages/pipdeptree.py", line 146, in aux
    name = pkg.project_name if dist is None else non_top_pkg_str(pkg, dist)
  File "/opt/ci/build/jobs/ProfileSvc/workspace/TOXENV/py27/.tox/py27/local/lib/python2.7/site-packages/pipdeptree.py", line 57, in non_top_pkg_name
    vers.append(('installed', pkg.version))
RuntimeError: maximum recursion depth exceeded
```

The infinite recursion is occurring here:

https://github.com/naiquevin/pipdeptree/blob/master/pipdeptree.py#L155

To fix this, I introduce a `pkgs_processed` set, which keeps track of the packages that we've already determined dependencies for so we don't keep redoing this ad-infinitum.
