### PR TITLE
Use tox to create dummy virtualenv within tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,13 +4,16 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = dummy, py26, py27, py32, py33, py34
+envlist = py26, py27, py32, py33, py34
 
 [testenv]
-commands = py.test {posargs:--cov pipdeptree --cov-report xml --cov-report html --cov-report term-missing tests/}
+commands =
+    tox -e dummy
+    py.test {posargs:--cov pipdeptree --cov-report xml --cov-report html --cov-report term-missing tests/}
 deps =
     pytest
     pytest-cov
+whitelist_externals = tox
 
 # ---------------------------------------------------------------------------
 # Dummy virtualenvs that get created and used by the tests


### PR DESCRIPTION
This creates the dummy env by calling tox within tox so it's guaranteed that it will be present, even on Travis CI, where different envs might run on different workers. 
