### PR TITLE
Remove computation of pkg_index and req_map

### DIFF
--- a/pipdeptree.py
+++ b/pipdeptree.py
@@ -127,8 +127,6 @@ def render_tree(pkgs, pkg_index, req_map, list_all,
     :rtype: str
 
     """
-    pkg_index = dict((p.key, p) for p in pkgs)
-    req_map = dict((p, p.requires()) for p in pkgs)
     non_top = set(r.key for r in flatten(req_map.values()))
     top = [p for p in pkgs if p.key not in non_top]
 


### PR DESCRIPTION
because they are already passed into the `render_tree` function.
