### PR TITLE
Restore Python 2.6 compatibility

### DIFF
--- a/tests/test_pipdeptree.py
+++ b/tests/test_pipdeptree.py
@@ -15,8 +15,8 @@ def venv_fixture(pickle_file):
     """
     with open(pickle_file, 'rb') as f:
         pkgs = pickle.load(f)
-        pkg_index = {p.key: p for p in pkgs}
-        req_map = {p: p.requires() for p in pkgs}
+        pkg_index = dict((p.key, p) for p in pkgs)
+        req_map = dict((p, p.requires()) for p in pkgs)
         return pkgs, pkg_index, req_map
 
 


### PR DESCRIPTION
c70525bb8430d7fa7de5919f0ef7d489428f7154 broke Python 2.6 compatibility by using a dict comprehension, which is a Python 2.7 feature. I replaced it with calling `dict` with a generator expression, which looks almost as good and it works in Python 2.6.
