### PR TITLE
Use package skip list inside the loop to avoid KeyError

### DIFF
--- a/pipdeptree.py
+++ b/pipdeptree.py
@@ -241,6 +241,8 @@ def main():
             print('Warning!!! Possible confusing dependencies found:', file=sys.stderr)
             for xs in confusing:
                 for i, (p, d) in enumerate(xs):
+                    if d.key in skip:
+                        continue
                     pkg = top_pkg_name(p)
                     req = non_top_pkg_name(d, pkg_index[d.key])
                     tmpl = '  {0} -> {1}' if i > 0 else '* {0} -> {1}'


### PR DESCRIPTION
This change should fix #21 and #23. I guess the intention was not to show `pip`, `setuptools` or `distribute` as confusing dependencies, so let's bail out of the loop if we encounter these.
