### PR TITLE
fix: remove imports from the deprecated pip API

### DIFF
--- a/pipdeptree.py
+++ b/pipdeptree.py
@@ -1,25 +1,20 @@
-from __future__ import print_function
+from __future__ import absolute_import, print_function
+
+import argparse
+import json
 import os
 import sys
-from itertools import chain
 from collections import defaultdict
-import argparse
-from operator import attrgetter
-import json
 from importlib import import_module
-
+from itertools import chain
+from operator import attrgetter
 try:
     from collections import OrderedDict
 except ImportError:
     from ordereddict import OrderedDict
 
-try:
-    from pip._internal import get_installed_distributions
-    from pip._internal.operations.freeze import FrozenRequirement
-except ImportError:
-    from pip import get_installed_distributions, FrozenRequirement
-
 import pkg_resources
+
 # inline:
 # from graphviz import backend, Digraph
 
@@ -156,8 +151,7 @@ class Package(object):
 
     @staticmethod
     def frozen_repr(obj):
-        fr = FrozenRequirement.from_dist(obj, [])
-        return str(fr).strip()
+        return str(obj.as_requirement())
 
     def __getattr__(self, key):
         return getattr(self._obj, key)
@@ -564,8 +558,9 @@ def _get_args():
 
 def main():
     args = _get_args()
-    pkgs = get_installed_distributions(local_only=args.local_only,
-                                           user_only=args.user_only)
+    # pkgs = get_installed_distributions(local_only=args.local_only,
+    #                                        user_only=args.user_only)
+    pkgs = list(pkg_resources.working_set)
 
     dist_index = build_dist_index(pkgs)
     tree = construct_tree(dist_index)

--- a/tests/test_pipdeptree.py
+++ b/tests/test_pipdeptree.py
@@ -3,16 +3,15 @@ import os
 import pickle
 import sys
 from contextlib import contextmanager
-from tempfile import NamedTemporaryFile
 from operator import attrgetter
+from tempfile import NamedTemporaryFile
 
 import pytest
-
-from pipdeptree import (build_dist_index, construct_tree,
-                        DistPackage, ReqPackage, render_tree,
-                        reverse_tree, cyclic_deps, conflicting_deps,
-                        get_parser, render_json, render_json_tree,
-                        dump_graphviz, print_graphviz, main)
+from pipdeptree import (DistPackage, ReqPackage, build_dist_index,
+                        conflicting_deps, construct_tree, cyclic_deps,
+                        dump_graphviz, get_parser, main, print_graphviz,
+                        render_json, render_json_tree, render_tree,
+                        reverse_tree)
 
 
 def venv_fixture(pickle_file):
@@ -125,13 +124,16 @@ def test_render_tree_list_all():
 
 
 def test_render_tree_exclude():
-    tree_str = render_tree(tree, list_all=True, exclude={'itsdangerous', 'SQLAlchemy', 'Flask', 'markupsafe', 'wheel'})
+    tree_str = render_tree(tree, list_all=True, exclude={
+        'itsdangerous', 'SQLAlchemy', 'Flask', 'markupsafe', 'wheel', 'Python',
+        'pip', 'setuptools'})
     expected = """alembic==0.9.10
   - Mako [required: Any, installed: 1.0.7]
   - python-dateutil [required: Any, installed: 2.7.3]
     - six [required: >=1.5, installed: 1.11.0]
   - python-editor [required: >=0.3, installed: 1.0.3]
-click==6.7
+argparse==1.2.1
+Click==7.0
 Flask-Script==2.0.6
 gnureadline==6.3.8
 Jinja2==2.10
@@ -144,15 +146,19 @@ python-editor==1.0.3
 redis==2.10.6
 six==1.11.0
 slugify==0.0.1
-Werkzeug==0.14.1"""
+Werkzeug==0.14.1
+wsgiref==0.1.2"""
     assert expected == tree_str
 
 
 def test_render_tree_exclude_reverse():
     rtree = reverse_tree(tree)
-    tree_str = render_tree(rtree, list_all=True, exclude={'itsdangerous', 'SQLAlchemy', 'Flask', 'markupsafe', 'wheel'})
+    tree_str = render_tree(rtree, list_all=True, exclude={
+        'itsdangerous', 'SQLAlchemy', 'Flask', 'markupsafe', 'wheel', 'Python',
+        'pip', 'setuptools'})
     expected = """alembic==0.9.10
-click==6.7
+argparse==1.2.1
+click==7.0
 Flask-Script==2.0.6
 gnureadline==6.3.8
 Jinja2==2.10
@@ -169,7 +175,8 @@ six==1.11.0
   - python-dateutil==2.7.3 [requires: six>=1.5]
     - alembic==0.9.10 [requires: python-dateutil]
 slugify==0.0.1
-Werkzeug==0.14.1"""
+Werkzeug==0.14.1
+wsgiref==0.1.2"""
     assert expected == tree_str
 
 

--- a/tests/virtualenvs/Makefile
+++ b/tests/virtualenvs/Makefile
@@ -1,4 +1,4 @@
-
+.PHONY : testenv cyclicenv unsatisfiedenv
 
 testenv:
 	virtualenv --python=python2.7 testenv

--- a/tests/virtualenvs/pickle_env.py
+++ b/tests/virtualenvs/pickle_env.py
@@ -4,21 +4,15 @@
 # purposes of writing tests
 
 import pickle
+import pkg_resources
 import sys
-
-try:
-    import pip._internal as pip
-except ImportError:
-    import pip
 
 
 def main():
-    default_skip = ['setuptools', 'pip', 'python', 'distribute']
-    skip = default_skip + ['pipdeptree']
-    pkgs = pip.get_installed_distributions(local_only=True, skip=skip)
+    skip = {'setuptools', 'pip', 'python', 'distribute', 'pipdeptree'}
+    pkgs = [p for p in pkg_resources.working_set if str(p) not in skip]
     pickle.dump(pkgs, sys.stdout)
-    return 0
 
 
 if __name__ == '__main__':
-    sys.exit(main())
+    main()


### PR DESCRIPTION
* Fix #105 

I think this should be a good start to move away entirely from pip. The only part I'm not clear about is the `local_only` and `user_only` flag. I'm not sure how to influence that for the `pkg_resources.working_set`.