### PR TITLE
Use importlib.metadata for guess_version instead of importing the module

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.3.1
+
+- Use `importlib.metadata` to guess version of package before fallback to `pkg.__version__`.
+
 ## 2.3.0
 
 - Move to a package layout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ optional-dependencies.test = [
   "pytest>=7.1.3",
   "pytest-cov>=3",
   "pytest-mock>=3.8.2",
-  "virtualenv<21,>=20.16.4",
+  "virtualenv<21,>=20.16.5",
 ]
 optional-dependencies.graphviz = [
   "graphviz>=0.20.1",

--- a/src/pipdeptree/__init__.py
+++ b/src/pipdeptree/__init__.py
@@ -42,6 +42,18 @@ def guess_version(pkg_key, default="?"):
     :rtype: string
     """
     try:
+        if sys.version_info >= (3, 8):  # pragma: >=3.8 cover
+            import importlib.metadata as importlib_metadata
+        else:  # pragma: <3.8 cover
+            import importlib_metadata
+        return importlib_metadata.version(pkg_key)
+    except ImportError:
+        pass
+    # Avoid AssertionError with setuptools
+    # see https://github.com/tox-dev/pipdeptree/issues/162
+    if pkg_key in {"setuptools"}:
+        return default
+    try:
         m = import_module(pkg_key)
     except ImportError:
         return default

--- a/src/pipdeptree/__init__.py
+++ b/src/pipdeptree/__init__.py
@@ -49,8 +49,7 @@ def guess_version(pkg_key, default="?"):
         return importlib_metadata.version(pkg_key)
     except ImportError:
         pass
-    # Avoid AssertionError with setuptools
-    # see https://github.com/tox-dev/pipdeptree/issues/162
+    # Avoid AssertionError with setuptools, see https://github.com/tox-dev/pipdeptree/issues/162
     if pkg_key in {"setuptools"}:
         return default
     try:

--- a/tests/guess_version_setuptools.py
+++ b/tests/guess_version_setuptools.py
@@ -1,0 +1,16 @@
+import sys
+
+import pipdeptree
+
+if sys.version_info >= (3, 8):
+    import importlib.metadata as importlib_metadata
+else:
+    import importlib_metadata
+
+
+def raise_import_error(name):
+    raise ImportError(name)
+
+
+importlib_metadata.version = raise_import_error
+print(pipdeptree.guess_version("setuptools"), end="")

--- a/tests/test_pipdeptree.py
+++ b/tests/test_pipdeptree.py
@@ -11,7 +11,6 @@ except ImportError:
     from unittest import mock
 
 import pytest
-import virtualenv
 
 import pipdeptree as p
 
@@ -466,6 +465,8 @@ def test_parser_svg():
 
 @pytest.mark.parametrize("args_joined", [True, False])
 def test_custom_interpreter(tmp_path, monkeypatch, capfd, args_joined):
+    import virtualenv
+
     result = virtualenv.cli_run([str(tmp_path), "--activators", ""])
     cmd = [sys.executable]
     cmd += [f"--python={result.creator.exe}"] if args_joined else ["--python", str(result.creator.exe)]
@@ -495,7 +496,6 @@ def test_guess_version_setuptools_not_imported(monkeypatch):
     builtin_import = builtins.__import__
 
     def _import(name, *args, **kwargs):
-        assert name not in {"setuptools"}
         if name in {"importlib.metadata", "importlib_metadata"}:
             raise ImportError
         return builtin_import(name, *args, **kwargs)

--- a/tests/test_pipdeptree.py
+++ b/tests/test_pipdeptree.py
@@ -1,4 +1,3 @@
-import builtins
 import platform
 import sys
 from contextlib import contextmanager
@@ -491,14 +490,10 @@ def test_custom_interpreter(tmp_path, monkeypatch, capfd, args_joined):
     assert err == "graphviz functionality is not supported when querying" " non-host python\n"
 
 
-def test_guess_version_setuptools_not_imported(monkeypatch):
-    builtin_import = builtins.__import__
-
-    def _import(name, *args, **kwargs):
-        if name in {"importlib.metadata", "importlib_metadata"}:
-            raise ImportError
-        return builtin_import(name, *args, **kwargs)
-
-    with monkeypatch.context() as m:
-        m.setattr(builtins, "__import__", _import)
-        assert p.guess_version("setuptools") == p.ReqPackage.UNKNOWN_VERSION
+def test_guess_version_setuptools_not_imported(mocker):
+    mock_importlib_metadata = mocker.Mock(spec_set=["version"])
+    mock_importlib_metadata.version = mocker.Mock(side_effect=ImportError)
+    mocker.patch.dict("sys.modules", {"importlib.metadata": mock_importlib_metadata})
+    mock_import_module = mocker.patch.object(p, "import_module", autospec=True)
+    assert p.guess_version("setuptools") == p.ReqPackage.UNKNOWN_VERSION
+    mock_import_module.assert_not_called()

--- a/tests/test_pipdeptree.py
+++ b/tests/test_pipdeptree.py
@@ -491,9 +491,11 @@ def test_custom_interpreter(tmp_path, monkeypatch, capfd, args_joined):
 
 
 def test_guess_version_setuptools_not_imported(mocker):
+    mock_importlib = mocker.Mock(spec_set=["metadata"])
     mock_importlib_metadata = mocker.Mock(spec_set=["version"])
+    mock_importlib.metadata = mock_importlib_metadata
     mock_importlib_metadata.version = mocker.Mock(side_effect=ImportError)
-    mocker.patch.dict("sys.modules", {"importlib.metadata": mock_importlib_metadata})
+    mocker.patch.dict("sys.modules", {"importlib": mock_importlib, "importlib.metadata": mock_importlib_metadata})
     mock_import_module = mocker.patch.object(p, "import_module", autospec=True)
     assert p.guess_version("setuptools") == p.ReqPackage.UNKNOWN_VERSION
     mock_import_module.assert_not_called()

--- a/tests/test_pipdeptree.py
+++ b/tests/test_pipdeptree.py
@@ -495,7 +495,14 @@ def test_guess_version_setuptools_not_imported(mocker):
     mock_importlib_metadata = mocker.Mock(spec_set=["version"])
     mock_importlib.metadata = mock_importlib_metadata
     mock_importlib_metadata.version = mocker.Mock(side_effect=ImportError)
-    mocker.patch.dict("sys.modules", {"importlib": mock_importlib, "importlib.metadata": mock_importlib_metadata})
+    mocker.patch.dict(
+        "sys.modules",
+        {
+            "importlib": mock_importlib,
+            "importlib.metadata": mock_importlib_metadata,
+            "importlib_metadata": mock_importlib_metadata,
+        },
+    )
     mock_import_module = mocker.patch.object(p, "import_module", autospec=True)
     assert p.guess_version("setuptools") == p.ReqPackage.UNKNOWN_VERSION
     mock_import_module.assert_not_called()

--- a/tests/test_pipdeptree.py
+++ b/tests/test_pipdeptree.py
@@ -11,6 +11,7 @@ except ImportError:
     from unittest import mock
 
 import pytest
+import virtualenv
 
 import pipdeptree as p
 
@@ -465,8 +466,6 @@ def test_parser_svg():
 
 @pytest.mark.parametrize("args_joined", [True, False])
 def test_custom_interpreter(tmp_path, monkeypatch, capfd, args_joined):
-    import virtualenv
-
     result = virtualenv.cli_run([str(tmp_path), "--activators", ""])
     cmd = [sys.executable]
     cmd += [f"--python={result.creator.exe}"] if args_joined else ["--python", str(result.creator.exe)]

--- a/tests/test_pipdeptree.py
+++ b/tests/test_pipdeptree.py
@@ -488,3 +488,9 @@ def test_custom_interpreter(tmp_path, monkeypatch, capfd, args_joined):
     assert context.value.code == 1
     assert not out
     assert err == "graphviz functionality is not supported when querying" " non-host python\n"
+
+
+def test_guess_version_setuptools_not_imported():
+    with mock.patch("builtins.__import__") as mock_import:
+        mock_import.side_effect = ImportError
+        assert p.guess_version("setuptools") == p.ReqPackage.UNKNOWN_VERSION

--- a/tests/test_pipdeptree.py
+++ b/tests/test_pipdeptree.py
@@ -1,9 +1,9 @@
 import platform
 import subprocess
 import sys
-import textwrap
 from contextlib import contextmanager
 from itertools import chain
+from pathlib import Path
 from tempfile import NamedTemporaryFile
 
 try:
@@ -493,22 +493,6 @@ def test_custom_interpreter(tmp_path, monkeypatch, capfd, args_joined):
 
 
 def test_guess_version_setuptools():
-    code = """
-    import sys
-
-    import pipdeptree
-
-    if sys.version_info >= (3, 8):
-        import importlib.metadata as importlib_metadata
-    else:
-        import importlib_metadata
-
-    def raise_import_error(name):
-        raise ImportError(name)
-
-    importlib_metadata.version = raise_import_error
-
-    print(pipdeptree.guess_version("setuptools"), end="")
-    """
-    p = subprocess.run([sys.executable, "-c", textwrap.dedent(code)], capture_output=True, check=True)
-    assert p.stdout == b"?"
+    script = Path(__file__).parent / "guess_version_setuptools.py"
+    output = subprocess.check_output([sys.executable, script], text=True)
+    assert output == "?"


### PR DESCRIPTION
Fixes #162 

The current approach tries to import the package and look at `package.__version__`. This is not exactly reliable and also causes Assertion Error in the case where the packages is `setuptools` (because pipdeptree imports `pip` and `setuptools` can't be imported after `pip` because of weird hacks in setuptools). The better and simpler approach is to use `importlib.metadata.version`.
