### PR TITLE
Make the output of the dot format deterministic and stable

### DIFF
--- a/src/pipdeptree/__init__.py
+++ b/src/pipdeptree/__init__.py
@@ -612,7 +612,11 @@ def dump_graphviz(tree, output_format="dot", is_reverse=False):
 
     # Allow output of dot format, even if GraphViz isn't installed.
     if output_format == "dot":
-        return graph.source
+        # Emulates graphviz.dot.Dot.__iter__() to force the sorting of graph.body.
+        # Fixes https://github.com/tox-dev/pipdeptree/issues/188
+        # That way we can guarantee the output of the dot format is deterministic
+        # and stable.
+        return "".join([tuple(graph)[0]] + sorted(graph.body) + [graph._tail])
 
     # As it's unknown if the selected output format is binary or not, try to
     # decode it as UTF8 and only print it out in binary if that's not possible.


### PR DESCRIPTION
This is an adhoc re-interpretation of the [`graphviz.dot.Dot.__iter__()` method](https://github.com/xflr6/graphviz/blob/master/graphviz/dot.py#L158-L182) that is used behind the scene by [the original `graph.source` call](https://github.com/tox-dev/pipdeptree/blob/2eb489449169b59711a4fc979f4fc3483e8e81b0/src/pipdeptree/__init__.py#L613-L615) to dump the graphviz dot file content in `pipdeptree` (i.e. when the `--graph-output dot` parameter in called on the CLI).

But in this PR, we forces the sorting of the generated nodes and edge statements of the graph. That way we address issue #188, in which each invokation of the `pipdeptree` generates a different dot file.

The order of the `dot`-statements does not matter because of the nature of dependencies and the way `pipdeptree` process them. That's why a call to `sorted()` works without any special care. Graphviz will anyway re-interpret internally the relationships on rendering.