### PR TITLE
Implements Mermaid output

### DIFF
--- a/src/pipdeptree/__init__.py
+++ b/src/pipdeptree/__init__.py
@@ -556,7 +556,7 @@ def render_mermaid(tree) -> str:
 
     :param dict tree: dependency graph
     """
-    # Use a sets to deduplicate entries.
+    # Use a sets to avoid duplicate entries.
     nodes: set[str] = set()
     edges: set[str] = set()
 
@@ -573,19 +573,19 @@ def render_mermaid(tree) -> str:
                 edges.add(f"{pkg.key} -- {edge_label} --> {dep.key}")
 
     # Produce the Mermaid Markdown.
-    INDENT = " " * 4
-    mmd = dedent(f"""\
+    indent = " " * 4
+    output = dedent(f"""\
         flowchart TD
-        {INDENT}classDef missing stroke-dasharray: 5
+        {indent}classDef missing stroke-dasharray: 5
         """
     )
     # Sort the nodes and edges to make the output deterministic.
-    mmd += INDENT
-    mmd += f"\n{INDENT}".join(node for node in sorted(nodes))
-    mmd += "\n" + INDENT
-    mmd += f"\n{INDENT}".join(edge for edge in sorted(edges))
-    mmd += "\n"
-    return mmd
+    output += indent
+    output += f"\n{indent}".join(node for node in sorted(nodes))
+    output += "\n" + indent
+    output += f"\n{indent}".join(edge for edge in sorted(edges))
+    output += "\n"
+    return output
 
 
 def dump_graphviz(tree, output_format="dot", is_reverse=False):

--- a/src/pipdeptree/__init__.py
+++ b/src/pipdeptree/__init__.py
@@ -574,7 +574,8 @@ def render_mermaid(tree) -> str:
 
     # Produce the Mermaid Markdown.
     indent = " " * 4
-    output = dedent(f"""\
+    output = dedent(
+        f"""\
         flowchart TD
         {indent}classDef missing stroke-dasharray: 5
         """
@@ -817,10 +818,7 @@ def get_parser():
         "--mermaid",
         action="store_true",
         default=False,
-        help=(
-            "Display dependency tree as a Maermaid graph. "
-            "This option overrides all other options."
-        ),
+        help=("Display dependency tree as a Maermaid graph. " "This option overrides all other options."),
     )
     parser.add_argument(
         "--graph-output",

--- a/tests/test_pipdeptree.py
+++ b/tests/test_pipdeptree.py
@@ -305,9 +305,9 @@ def test_render_text(capsys, list_all, reverse, expected_output):
 
 # Tests for graph outputs
 
+
 def randomized_dag_copy(t):
-    """Returns a copy of the package tree fixture with dependencies in randomized order.
-    """
+    """Returns a copy of the package tree fixture with dependencies in randomized order."""
     # Extract the dependency graph from the package tree and randomize it.
     randomized_graph = {}
     randomized_nodes = list(t._obj.keys())
@@ -329,7 +329,8 @@ def test_render_mermaid():
     # Mermaid output.
     for package_tree in (t, randomized_dag_copy(t)):
         output = p.render_mermaid(package_tree)
-        assert output == dedent("""\
+        assert output == dedent(
+            """\
             flowchart TD
                 classDef missing stroke-dasharray: 5
                 a[a\\n3.4.0]
@@ -350,6 +351,7 @@ def test_render_mermaid():
                 g -- >=3.0.0 --> f
             """
         )
+
 
 def test_render_dot(capsys):
     # Check both the sorted and randomized package tree produces the same sorted


### PR DESCRIPTION
This PR adds a new `--mermaid` to the CLI to produce Mermaid's Markdown output of the dependency graph.

This closes #129.