### PR TITLE
Avoid changing `t` in `randomized_dag_copy()` by shallow copying

### DIFF
--- a/tests/test_pipdeptree.py
+++ b/tests/test_pipdeptree.py
@@ -774,7 +774,7 @@ def randomized_dag_copy(raw: PackageDAG) -> PackageDAG:
     randomized_nodes = list(raw._obj.keys())  # noqa: SLF001
     random.shuffle(randomized_nodes)
     for node in randomized_nodes:
-        edges = raw._obj[node]  # noqa: SLF001
+        edges = raw._obj[node].copy()  # noqa: SLF001
         random.shuffle(edges)
         randomized_graph[node] = edges
     assert set(randomized_graph) == set(raw._obj)  # noqa: SLF001


### PR DESCRIPTION
Resolves #256.

After doing some bisecting and running the testing code using the `randomly` plugin, I found that the problem lies here:

https://github.com/tox-dev/pipdeptree/blob/f18a32136cbc69c13cfdf76c7065e84e25ee4ea8/tests/test_pipdeptree.py#L775

`randomized_dag_copy()` ends up modifying the global variable `t` when it shuffles the list of `ReqPackage`s associated to a `DistPackage`.

This CL fixes this by just shallow copying the list.
