### PR TITLE
Have --packages and --all work together

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
       - id: prettier
         args: ["--print-width=120", "--prose-wrap=always"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.0.278"
+    rev: "v0.0.280"
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/src/pipdeptree/_cli.py
+++ b/src/pipdeptree/_cli.py
@@ -70,8 +70,8 @@ def build_parser() -> ArgumentParser:
     select.add_argument(
         "-e",
         "--exclude",
-        help="comma separated list of packages to not show - wildcards are supported, like 'somepackage.*'."
-        " Cannot be used with -p or -a.",
+        help="comma separated list of packages to not show - wildcards are supported, like 'somepackage.*'. "
+        "(cannot combine with -p or -a)",
         metavar="P",
     )
     select.add_argument("-a", "--all", action="store_true", help="list all deps at top level")

--- a/tests/render/test_text.py
+++ b/tests/render/test_text.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Callable, Iterator
-from unittest.mock import Mock
 
 import pytest
 
-from pipdeptree._render.text import render_text
-from tests.our_types import MockGraph
-
 from pipdeptree._models import PackageDAG
+from pipdeptree._render.text import render_text
+
+if TYPE_CHECKING:
+    from unittest.mock import Mock
+
+    from tests.our_types import MockGraph
 
 
 @pytest.mark.parametrize(

--- a/tests/render/test_text.py
+++ b/tests/render/test_text.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, Iterator
+from unittest.mock import Mock
 
 import pytest
 
 from pipdeptree._render.text import render_text
+from tests.our_types import MockGraph
 
-if TYPE_CHECKING:
-    from pipdeptree._models import PackageDAG
+from pipdeptree._models import PackageDAG
 
 
 @pytest.mark.parametrize(
@@ -505,4 +506,33 @@ def test_render_text_encoding(
 ) -> None:
     render_text(example_dag, max_depth=level, encoding=encoding, list_all=True, frozen=False)
     captured = capsys.readouterr()
+    assert "\n".join(expected_output).strip() == captured.out.strip()
+
+
+def test_render_text_list_all_and_packages_options_used(
+    capsys: pytest.CaptureFixture[str],
+    mock_pkgs: Callable[[MockGraph], Iterator[Mock]],
+) -> None:
+    graph: dict[tuple[str, str], list[tuple[str, list[tuple[str, str]]]]] = {
+        ("examplePy", "1.2.3"): [("hellopy", [(">=", "2.0.0")]), ("worldpy", [(">=", "0.0.2")])],
+        ("HelloPy", "2.0.0"): [],
+        ("worldpy", "0.0.2"): [],
+        ("anotherpy", "0.1.2"): [("hellopy", [(">=", "2.0.0")])],
+        ("YetAnotherPy", "3.1.2"): [],
+    }
+    package_dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
+
+    # NOTE: Mimicking the --packages option being used here.
+    package_dag = package_dag.filter_nodes({"examplePy"}, None)
+
+    render_text(package_dag, max_depth=float("inf"), encoding="utf-8", list_all=True, frozen=False)
+    captured = capsys.readouterr()
+    expected_output = [
+        "examplePy==1.2.3",
+        "├── HelloPy [required: >=2.0.0, installed: 2.0.0]",
+        "└── worldpy [required: >=0.0.2, installed: 0.0.2]",
+        "HelloPy==2.0.0",
+        "worldpy==0.0.2",
+    ]
+
     assert "\n".join(expected_output).strip() == captured.out.strip()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from pipdeptree._cli import build_parser
+from pipdeptree._cli import build_parser, get_options
 
 
 def test_parser_default() -> None:
@@ -75,3 +75,23 @@ def test_parser_depth(should_be_error: bool, depth_arg: list[str], expected_valu
     else:
         args = parser.parse_args(depth_arg)
         assert args.depth == expected_value
+
+
+@pytest.mark.parametrize(
+    ("should_be_error", "args", "expected_value"),
+    [
+        (True, ["--exclude", "examplepy", "--all"], None),
+        (True, ["-e", "examplepy", "--packages", "anotherpy"], None),
+        (True, ["-e", "examplepy", "-p", "anotherpy", "-a"], None),
+        (False, ["--exclude", "examplepy"], "examplepy"),
+    ],
+)
+def test_parser_get_options_exclude_mutual_exclusion(
+    should_be_error: bool, args: list[str], expected_value: str
+) -> None:
+    if should_be_error:
+        with pytest.raises(SystemExit):
+            get_options(args)
+    else:
+        parsed_args = get_options(args)
+        assert parsed_args.exclude == expected_value

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -87,7 +87,9 @@ def test_parser_depth(should_be_error: bool, depth_arg: list[str], expected_valu
     ],
 )
 def test_parser_get_options_exclude_mutual_exclusion(
-    should_be_error: bool, args: list[str], expected_value: str
+    should_be_error: bool,
+    args: list[str],
+    expected_value: str,
 ) -> None:
     if should_be_error:
         with pytest.raises(SystemExit):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -78,22 +78,22 @@ def test_parser_depth(should_be_error: bool, depth_arg: list[str], expected_valu
 
 
 @pytest.mark.parametrize(
-    ("should_be_error", "args", "expected_value"),
+    "args",
     [
-        (True, ["--exclude", "examplepy", "--all"], None),
-        (True, ["-e", "examplepy", "--packages", "anotherpy"], None),
-        (True, ["-e", "examplepy", "-p", "anotherpy", "-a"], None),
-        (False, ["--exclude", "examplepy"], "examplepy"),
+        pytest.param(["--exclude", "py", "--all"], id="exclude-all"),
+        pytest.param(["-e", "py", "--packages", "py2"], id="exclude-packages"),
+        pytest.param(["-e", "py", "-p", "py2", "-a"], id="exclude-packages-all"),
     ],
 )
-def test_parser_get_options_exclude_mutual_exclusion(
-    should_be_error: bool,
-    args: list[str],
-    expected_value: str,
-) -> None:
-    if should_be_error:
-        with pytest.raises(SystemExit):
-            get_options(args)
-    else:
-        parsed_args = get_options(args)
-        assert parsed_args.exclude == expected_value
+def test_parser_get_options_exclude_combine_not_supported(args: list[str], capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit, match="2"):
+        get_options(args)
+
+    out, err = capsys.readouterr()
+    assert not out
+    assert "cannot use --exclude with --packages or --all" in err
+
+
+def test_parser_get_options_exclude_only() -> None:
+    parsed_args = get_options(["--exclude", "py"])
+    assert parsed_args.exclude == "py"


### PR DESCRIPTION
Resolves #161.

Had trouble using the `argparse` mutual exclusion API. I couldn't find an approach to get -e to be mutually exclusive to -p and -a without the latter two being mutually exclusive to each other. Therefore, I ended up doing so manually in `get_options()`.