### PR TITLE
Add missing `user_only` field in `Options`

### DIFF
--- a/src/pipdeptree/_cli.py
+++ b/src/pipdeptree/_cli.py
@@ -15,6 +15,7 @@ class Options(Namespace):
     python: str
     all: bool  # noqa: A003
     local_only: bool
+    user_only: bool
     warn: Literal["silence", "suppress", "fail"]
     reverse: bool
     packages: str


### PR DESCRIPTION
Found this while exploring the code. The absence of this field doesn't affect the runtime since the `cast()` call in `get_options()` exists more-or-less to provide information to the type checker.