### PR TITLE
Exit with error when `-p` given patterns that fail to match

### DIFF
--- a/src/pipdeptree/__main__.py
+++ b/src/pipdeptree/__main__.py
@@ -27,11 +27,17 @@ def main(args: Sequence[str] | None = None) -> None | int:
     if options.reverse:
         tree = tree.reverse()
 
-    show_only = set(options.packages.split(",")) if options.packages else None
+    show_only = options.packages.split(",") if options.packages else None
     exclude = set(options.exclude.split(",")) if options.exclude else None
 
     if show_only is not None or exclude is not None:
-        tree = tree.filter_nodes(show_only, exclude)
+        try:
+            tree = tree.filter_nodes(show_only, exclude)
+        except ValueError as e:
+            if options.warn in ("suppress", "fail"):
+                print(e, file=sys.stderr)  # noqa: T201
+                return_code |= 1 if options.warn == "fail" else 0
+            return return_code
 
     render(options, tree)
 

--- a/src/pipdeptree/_models/dag.py
+++ b/src/pipdeptree/_models/dag.py
@@ -91,7 +91,7 @@ class PackageDAG(Mapping[DistPackage, List[ReqPackage]]):
         node = self.get_node_as_parent(node_key)
         return self._obj[node] if node else []
 
-    def filter_nodes(self, include: list[str] | None, exclude: set[str] | None) -> PackageDAG:  # noqa: C901
+    def filter_nodes(self, include: list[str] | None, exclude: set[str] | None) -> PackageDAG:  # noqa: C901, PLR0912
         """
         Filters nodes in a graph by given parameters.
 

--- a/tests/_models/test_dag.py
+++ b/tests/_models/test_dag.py
@@ -39,14 +39,14 @@ def dag_to_dict(g: PackageDAG) -> dict[str, list[str]]:
 
 def test_package_dag_filter_fnmatch_include_a(t_fnmatch: PackageDAG) -> None:
     # test include for a.*in the result we got only a.* nodes
-    graph = dag_to_dict(t_fnmatch.filter_nodes({"a.*"}, None))
+    graph = dag_to_dict(t_fnmatch.filter_nodes(["a.*"], None))
     assert graph == {"a.a": ["a.b", "a.c"], "a.b": ["a.c"]}
 
 
 def test_package_dag_filter_fnmatch_include_b(t_fnmatch: PackageDAG) -> None:
     # test include for b.*, which has a.b and a.c in tree, but not a.a
     # in the result we got the b.* nodes plus the a.b node as child in the tree
-    graph = dag_to_dict(t_fnmatch.filter_nodes({"b.*"}, None))
+    graph = dag_to_dict(t_fnmatch.filter_nodes(["b.*"], None))
     assert graph == {"b.a": ["b.b"], "b.b": ["a.b"], "a.b": ["a.c"]}
 
 
@@ -60,6 +60,11 @@ def test_package_dag_filter_fnmatch_exclude_a(t_fnmatch: PackageDAG) -> None:
     # test exclude for a.* in the result we got only b.* nodes
     graph = dag_to_dict(t_fnmatch.filter_nodes(None, {"a.*"}))
     assert graph == {"b.a": ["b.b"], "b.b": []}
+
+
+def test_package_dag_filter_nonexistent_packages(t_fnmatch: PackageDAG) -> None:
+    with pytest.raises(ValueError, match="No packages matched using the following patterns: x, y, z"):
+        t_fnmatch.filter_nodes(["x", "y", "z"], None)
 
 
 def test_package_dag_reverse(example_dag: PackageDAG) -> None:

--- a/tests/_models/test_dag.py
+++ b/tests/_models/test_dag.py
@@ -62,6 +62,11 @@ def test_package_dag_filter_fnmatch_exclude_a(t_fnmatch: PackageDAG) -> None:
     assert graph == {"b.a": ["b.b"], "b.b": []}
 
 
+def test_package_dag_filter_include_exclude_both_used(t_fnmatch: PackageDAG) -> None:
+    with pytest.raises(AssertionError):
+        t_fnmatch.filter_nodes(["a.a", "a.b"], {"a.b"})
+
+
 def test_package_dag_filter_nonexistent_packages(t_fnmatch: PackageDAG) -> None:
     with pytest.raises(ValueError, match="No packages matched using the following patterns: x, y, z"):
         t_fnmatch.filter_nodes(["x", "y", "z"], None)

--- a/tests/render/test_text.py
+++ b/tests/render/test_text.py
@@ -525,7 +525,7 @@ def test_render_text_list_all_and_packages_options_used(
     package_dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
 
     # NOTE: Mimicking the --packages option being used here.
-    package_dag = package_dag.filter_nodes({"examplePy"}, None)
+    package_dag = package_dag.filter_nodes(["examplePy"], None)
 
     render_text(package_dag, max_depth=float("inf"), encoding="utf-8", list_all=True, frozen=False)
     captured = capsys.readouterr()


### PR DESCRIPTION
Should resolve #127.

Note that the `include` parameter in `filter_nodes()` was turned into a list so that when printing an error they will appear in order (at the cost of allowing duplicate patterns to be added). I don't see a performance cost by doing this since previously we seem to just iterate `include` rather than do any lookups.

When the -w fail option and the --packages option is given, patterns that fail to match with any package names will printed to stderr and return with exit code 1.

-w suppress and -w silence work as attended.