### PR TITLE
models/package: move `requires()` and `version` to `DistPackage`

### DIFF
--- a/src/pipdeptree/_models/package.py
+++ b/src/pipdeptree/_models/package.py
@@ -81,13 +81,6 @@ class Package(ABC):
             fr = FrozenRequirement.from_dist(our_dist, [])  # type: ignore[call-arg]
         return str(fr).strip()
 
-    def requires(self) -> list[Requirement]:
-        return self._obj.requires()  # type: ignore[no-untyped-call,no-any-return]
-
-    @property
-    def version(self) -> str:
-        return self._obj.version  # type: ignore[no-any-return]
-
     def __repr__(self) -> str:
         return f'<{self.__class__.__name__}("{self.key}")>'
 
@@ -107,6 +100,13 @@ class DistPackage(Package):
     def __init__(self, obj: DistInfoDistribution, req: ReqPackage | None = None) -> None:
         super().__init__(obj)
         self.req = req
+
+    def requires(self) -> list[Requirement]:
+        return self._obj.requires()  # type: ignore[no-untyped-call,no-any-return]
+
+    @property
+    def version(self) -> str:
+        return self._obj.version  # type: ignore[no-any-return]
 
     def render_as_root(self, *, frozen: bool) -> str:
         if not frozen:


### PR DESCRIPTION
This change exists due to how we use ReqPackage. Since we pass a pip._vendor.pkg_resources.Requirement to Package's constructor instead of the expected DistInfoDistribution, using this method and property will cause a crash because Requirement does not have this data.

To resolve this, they have been moved to DistPackage as it makes more sense for the behavior to exist here rather than force ReqPackage to also have this behavior.

**NOTE**: I also believe `version_spec()` should be moved into `ReqPackage` as it doesn't make sense for this to be available to `DistPackage`, but currently we have modules whose logic depend on its return value.