### PR TITLE
PackageDAG: Allow supressing the check for non-existent includes

### DIFF
--- a/src/pipdeptree/_models/dag.py
+++ b/src/pipdeptree/_models/dag.py
@@ -89,7 +89,9 @@ class PackageDAG(Mapping[DistPackage, List[ReqPackage]]):
         node = self.get_node_as_parent(node_key)
         return self._obj[node] if node else []
 
-    def filter_nodes(self, include: list[str] | None, exclude: set[str] | None) -> PackageDAG:  # noqa: C901, PLR0912
+    def filter_nodes(
+        self, include: list[str] | None, exclude: set[str] | None, check_non_existent_includes: bool = True
+    ) -> PackageDAG:  # noqa: C901, PLR0912
         """Filter nodes in a graph by given parameters.
 
         If a node is included, then all it's children are also included.
@@ -158,9 +160,12 @@ class PackageDAG(Mapping[DistPackage, List[ReqPackage]]):
                             # a dependency is missing
                             continue
 
-        non_existent_includes = [i for i in include_with_casing_preserved if i.lower() not in matched_includes]
-        if non_existent_includes:
-            raise ValueError("No packages matched using the following patterns: " + ", ".join(non_existent_includes))
+        if check_non_existent_includes:
+            non_existent_includes = [i for i in include_with_casing_preserved if i.lower() not in matched_includes]
+            if non_existent_includes:
+                raise ValueError(
+                    "No packages matched using the following patterns: " + ", ".join(non_existent_includes)
+                )
 
         return self.__class__(m)
 


### PR DESCRIPTION
At @proteinqure we use the `PackageDAG` to analyze the relationship between components in our stack but a recent addition to the `filter_nodes` breaks our workflows. Now I realize this is not part of a public API, but the ability to filter for only possibly present packages might be useful to others.

----

Adds an optional flag to suppress the check for non-existent includes. The flag defaults to True and hence the preserves the original behavior by default.

This is useful for filtering the DAG nodes by multiple packages, expected only some of them to match.