### PR TITLE
Use "Any" value if necessary for required version in JSON render

### DIFF
--- a/src/pipdeptree/_models/package.py
+++ b/src/pipdeptree/_models/package.py
@@ -36,7 +36,7 @@ class Package(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def as_dict(self) -> dict[str, str | None]:
+    def as_dict(self) -> dict[str, str]:
         raise NotImplementedError
 
     def render(
@@ -138,7 +138,7 @@ class DistPackage(Package):
             return self
         return self.__class__(self._obj, req)
 
-    def as_dict(self) -> dict[str, str | None]:
+    def as_dict(self) -> dict[str, str]:
         return {"key": self.key, "package_name": self.project_name, "installed_version": self.version}
 
 
@@ -209,12 +209,12 @@ class ReqPackage(Package):
         req_obj = Requirement.parse(req_version_str)  # type: ignore[no-untyped-call]
         return self.installed_version not in req_obj
 
-    def as_dict(self) -> dict[str, str | None]:
+    def as_dict(self) -> dict[str, str]:
         return {
             "key": self.key,
             "package_name": self.project_name,
             "installed_version": self.installed_version,
-            "required_version": self.version_spec,
+            "required_version": self.version_spec if self.version_spec is not None else "Any",
         }
 
 

--- a/tests/_models/test_package.py
+++ b/tests/_models/test_package.py
@@ -84,3 +84,12 @@ def test_req_package_as_dict() -> None:
     result = rp.as_dict()
     expected = {"key": "bar", "package_name": "bar", "installed_version": "4.1.0", "required_version": ">=4.0"}
     assert expected == result
+
+
+def test_req_package_as_dict_with_no_version_spec() -> None:
+    bar = Mock(key="bar", project_name="bar", version="4.1.0")
+    bar_req = Mock(key="bar", project_name="bar", version="4.1.0", specs=[])
+    rp = ReqPackage(bar_req, dist=bar)
+    result = rp.as_dict()
+    expected = {"key": "bar", "package_name": "bar", "installed_version": "4.1.0", "required_version": "Any"}
+    assert expected == result


### PR DESCRIPTION
Resolves #309 by having the --json render return `"required_version": "Any"` instead of `"required_version": null`.

The only problem with this change is that I'm unsure if this should be considered a breaking change or not...? Not sure if it would be better to just have both --json and --json-tree give null values for this key (I guess it would be easier for users to determine whether or not a required package has a version spec)