### PR TITLE
Implement --license option

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ options:
                       warning control: suppress will show warnings but return 0 whether or not they are present; silence will not show warnings at all and always return 0; fail will show warnings and return 1 if any are present (default:
                       suppress)
   -r, --reverse       render the dependency tree in the reverse fashion ie. the sub-dependencies are listed with the list of packages that need them under them (default: False)
+  --license           list the license(s) of a package (text render only) (default: False)
 
 select:
   choose what to render

--- a/src/pipdeptree/_cli.py
+++ b/src/pipdeptree/_cli.py
@@ -26,6 +26,7 @@ class Options(Namespace):
     output_format: str | None
     depth: float
     encoding: str
+    license: bool
 
 
 class _Formatter(ArgumentDefaultsHelpFormatter):
@@ -58,6 +59,12 @@ def build_parser() -> ArgumentParser:
             "render the dependency tree in the reverse fashion ie. the sub-dependencies are listed with the list of "
             "packages that need them under them"
         ),
+    )
+
+    parser.add_argument(
+        "--license",
+        action="store_true",
+        help="list the license(s) of a package (text render only)",
     )
 
     select = parser.add_argument_group(title="select", description="choose what to render")
@@ -142,6 +149,8 @@ def get_options(args: Sequence[str] | None) -> Options:
 
     if parsed_args.exclude and (parsed_args.all or parsed_args.packages):
         return parser.error("cannot use --exclude with --packages or --all")
+    if parsed_args.license and parsed_args.freeze:
+        return parser.error("cannot use --license with --freeze")
 
     return cast(Options, parsed_args)
 

--- a/src/pipdeptree/_render/__init__.py
+++ b/src/pipdeptree/_render/__init__.py
@@ -30,6 +30,7 @@ def render(options: Options, tree: PackageDAG) -> None:
             encoding=options.encoding_type,
             list_all=options.all,
             frozen=options.freeze,
+            include_license=options.license,
         )
 
 

--- a/tests/render/test_render.py
+++ b/tests/render/test_render.py
@@ -37,4 +37,6 @@ def test_grahpviz_routing(mocker: MockerFixture) -> None:
 def test_text_routing(mocker: MockerFixture) -> None:
     render = mocker.patch("pipdeptree._render.render_text")
     main([])
-    render.assert_called_once_with(ANY, encoding="utf-8", frozen=False, list_all=False, max_depth=inf)
+    render.assert_called_once_with(
+        ANY, encoding="utf-8", frozen=False, list_all=False, max_depth=inf, include_license=False
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -97,3 +97,12 @@ def test_parser_get_options_exclude_combine_not_supported(args: list[str], capsy
 def test_parser_get_options_exclude_only() -> None:
     parsed_args = get_options(["--exclude", "py"])
     assert parsed_args.exclude == "py"
+
+
+def test_parser_get_options_license_and_freeze_together_not_supported(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit, match="2"):
+        get_options(["--license", "--freeze"])
+
+    out, err = capsys.readouterr()
+    assert not out
+    assert "cannot use --license with --freeze" in err


### PR DESCRIPTION
Resolves #79.

An example:
```console
$ pipdeptree -d 0 -a --license
chardet==5.2.0 (GNU Lesser General Public License v2 or later (LGPLv2+))
covdefaults==2.3.0 (MIT License)
coverage==7.4.0 (Apache Software License)
diff-cover==8.0.2 (Apache Software License)
distlib==0.3.8 (Python Software Foundation License)
exceptiongroup==1.2.0 (MIT License)
filelock==3.13.1 (The Unlicense (Unlicense))
iniconfig==2.0.0 (MIT License)
Jinja2==3.1.2 (BSD License)
MarkupSafe==2.1.3 (BSD License)
packaging==23.2 (Apache Software License, BSD License)
pip==23.3.2 (MIT License)
pipdeptree==0.1.dev414+g1cd3453 (MIT License)
platformdirs==4.1.0 (MIT License)
pluggy==1.3.0 (MIT License)
pygments==2.17.2 (BSD License)
pytest==7.4.4 (MIT License)
pytest-cov==4.1.0 (MIT License)
pytest-mock==3.12.0 (MIT License)
setuptools==69.0.3 (MIT License)
tomli==2.0.1 (MIT License)
virtualenv==20.25.0 (MIT License)
wheel==0.42.0 (MIT License)
```
Some notes about the choices made:
- Have --license and --freeze be mutually exclusive (as it doesn't make sense to use it when creating freeze requirements)
- Currently, it is only used by the text render option (both unicode and non-unicode options)