### PR TITLE
Fix key mismatch between requirements and dists

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.0.0
+## 2.7.0
 
 - Normalize keys with pep503 regex and recover package names from metadata instead of relying on DistInfoDistribution
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.0
+
+- Normalize keys with pep503 regex and recover package names from metadata instead of relying on DistInfoDistribution
+
 ## 2.6.0
 
 - Handle mermaid output for a reversed tree

--- a/src/pipdeptree/_models/dag.py
+++ b/src/pipdeptree/_models/dag.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from pip._vendor.pkg_resources import DistInfoDistribution
 
 
-from .package import DistPackage, ReqPackage
+from .package import DistPackage, ReqPackage, pep503_normalize
 
 
 class PackageDAG(Mapping[DistPackage, List[ReqPackage]]):
@@ -43,7 +43,8 @@ class PackageDAG(Mapping[DistPackage, List[ReqPackage]]):
         for p in dist_pkgs:
             reqs = []
             for r in p.requires():
-                d = idx.get(r.key)
+                # Requirement key is not sufficiently normalized in pkg_resources - apply additional normalization
+                d = idx.get(pep503_normalize(r.key))
                 # pip's _vendor.packaging.requirements.Requirement uses the exact casing of a dependency's name found in
                 # a project's build config, which is not ideal when rendering.
                 # See https://github.com/tox-dev/pipdeptree/issues/242


### PR DESCRIPTION
It was found that keys are not pep503 normalized in `pkg_resources`, instead using different regex which retains dots, creating potential mismatch between keys in `Requirement` objects and keys in `DistInfoDistribution` objects.
This change fixes that by applying pep503 normalization on the keys we get from `pkg_resources` objects.

Additionally, it was found that `DistInfoDistribution` uses derived value for `project_name` based on `.dist-info` folder name, which may result in an imprecise package name (not the same as in metadata due to double normalization).
This change recovers true package name from metadata when possible.

Fixes #324