### PR TITLE
List pip as dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,9 @@ dynamic = [
   "version",
 ]
 dependencies = [
-  "pip>=18.1",
+  'pip>=23.1.2; python_version >= "3.12"',
+  'pip>=18.1; python_version >= "3.10" and python_version < "3.12"',
+  'pip>=10; python_version >= "3.8" and python_version < "3.10"',
 ]
 optional-dependencies.graphviz = [
   "graphviz>=0.20.1",
@@ -48,7 +50,6 @@ optional-dependencies.graphviz = [
 optional-dependencies.test = [
   "covdefaults>=2.3",
   "diff-cover>=8.0.1",
-  "pip>=23.3.1",
   "pytest>=7.4.3",
   "pytest-cov>=4.1",
   "pytest-mock>=3.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ classifiers = [
 dynamic = [
   "version",
 ]
+dependencies = [
+  "pip>=18.1",
+]
 optional-dependencies.graphviz = [
   "graphviz>=0.20.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,9 +40,7 @@ dynamic = [
   "version",
 ]
 dependencies = [
-  'pip>=23.1.2; python_version >= "3.12"',
-  'pip>=18.1; python_version >= "3.10" and python_version < "3.12"',
-  'pip>=10; python_version >= "3.8" and python_version < "3.10"',
+  "pip>=23.1.2",
 ]
 optional-dependencies.graphviz = [
   "graphviz>=0.20.1",


### PR DESCRIPTION
We ran the test suite with a decreasing version of pip until it failed at 18.0.

```bash
#!/usr/bin/env bash

pip_version=100  # very high on purpose
install_pip() {
    pip_version=$(uv pip install "pip<${pip_version}" 2>&1 | grep -F '+ pip==' | cut -d= -f3)
    echo -en "Testing with pip version ${pip_version}: "
}

main() {
    echo "Setup"
    {
        uv venv
        . .venv/bin/activate
        uv pip install -e .[test,graphviz]
        uv pip uninstall pip
    } &>/dev/null
    install_pip
    while :; do
        if pytest tests &>/dev/null; then
            echo "OK"
            install_pip
        else
            echo "Failed"
            break
        fi
    done
}

main
```

---

The above text is the commit message. Feel free to reword it by squashing the PR.

Output of the script:

```console
% bash testpip.sh
Setup
Testing with pip version 24.0: OK
Testing with pip version 23.3.2: OK
Testing with pip version 23.3.1: OK
Testing with pip version 23.3: OK
Testing with pip version 23.2.1: OK
Testing with pip version 23.2: OK
Testing with pip version 23.1.2: OK
Testing with pip version 23.1.1: OK
Testing with pip version 23.1: OK
Testing with pip version 23.0.1: OK
Testing with pip version 23.0: OK
Testing with pip version 22.3.1: OK
Testing with pip version 22.3: OK
Testing with pip version 22.2.2: OK
Testing with pip version 22.2.1: OK
Testing with pip version 22.2: OK
Testing with pip version 22.1.2: OK
Testing with pip version 22.1.1: OK
Testing with pip version 22.1: OK
Testing with pip version 22.0.4: OK
Testing with pip version 22.0.3: OK
Testing with pip version 22.0.2: OK
Testing with pip version 22.0.1: OK
Testing with pip version 22.0: OK
Testing with pip version 21.3.1: OK
Testing with pip version 21.3: OK
Testing with pip version 21.2.4: OK
Testing with pip version 21.2.3: OK
Testing with pip version 21.2.2: OK
Testing with pip version 21.2.1: OK
Testing with pip version 21.1.3: OK
Testing with pip version 21.1.2: OK
Testing with pip version 21.1.1: OK
Testing with pip version 21.1: OK
Testing with pip version 21.0.1: OK
Testing with pip version 21.0: OK
Testing with pip version 20.3.4: OK
Testing with pip version 20.3.3: OK
Testing with pip version 20.3.1: OK
Testing with pip version 20.3: OK
Testing with pip version 20.2.4: OK
Testing with pip version 20.2.3: OK
Testing with pip version 20.2.2: OK
Testing with pip version 20.2.1: OK
Testing with pip version 20.2: OK
Testing with pip version 20.1.1: OK
Testing with pip version 20.1: OK
Testing with pip version 20.0.2: OK
Testing with pip version 20.0.1: OK
Testing with pip version 19.3.1: OK
Testing with pip version 19.3: OK
Testing with pip version 19.2.3: OK
Testing with pip version 19.2.2: OK
Testing with pip version 19.2.1: OK
Testing with pip version 19.2: OK
Testing with pip version 19.1.1: OK
Testing with pip version 19.1: OK
Testing with pip version 19.0.3: OK
Testing with pip version 19.0.2: OK
Testing with pip version 19.0.1: OK
Testing with pip version 19.0: OK
Testing with pip version 18.1: OK
Testing with pip version 18.0: Failed
```

It's possible that lower versions would work, and only 18.0 failed because of some bug in it. However I feel like v18.1 is old enough and we don't have to support even lower versions. Happy to test further down if you disagree!

**IMPORTANT**: I consider this PR a quick fix for #335, waiting for a better solution such as #333. Feel free to close this PR if you don't plan on merging it and quickly releasing a new version with pip as a dependency *before* merging and releasing #333.

Closes #335.