### PR TITLE
Allow pip>=20.2.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dynamic = [
   "version",
 ]
 dependencies = [
-  "pip>=23.1.2",
+  "pip>=20.2.4",
 ]
 optional-dependencies.graphviz = [
   "graphviz>=0.20.1",


### PR DESCRIPTION
I was actively using pipdeptree to revive a legacy project stuck on 20.2.4 (https://pip.pypa.io/en/stable/user_guide/#changes-to-the-pip-dependency-resolver-in-20-3-2020). Requiring a more modern pip version breaks this use case. Furthermore could cause issues debugging docker images with pinned pip versions etc.

Is there any reason to make the pip dependency range so tight? This would allow people on pinned pip versions to install pipdeptree without it upsetting their environment.