### PR TITLE
Handle duplicated package metadata when using importlib.metadata

### DIFF
--- a/src/pipdeptree/_discovery.py
+++ b/src/pipdeptree/_discovery.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import site
 import sys
 from importlib.metadata import Distribution, distributions
-from typing import Tuple
+from typing import Iterable, Tuple
 
 from packaging.utils import canonicalize_name
 
@@ -14,15 +14,15 @@ def get_installed_distributions(
 ) -> list[Distribution]:
     # See https://docs.python.org/3/library/venv.html#how-venvs-work for more details.
     in_venv = sys.prefix != sys.base_prefix
-    orginal_dists = []
+    original_dists: Iterable[Distribution] = []
 
     if local_only and in_venv:
         venv_site_packages = site.getsitepackages([sys.prefix])
-        orginal_dists = distributions(path=venv_site_packages)
+        original_dists = distributions(path=venv_site_packages)
     elif user_only:
-        orginal_dists = distributions(path=[site.getusersitepackages()])
+        original_dists = distributions(path=[site.getusersitepackages()])
     else:
-        orginal_dists = distributions()
+        original_dists = distributions()
 
     # Since importlib.metadata.distributions() can return duplicate packages, we need to handle this. pip's approach is
     # to keep track of each package metadata it finds, and if it encounters one again it will simply just ignore it. We
@@ -31,7 +31,7 @@ def get_installed_distributions(
     seen_dists: dict[str, Distribution] = {}
     first_seen_to_already_seen_dists_dict: dict[Distribution, list[Distribution]] = {}
     dists = []
-    for dist in orginal_dists:
+    for dist in original_dists:
         normalized_name = canonicalize_name(dist.metadata["Name"])
         if normalized_name not in seen_dists:
             seen_dists[normalized_name] = dist

--- a/src/pipdeptree/_discovery.py
+++ b/src/pipdeptree/_discovery.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import site
 import sys
 from importlib.metadata import Distribution, distributions
+from typing import Tuple
 
 from packaging.utils import canonicalize_name
 
@@ -45,7 +46,7 @@ def get_installed_distributions(
     return dists
 
 
-FirstSeenWithDistsPair = tuple[Distribution, Distribution]
+FirstSeenWithDistsPair = Tuple[Distribution, Distribution]
 
 
 def render_duplicated_dist_metadata_text(
@@ -63,7 +64,10 @@ def render_duplicated_dist_metadata_text(
         print(f'"{entry}"', file=sys.stderr)  # noqa: T201
         for first_seen, dist in pairs:
             print(  # noqa: T201
-                f"  {dist.metadata['Name']:<32} {dist.version:<16} (using {first_seen.version}, \"{first_seen.locate_file('')}\")",
+                (
+                    f"  {dist.metadata['Name']:<32} {dist.version:<16} (using {first_seen.version},"
+                    f" \"{first_seen.locate_file('')}\")"
+                ),
                 file=sys.stderr,
             )
     print("-" * 72, file=sys.stderr)  # noqa: T201

--- a/src/pipdeptree/_discovery.py
+++ b/src/pipdeptree/_discovery.py
@@ -4,7 +4,7 @@ import site
 import sys
 from importlib.metadata import Distribution, distributions
 
-from pipdeptree._util import pep503_normalize
+from packaging.utils import canonicalize_name
 
 
 def get_installed_distributions(
@@ -31,7 +31,7 @@ def get_installed_distributions(
     first_seen_to_already_seen_dists_dict: dict[Distribution, list[Distribution]] = {}
     dists = []
     for dist in orginal_dists:
-        normalized_name = pep503_normalize(dist.metadata["Name"])
+        normalized_name = canonicalize_name(dist.metadata["Name"])
         if normalized_name not in seen_dists:
             seen_dists[normalized_name] = dist
             dists.append(dist)
@@ -63,7 +63,7 @@ def render_duplicated_dist_metadata_text(
         print(f'"{entry}"', file=sys.stderr)  # noqa: T201
         for first_seen, dist in pairs:
             print(  # noqa: T201
-                f"  {dist.metadata['Name']:<32} {dist.version:<16} (using {first_seen.version}, \"{first_seen.locate_file('')}\")",  # noqa: E501
+                f"  {dist.metadata['Name']:<32} {dist.version:<16} (using {first_seen.version}, \"{first_seen.locate_file('')}\")",
                 file=sys.stderr,
             )
     print("-" * 72, file=sys.stderr)  # noqa: T201

--- a/src/pipdeptree/_discovery.py
+++ b/src/pipdeptree/_discovery.py
@@ -2,28 +2,71 @@ from __future__ import annotations
 
 import site
 import sys
-from importlib.metadata import distributions
-from typing import TYPE_CHECKING
+from importlib.metadata import Distribution, distributions
 
-if TYPE_CHECKING:
-    from importlib.metadata import Distribution
+from pipdeptree._util import pep503_normalize
 
 
 def get_installed_distributions(
     local_only: bool = False,  # noqa: FBT001, FBT002
     user_only: bool = False,  # noqa: FBT001, FBT002
 ) -> list[Distribution]:
-    if user_only:
-        return list(distributions(path=[site.getusersitepackages()]))
-
-    # NOTE: See https://docs.python.org/3/library/venv.html#how-venvs-work for more details.
+    # See https://docs.python.org/3/library/venv.html#how-venvs-work for more details.
     in_venv = sys.prefix != sys.base_prefix
+    orginal_dists = []
 
     if local_only and in_venv:
         venv_site_packages = site.getsitepackages([sys.prefix])
-        return list(distributions(path=venv_site_packages))
+        orginal_dists = distributions(path=venv_site_packages)
+    elif user_only:
+        orginal_dists = distributions(path=[site.getusersitepackages()])
+    else:
+        orginal_dists = distributions()
 
-    return list(distributions())
+    # Since importlib.metadata.distributions() can return duplicate packages, we need to handle this. pip's approach is
+    # to keep track of each package metadata it finds, and if it encounters one again it will simply just ignore it. We
+    # take it one step further and warn the user that there are duplicate packages in their environment.
+    # See https://github.com/pypa/pip/blob/7c49d06ea4be4635561f16a524e3842817d1169a/src/pip/_internal/metadata/importlib/_envs.py#L34
+    seen_dists: dict[str, Distribution] = {}
+    first_seen_to_already_seen_dists_dict: dict[Distribution, list[Distribution]] = {}
+    dists = []
+    for dist in orginal_dists:
+        normalized_name = pep503_normalize(dist.metadata["Name"])
+        if normalized_name not in seen_dists:
+            seen_dists[normalized_name] = dist
+            dists.append(dist)
+            continue
+        already_seen_dists = first_seen_to_already_seen_dists_dict.setdefault(seen_dists[normalized_name], [])
+        already_seen_dists.append(dist)
+
+    if first_seen_to_already_seen_dists_dict:
+        render_duplicated_dist_metadata_text(first_seen_to_already_seen_dists_dict)
+
+    return dists
+
+
+FirstSeenWithDistsPair = tuple[Distribution, Distribution]
+
+
+def render_duplicated_dist_metadata_text(
+    first_seen_to_already_seen_dists_dict: dict[Distribution, list[Distribution]],
+) -> None:
+    entries_to_pairs_dict: dict[str, list[FirstSeenWithDistsPair]] = {}
+    for first_seen, dists in first_seen_to_already_seen_dists_dict.items():
+        for dist in dists:
+            entry = str(dist.locate_file(""))
+            dist_list = entries_to_pairs_dict.setdefault(entry, [])
+            dist_list.append((first_seen, dist))
+
+    print("Warning!!! Duplicate package metadata found:", file=sys.stderr)  # noqa: T201
+    for entry, pairs in entries_to_pairs_dict.items():
+        print(f'"{entry}"', file=sys.stderr)  # noqa: T201
+        for first_seen, dist in pairs:
+            print(  # noqa: T201
+                f"  {dist.metadata['Name']:<32} {dist.version:<16} (using {first_seen.version}, \"{first_seen.locate_file('')}\")",  # noqa: E501
+                file=sys.stderr,
+            )
+    print("-" * 72, file=sys.stderr)  # noqa: T201
 
 
 __all__ = [

--- a/src/pipdeptree/_models/dag.py
+++ b/src/pipdeptree/_models/dag.py
@@ -5,11 +5,13 @@ from fnmatch import fnmatch
 from itertools import chain
 from typing import TYPE_CHECKING, Iterator, List, Mapping
 
+from packaging.utils import canonicalize_name
+
 if TYPE_CHECKING:
     from importlib.metadata import Distribution
 
 
-from .package import DistPackage, ReqPackage, pep503_normalize
+from .package import DistPackage, ReqPackage
 
 
 class PackageDAG(Mapping[DistPackage, List[ReqPackage]]):
@@ -43,7 +45,7 @@ class PackageDAG(Mapping[DistPackage, List[ReqPackage]]):
         for p in dist_pkgs:
             reqs = []
             for r in p.requires():
-                d = idx.get(pep503_normalize(r.name))
+                d = idx.get(canonicalize_name(r.name))
                 # Distribution.requires only return the name of requirements in metadata file, which may not be
                 # the same with the capitalized one in pip. We should retain the casing of required package name.
                 # see https://github.com/tox-dev/pipdeptree/issues/242
@@ -112,8 +114,8 @@ class PackageDAG(Mapping[DistPackage, List[ReqPackage]]):
         include_with_casing_preserved: list[str] = []
         if include:
             include_with_casing_preserved = include
-            include = [pep503_normalize(i) for i in include]
-        exclude = {pep503_normalize(s) for s in exclude} if exclude else set()
+            include = [canonicalize_name(i) for i in include]
+        exclude = {canonicalize_name(s) for s in exclude} if exclude else set()
 
         # Check for mutual exclusion of show_only and exclude sets
         # after normalizing the values to lowercase
@@ -159,7 +161,7 @@ class PackageDAG(Mapping[DistPackage, List[ReqPackage]]):
                             continue
 
         non_existent_includes = [
-            i for i in include_with_casing_preserved if pep503_normalize(i) not in matched_includes
+            i for i in include_with_casing_preserved if canonicalize_name(i) not in matched_includes
         ]
         if non_existent_includes:
             raise ValueError("No packages matched using the following patterns: " + ", ".join(non_existent_includes))

--- a/src/pipdeptree/_models/package.py
+++ b/src/pipdeptree/_models/package.py
@@ -7,8 +7,7 @@ from inspect import ismodule
 from typing import TYPE_CHECKING
 
 from packaging.requirements import Requirement
-
-from pipdeptree._util import pep503_normalize
+from packaging.utils import canonicalize_name
 
 if TYPE_CHECKING:
     from importlib.metadata import Distribution
@@ -23,7 +22,7 @@ class Package(ABC):
 
     def __init__(self, project_name: str) -> None:
         self.project_name = project_name
-        self.key = pep503_normalize(project_name)
+        self.key = canonicalize_name(project_name)
 
     def licenses(self) -> str:
         try:

--- a/src/pipdeptree/_models/package.py
+++ b/src/pipdeptree/_models/package.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import re
 from abc import ABC, abstractmethod
 from importlib import import_module
 from importlib.metadata import Distribution, PackageNotFoundError, metadata, version
@@ -9,14 +8,12 @@ from typing import TYPE_CHECKING
 
 from packaging.requirements import Requirement
 
+from pipdeptree._util import pep503_normalize
+
 if TYPE_CHECKING:
     from importlib.metadata import Distribution
 
 from pipdeptree._adapter import PipBaseDistributionAdapter
-
-
-def pep503_normalize(name: str) -> str:
-    return re.sub("[-_.]+", "-", name).lower()
 
 
 class Package(ABC):

--- a/src/pipdeptree/_util.py
+++ b/src/pipdeptree/_util.py
@@ -1,7 +1,0 @@
-from __future__ import annotations
-
-import re
-
-
-def pep503_normalize(name: str) -> str:
-    return re.sub("[-_.]+", "-", name).lower()

--- a/src/pipdeptree/_util.py
+++ b/src/pipdeptree/_util.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+import re
+
+
+def pep503_normalize(name: str) -> str:
+    return re.sub("[-_.]+", "-", name).lower()

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -61,8 +61,8 @@ def test_duplicate_metadata(monkeypatch: pytest.MonkeyPatch, capfd: pytest.Captu
         "pipdeptree._discovery.distributions",
         Mock(
             return_value=[
-                Mock(metadata={"Name": "foo"}, version="1.2.5", locate_file=Mock(return_value="test")),
-                Mock(metadata={"Name": "foo"}, version="5.9.0", locate_file=Mock(return_value="test")),
+                Mock(metadata={"Name": "foo"}, version="1.2.5", locate_file=Mock(return_value="/path/1")),
+                Mock(metadata={"Name": "foo"}, version="5.9.0", locate_file=Mock(return_value="/path/2")),
             ]
         ),
     )
@@ -74,7 +74,7 @@ def test_duplicate_metadata(monkeypatch: pytest.MonkeyPatch, capfd: pytest.Captu
 
     _, err = capfd.readouterr()
     expected = (
-        'Warning!!! Duplicate package metadata found:\n"test"\n  foo                              5.9.0       '
-        '     (using 1.2.5, "test")\n------------------------------------------------------------------------\n'
+        'Warning!!! Duplicate package metadata found:\n"/path/2"\n  foo                              5.9.0       '
+        '     (using 1.2.5, "/path/1")\n------------------------------------------------------------------------\n'
     )
     assert err == expected

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -73,5 +73,8 @@ def test_duplicate_metadata(monkeypatch: pytest.MonkeyPatch, capfd: pytest.Captu
     assert dists[0].version == "1.2.5"
 
     _, err = capfd.readouterr()
-    expected = """Warning!!! Duplicate package metadata found:\n"test"\n  foo                              5.9.0            (using 1.2.5, "test")\n------------------------------------------------------------------------\n"""  # noqa: E501
+    expected = (
+        'Warning!!! Duplicate package metadata found:\n"test"\n  foo                              5.9.0       '
+        '     (using 1.2.5, "test")\n------------------------------------------------------------------------\n'
+    )
     assert err == expected

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -13,6 +13,7 @@ from pipdeptree._discovery import get_installed_distributions
 
 if TYPE_CHECKING:
     import pytest
+    from pytest_mock import MockerFixture
 
 
 def test_local_only(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capfd: pytest.CaptureFixture[str]) -> None:
@@ -56,8 +57,8 @@ def test_user_only(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capfd: pytes
     assert found == expected
 
 
-def test_duplicate_metadata(monkeypatch: pytest.MonkeyPatch, capfd: pytest.CaptureFixture[str]) -> None:
-    monkeypatch.setattr(
+def test_duplicate_metadata(mocker: MockerFixture, capfd: pytest.CaptureFixture[str]) -> None:
+    mocker.patch(
         "pipdeptree._discovery.distributions",
         Mock(
             return_value=[


### PR DESCRIPTION
Fixes #341.

Using an environment similar to the one shown in the issue:
```console
$ PYTHONPATH=/workspaces/pipdeptree/temp-site-pkgs/ pipdeptree -a -d 0
Warning!!! Duplicate package metadata found:
"/home/vscode/.local/lib/python3.9/site-packages"
  pluggy                           1.4.0            (using 1.4.0, "/workspaces/pipdeptree/temp-site-pkgs")
  packaging                        24.0             (using 24.0, "/workspaces/pipdeptree/temp-site-pkgs")
  tomli                            2.0.1            (using 2.0.1, "/workspaces/pipdeptree/temp-site-pkgs")
  pytest                           8.1.1            (using 8.1.1, "/workspaces/pipdeptree/temp-site-pkgs")
  exceptiongroup                   1.2.0            (using 1.2.0, "/workspaces/pipdeptree/temp-site-pkgs")
  iniconfig                        2.0.0            (using 2.0.0, "/workspaces/pipdeptree/temp-site-pkgs")
"/usr/local/lib/python3.9/site-packages"
  pip                              23.0.1           (using 24.0, "/home/vscode/.local/lib/python3.9/site-packages")
------------------------------------------------------------------------
chardet==5.2.0
covdefaults==2.3.0
coverage==7.4.4
diff_cover==8.0.3
distlib==0.3.8
exceptiongroup==1.2.0
filelock==3.13.3
gitdb==4.0.11
GitPython==3.1.41
iniconfig==2.0.0
Jinja2==3.1.3
MarkupSafe==2.1.5
packaging==24.0
pip==24.0
pipdeptree==2.16.3.dev3+g91d21e3.d20240403
platformdirs==4.2.0
pluggy==1.4.0
Pygments==2.17.2
pytest==8.1.1
pytest-cov==5.0.0
pytest-mock==3.14.0
setuptools==69.0.3
smmap==5.0.1
tomli==2.0.1
virtualenv==20.25.1
wheel==0.42.0
```