### PR TITLE
Handle invalid requirement strings when using importlib.metadata

### DIFF
--- a/src/pipdeptree/_models/dag.py
+++ b/src/pipdeptree/_models/dag.py
@@ -64,15 +64,14 @@ class PackageDAG(Mapping[DistPackage, List[ReqPackage]]):
                 try:
                     req = next(requires_iterator)
                 except InvalidRequirementError as err:
-                    # We can't work with invalid requirement strings. Let's warn the user about
-                    # them.
+                    # We can't work with invalid requirement strings. Let's warn the user about them.
                     dist_name_to_invalid_reqs_dict.setdefault(p.project_name, []).append(str(err))
                     continue
                 except StopIteration:
                     break
                 d = idx.get(canonicalize_name(req.name))
-                # Distribution.requires only returns the name of requirements in the metadata file, which may not be
-                # the same as the name in PyPI. We should try to retain the original package names for requirements.
+                # Distribution.requires only returns the name of requirements in the metadata file, which may not be the
+                # same as the name in PyPI. We should try to retain the original package names for requirements.
                 # See https://github.com/tox-dev/pipdeptree/issues/242
                 req.name = d.project_name if d is not None else req.name
                 pkg = ReqPackage(req, d)

--- a/src/pipdeptree/_models/dag.py
+++ b/src/pipdeptree/_models/dag.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from collections import defaultdict, deque
 from fnmatch import fnmatch
 from itertools import chain
@@ -11,7 +12,20 @@ if TYPE_CHECKING:
     from importlib.metadata import Distribution
 
 
-from .package import DistPackage, ReqPackage
+from .package import DistPackage, InvalidRequirementError, ReqPackage
+
+
+def render_invalid_reqs_text_if_necessary(dist_name_to_invalid_reqs_dict: dict[str, list[str]]) -> None:
+    if not dist_name_to_invalid_reqs_dict:
+        return
+
+    print("Warning!!! Invalid requirement strings found for the following distributions:", file=sys.stderr)  # noqa: T201
+    for dist_name, invalid_reqs in dist_name_to_invalid_reqs_dict.items():
+        print(dist_name, file=sys.stderr)  # noqa: T201
+
+        for invalid_req in invalid_reqs:
+            print(f'  Skipping "{invalid_req}"', file=sys.stderr)  # noqa: T201
+    print("-" * 72, file=sys.stderr)  # noqa: T201
 
 
 class PackageDAG(Mapping[DistPackage, List[ReqPackage]]):
@@ -42,17 +56,30 @@ class PackageDAG(Mapping[DistPackage, List[ReqPackage]]):
         dist_pkgs = [DistPackage(p) for p in pkgs]
         idx = {p.key: p for p in dist_pkgs}
         m: dict[DistPackage, list[ReqPackage]] = {}
+        dist_name_to_invalid_reqs_dict: dict[str, list[str]] = {}
         for p in dist_pkgs:
             reqs = []
-            for r in p.requires():
-                d = idx.get(canonicalize_name(r.name))
-                # Distribution.requires only return the name of requirements in metadata file, which may not be
-                # the same with the capitalized one in pip. We should retain the casing of required package name.
-                # see https://github.com/tox-dev/pipdeptree/issues/242
-                r.name = d.project_name if d is not None else r.name
-                pkg = ReqPackage(r, d)
+            requires_iterator = p.requires()
+            while True:
+                try:
+                    req = next(requires_iterator)
+                except InvalidRequirementError as err:
+                    # We can't work with invalid requirement strings. Let's warn the user about
+                    # them.
+                    dist_name_to_invalid_reqs_dict.setdefault(p.project_name, []).append(str(err))
+                    continue
+                except StopIteration:
+                    break
+                d = idx.get(canonicalize_name(req.name))
+                # Distribution.requires only returns the name of requirements in the metadata file, which may not be
+                # the same as the name in PyPI. We should try to retain the orginal package names for requirements.
+                # See https://github.com/tox-dev/pipdeptree/issues/242
+                req.name = d.project_name if d is not None else req.name
+                pkg = ReqPackage(req, d)
                 reqs.append(pkg)
             m[p] = reqs
+
+        render_invalid_reqs_text_if_necessary(dist_name_to_invalid_reqs_dict)
 
         return cls(m)
 

--- a/src/pipdeptree/_models/dag.py
+++ b/src/pipdeptree/_models/dag.py
@@ -72,7 +72,7 @@ class PackageDAG(Mapping[DistPackage, List[ReqPackage]]):
                     break
                 d = idx.get(canonicalize_name(req.name))
                 # Distribution.requires only returns the name of requirements in the metadata file, which may not be
-                # the same as the name in PyPI. We should try to retain the orginal package names for requirements.
+                # the same as the name in PyPI. We should try to retain the original package names for requirements.
                 # See https://github.com/tox-dev/pipdeptree/issues/242
                 req.name = d.project_name if d is not None else req.name
                 pkg = ReqPackage(req, d)

--- a/tests/_models/test_package.py
+++ b/tests/_models/test_package.py
@@ -45,7 +45,7 @@ def test_dist_package_requires() -> None:
         requires=["bar", "baz >=2.7.2"],
     )
     dp = DistPackage(foo)
-    reqs = dp.requires()
+    reqs = list(dp.requires())
     assert len(reqs) == 2
 
 
@@ -55,7 +55,7 @@ def test_dist_package_requires_with_environment_markers_that_eval_to_false() -> 
         requires=['foo ; sys_platform == "NoexistOS"', "bar >=2.7.2 ; extra == 'testing'"],
     )
     dp = DistPackage(foo)
-    reqs = dp.requires()
+    reqs = list(dp.requires())
     assert len(reqs) == 0
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from random import shuffle
 from typing import TYPE_CHECKING, Callable, Iterator
-from unittest.mock import MagicMock, Mock
+from unittest.mock import Mock
 
 import pytest
 
@@ -18,16 +18,15 @@ def mock_pkgs() -> Callable[[MockGraph], Iterator[Mock]]:
         for node, children in simple_graph.items():
             nk, nv = node
             m = Mock(metadata={"Name": nk}, version=nv)
-            as_req = MagicMock(specifier=[("==", nv)])
-            as_req.name = nk
-            m.as_requirement = Mock(return_value=as_req)
             reqs = []
             for ck, cv in children:
                 r = ck
                 for item in cv:
                     if item:
                         rs, rv = item
-                        r = r + rs + rv + ","
+                        r = r + rs + rv
+                    if item != cv[-1]:
+                        r += ","
                 reqs.append(r)
             m.requires = reqs
             yield m


### PR DESCRIPTION
Resolves #344.

This change also:
- Makes `Distribution.requires()` into a generator for performance (i.e. avoid building `list[Requirement]` and then iterating `list[Requirement` and instead do both at the same time) and so that we can handle invalid requirement exceptions in `PackageDAG.from_pkgs()` for each individual requirement string
- Modified conftest to avoid adding a extra comma at the end and removed some older code