### PR TITLE
Fix test_console failure finding pipdeptree in other environments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ optional-dependencies.test = [
   "covdefaults>=2.3",
   "diff-cover>=8.0.1",
   "pytest>=7.4.3",
+  "pytest-console-scripts>=1.4.1",
   "pytest-cov>=4.1",
   "pytest-mock>=3.12",
   "virtualenv<21,>=20.25",

--- a/tests/test_pipdeptree.py
+++ b/tests/test_pipdeptree.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
 import sys
-from pathlib import Path
 from subprocess import check_call  # noqa: S404
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pytest_console_scripts import ScriptRunner
 
 
 def test_main() -> None:
     check_call([sys.executable, "-m", "pipdeptree", "--help"])
 
 
-def test_console() -> None:
-    check_call([Path(sys.executable).parent / "pipdeptree", "--help"])
+def test_console(script_runner: ScriptRunner) -> None:
+    result = script_runner.run("pipdeptree", "--help")
+    assert result.success


### PR DESCRIPTION
When we are using pytest in packaging process, we may not get the `/usr/bin/pipdeptree` as we need. So, let's use the `PATH` env to get the binary instead.

fix: https://github.com/tox-dev/pipdeptree/issues/348