### PR TITLE
Modify tests to ensure $PYTHONPATH is given to the custom interpreter

### DIFF
--- a/tests/test_non_host.py
+++ b/tests/test_non_host.py
@@ -103,6 +103,6 @@ def test_custom_interpreter_ensure_pythonpath_envar_is_honored(
         expected = {"foo", "cffi", "greenlet", "pip", "readline", "setuptools", "wheel"}
     else:  # pragma: no cover
         raise ValueError(implementation)
-    if sys.version_info >= (3, 12):  # pragma: <3.12 no cover
+    if sys.version_info >= (3, 12):  # pragma: >=3.12 cover
         expected -= {"setuptools", "wheel"}
     assert found == expected, out

--- a/tests/test_non_host.py
+++ b/tests/test_non_host.py
@@ -99,10 +99,10 @@ def test_custom_interpreter_ensure_pythonpath_envar_is_honored(
     implementation = python_implementation()
     if implementation == "CPython":
         expected = {"foo", "pip", "setuptools", "wheel"}
-    elif implementation == "PyPy":
-        expected = {"foo", "cffi", "greenlet", "pip", "readline", "setuptools", "wheel"}  # pragma: no cover
-    else:
+    elif implementation == "PyPy":  # pragma: cpython no cover
+        expected = {"foo", "cffi", "greenlet", "pip", "readline", "setuptools", "wheel"}
+    else:  # pragma: no cover
         raise ValueError(implementation)
-    if sys.version_info >= (3, 12):
+    if sys.version_info >= (3, 12):  # pragma: <3.12 no cover
         expected -= {"setuptools", "wheel"}
     assert found == expected, out

--- a/tests/test_non_host.py
+++ b/tests/test_non_host.py
@@ -23,11 +23,14 @@ def test_custom_interpreter(
     capfd: pytest.CaptureFixture[str],
     args_joined: bool,
 ) -> None:
-    result = virtualenv.cli_run([str(tmp_path / "venv"), "--activators", ""])
-    cmd = [sys.executable]
+    # Delete $PYTHONPATH so that it cannot be passed to the custom interpreter process (since we don't know what
+    # distribution metadata to expect when it's used).
+    monkeypatch.delenv("PYTHONPATH", False)
+
     monkeypatch.chdir(tmp_path)
+    result = virtualenv.cli_run([str(tmp_path / "venv"), "--activators", ""])
     py = str(result.creator.exe.relative_to(tmp_path))
-    cmd += [f"--python={result.creator.exe}"] if args_joined else ["--python", py]
+    cmd = ["", f"--python={result.creator.exe}"] if args_joined else ["", "--python", py]
     mocker.patch("pipdeptree._discovery.sys.argv", cmd)
     main()
     out, _ = capfd.readouterr()
@@ -68,4 +71,38 @@ def test_custom_interpreter_with_local_only(
         raise ValueError(implementation)  # pragma: no cover
     if sys.version_info >= (3, 12):
         expected -= {"setuptools", "wheel"}  # pragma: no cover
+    assert found == expected, out
+
+
+def test_custom_interpreter_ensure_pythonpath_envar_is_honored(
+    tmp_path: Path,
+    mocker: MockerFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    # ensures that we honor $PYTHONPATH when passing it to the custom interpreter process
+    venv_path = str(tmp_path / "venv")
+    result = virtualenv.cli_run([venv_path, "--activators", ""])
+
+    another_path = tmp_path / "another-path"
+    fake_dist = another_path / "foo-1.2.3.dist-info"
+    fake_dist.mkdir(parents=True)
+    fake_metadata = fake_dist / "METADATA"
+    with fake_metadata.open("w") as f:
+        f.write("Metadata-Version: 2.3\n" "Name: foo\n" "Version: 1.2.3\n")
+    cmd = ["", f"--python={result.creator.exe}"]
+    mocker.patch("pipdeptree._discovery.sys.argv", cmd)
+    monkeypatch.setenv("PYTHONPATH", str(another_path))
+    main()
+    out, _ = capfd.readouterr()
+    found = {i.split("==")[0] for i in out.splitlines()}
+    implementation = python_implementation()
+    if implementation == "CPython":
+        expected = {"foo", "pip", "setuptools", "wheel"}
+    elif implementation == "PyPy":
+        expected = {"foo", "cffi", "greenlet", "pip", "readline", "setuptools", "wheel"}  # pragma: no cover
+    else:
+        raise ValueError(implementation)
+    if sys.version_info >= (3, 12):
+        expected -= {"setuptools", "wheel"}
     assert found == expected, out


### PR DESCRIPTION
Should finally resolve #343.

Before 2.17.0, we weren't honoring `$PYTHONPATH` when it was passed to the custom interpreter (but were honoring it when not using a custom interpreter).

With the changes made in 2.17.0, we (unexpectedly) began to honor `$PYTHONPATH` when using `--python`. I believe this is fine since as I explained above we honored it when it was used without this option and because of this it makes sense to pass this env var to the custom interpreter child process instead of ignoring it. Maybe we should document this in the 2.17.0 release notes?

This adds a test and changes another to ensure that there aren't future hiccups when using this env var.