### PR TITLE
Use dropdown instead of checkbox in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/0-new-issue.yml
+++ b/.github/ISSUE_TEMPLATE/0-new-issue.yml
@@ -10,11 +10,16 @@ body:
     validations:
       required: true
 
-  - type: checkboxes
+  - type: dropdown
     attributes:
       label: Are you running pipdeptree in a virtual environment?
       options:
-        - label: "Yes"
+        - "Yes"
+        - "No"
+      default: 1
+    validations:
+      required: true
+
 
   - type: textarea
     attributes:


### PR DESCRIPTION
Somehow missed the dropdown menu type when reading the [docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#dropdown) and to me this reads much better.

See an example by going to https://github.com/kemzeb/pipdeptree/issues and then navigate to `Report a Bug -> Get Started`.