### PR TITLE
Have duplicate metadata and invalid req strings honor --warn option

### DIFF
--- a/src/pipdeptree/__main__.py
+++ b/src/pipdeptree/__main__.py
@@ -10,19 +10,25 @@ from pipdeptree._discovery import get_installed_distributions
 from pipdeptree._models import PackageDAG
 from pipdeptree._render import render
 from pipdeptree._validate import validate
+from pipdeptree._warning import WarningPrinter, WarningType, get_warning_printer, parse_warning_type
 
 
 def main(args: Sequence[str] | None = None) -> None | int:
     """CLI - The main function called as entry point."""
     options = get_options(args)
 
+    # Warnings are only enabled when using text output.
+    is_text_output = not any([options.json, options.json_tree, options.output_format])
+    warning_type = WarningType.SILENCE if not is_text_output else parse_warning_type(options.warn)
+    warning_printer = get_warning_printer()
+    warning_printer.warning_type = warning_type
+
     pkgs = get_installed_distributions(
         interpreter=options.python, local_only=options.local_only, user_only=options.user_only
     )
     tree = PackageDAG.from_pkgs(pkgs)
-    is_text_output = not any([options.json, options.json_tree, options.output_format])
 
-    return_code = validate(options, is_text_output, tree)
+    validate(tree)
 
     # Reverse the tree (if applicable) before filtering, thus ensuring, that the filter will be applied on ReverseTree
     if options.reverse:
@@ -35,14 +41,16 @@ def main(args: Sequence[str] | None = None) -> None | int:
         try:
             tree = tree.filter_nodes(show_only, exclude)
         except ValueError as e:
-            if options.warn in {"suppress", "fail"}:
-                print(e, file=sys.stderr)  # noqa: T201
-                return_code |= 1 if options.warn == "fail" else 0
-            return return_code
+            warning_printer.print_single_line(str(e))
+            return _determine_return_code(warning_printer)
 
     render(options, tree)
 
-    return return_code
+    return _determine_return_code(warning_printer)
+
+
+def _determine_return_code(warning_printer: WarningPrinter) -> int:
+    return 1 if warning_printer.has_warned_with_failure() else 0
 
 
 if __name__ == "__main__":

--- a/src/pipdeptree/__main__.py
+++ b/src/pipdeptree/__main__.py
@@ -41,7 +41,8 @@ def main(args: Sequence[str] | None = None) -> None | int:
         try:
             tree = tree.filter_nodes(show_only, exclude)
         except ValueError as e:
-            warning_printer.print_single_line(str(e))
+            if warning_printer.should_warn():
+                warning_printer.print_single_line(str(e))
             return _determine_return_code(warning_printer)
 
     render(options, tree)

--- a/src/pipdeptree/__main__.py
+++ b/src/pipdeptree/__main__.py
@@ -10,7 +10,7 @@ from pipdeptree._discovery import get_installed_distributions
 from pipdeptree._models import PackageDAG
 from pipdeptree._render import render
 from pipdeptree._validate import validate
-from pipdeptree._warning import WarningPrinter, WarningType, get_warning_printer, parse_warning_type
+from pipdeptree._warning import WarningPrinter, WarningType, get_warning_printer
 
 
 def main(args: Sequence[str] | None = None) -> None | int:
@@ -19,9 +19,10 @@ def main(args: Sequence[str] | None = None) -> None | int:
 
     # Warnings are only enabled when using text output.
     is_text_output = not any([options.json, options.json_tree, options.output_format])
-    warning_type = WarningType.SILENCE if not is_text_output else parse_warning_type(options.warn)
+    if not is_text_output:
+        options.warn = WarningType.SILENCE
     warning_printer = get_warning_printer()
-    warning_printer.warning_type = warning_type
+    warning_printer.warning_type = options.warn
 
     pkgs = get_installed_distributions(
         interpreter=options.python, local_only=options.local_only, user_only=options.user_only

--- a/src/pipdeptree/_cli.py
+++ b/src/pipdeptree/_cli.py
@@ -160,7 +160,11 @@ class EnumAction(Action):
 
     This custom action exists because argparse doesn't have support for enums.
 
-    Adapted from: https://github.com/python/cpython/issues/69247#issuecomment-1308082792
+    References
+    ----------
+    - https://github.com/python/cpython/issues/69247#issuecomment-1308082792
+    - https://docs.python.org/3/library/argparse.html#action-classes
+
     """
 
     def __init__(  # noqa: PLR0913, PLR0917
@@ -203,7 +207,6 @@ class EnumAction(Action):
 
         self._enum = type
 
-    # See https://docs.python.org/3/library/argparse.html#action-classes as to why we need these params.
     def __call__(
         self,
         parser: ArgumentParser,  # noqa: ARG002

--- a/src/pipdeptree/_cli.py
+++ b/src/pipdeptree/_cli.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
+import enum
 import sys
-from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, Namespace
-from typing import TYPE_CHECKING, Sequence, cast
+from argparse import Action, ArgumentDefaultsHelpFormatter, ArgumentParser, Namespace
+from typing import Any, Sequence, cast
+
+from pipdeptree._warning import WarningType
 
 from .version import __version__
-
-if TYPE_CHECKING:
-    from typing import Literal
 
 
 class Options(Namespace):
@@ -16,7 +16,7 @@ class Options(Namespace):
     all: bool
     local_only: bool
     user_only: bool
-    warn: Literal["silence", "suppress", "fail"]
+    warn: WarningType
     reverse: bool
     packages: str
     exclude: str
@@ -40,11 +40,11 @@ def build_parser() -> ArgumentParser:
     parser.add_argument(
         "-w",
         "--warn",
-        action="store",
         dest="warn",
+        type=WarningType,
         nargs="?",
         default="suppress",
-        choices=("silence", "suppress", "fail"),
+        action=EnumAction,
         help=(
             "warning control: suppress will show warnings but return 0 whether or not they are present; silence will "
             "not show warnings at all and  always return 0; fail will show warnings and  return 1 if any are present"
@@ -152,6 +152,68 @@ def get_options(args: Sequence[str] | None) -> Options:
         return parser.error("cannot use --license with --freeze")
 
     return cast(Options, parsed_args)
+
+
+class EnumAction(Action):
+    """
+    Generic action that exists to convert a string into a Enum value that is then added into a `Namespace` object.
+
+    This custom action exists because argparse doesn't have support enums.
+
+    Adapted from: https://github.com/python/cpython/issues/69247#issuecomment-1308082792
+    """
+
+    def __init__(  # noqa: PLR0913, PLR0917
+        self,
+        option_strings: list[str],
+        dest: str,
+        nargs: str | None = None,
+        const: Any | None = None,
+        default: Any | None = None,
+        type: Any | None = None,  # noqa: A002
+        choices: Any | None = None,
+        required: bool = False,  # noqa: FBT001, FBT002
+        help: str | None = None,  # noqa: A002
+        metavar: str | None = None,
+    ) -> None:
+        if not type or not issubclass(type, enum.Enum):
+            msg = "type must be a subclass of Enum"
+            raise TypeError(msg)
+        if not isinstance(default, str):
+            msg = "default must be defined with a string value"
+            raise TypeError(msg)
+
+        choices = tuple(e.name.lower() for e in type)
+        if default not in choices:
+            msg = "default value should be among the enum choices"
+            raise ValueError(msg)
+
+        super().__init__(
+            option_strings=option_strings,
+            dest=dest,
+            nargs=nargs,
+            const=const,
+            default=default,
+            type=None,  # We return None here so that we default to str.
+            choices=choices,
+            required=required,
+            help=help,
+            metavar=metavar,
+        )
+
+        self._enum = type
+
+    # See https://docs.python.org/3/library/argparse.html#action-classes as to why we need these params.
+    def __call__(
+        self,
+        parser: ArgumentParser,  # noqa: ARG002
+        namespace: Namespace,
+        value: Any,
+        option_string: str | None = None,  # noqa: ARG002
+    ) -> None:
+        value = value or self.default
+        value = next(e for e in self._enum if e.name.lower() == value)
+        setattr(namespace, self.dest, value)
 
 
 __all__ = [

--- a/src/pipdeptree/_cli.py
+++ b/src/pipdeptree/_cli.py
@@ -158,7 +158,7 @@ class EnumAction(Action):
     """
     Generic action that exists to convert a string into a Enum value that is then added into a `Namespace` object.
 
-    This custom action exists because argparse doesn't have support enums.
+    This custom action exists because argparse doesn't have support for enums.
 
     Adapted from: https://github.com/python/cpython/issues/69247#issuecomment-1308082792
     """

--- a/src/pipdeptree/_models/dag.py
+++ b/src/pipdeptree/_models/dag.py
@@ -12,20 +12,17 @@ if TYPE_CHECKING:
     from importlib.metadata import Distribution
 
 
+from pipdeptree._warning import get_warning_printer
+
 from .package import DistPackage, InvalidRequirementError, ReqPackage
 
 
-def render_invalid_reqs_text_if_necessary(dist_name_to_invalid_reqs_dict: dict[str, list[str]]) -> None:
-    if not dist_name_to_invalid_reqs_dict:
-        return
-
-    print("Warning!!! Invalid requirement strings found for the following distributions:", file=sys.stderr)  # noqa: T201
+def render_invalid_reqs_text(dist_name_to_invalid_reqs_dict: dict[str, list[str]]) -> None:
     for dist_name, invalid_reqs in dist_name_to_invalid_reqs_dict.items():
         print(dist_name, file=sys.stderr)  # noqa: T201
 
         for invalid_req in invalid_reqs:
             print(f'  Skipping "{invalid_req}"', file=sys.stderr)  # noqa: T201
-    print("-" * 72, file=sys.stderr)  # noqa: T201
 
 
 class PackageDAG(Mapping[DistPackage, List[ReqPackage]]):
@@ -53,6 +50,7 @@ class PackageDAG(Mapping[DistPackage, List[ReqPackage]]):
 
     @classmethod
     def from_pkgs(cls, pkgs: list[Distribution]) -> PackageDAG:
+        warning_printer = get_warning_printer()
         dist_pkgs = [DistPackage(p) for p in pkgs]
         idx = {p.key: p for p in dist_pkgs}
         m: dict[DistPackage, list[ReqPackage]] = {}
@@ -65,7 +63,8 @@ class PackageDAG(Mapping[DistPackage, List[ReqPackage]]):
                     req = next(requires_iterator)
                 except InvalidRequirementError as err:
                     # We can't work with invalid requirement strings. Let's warn the user about them.
-                    dist_name_to_invalid_reqs_dict.setdefault(p.project_name, []).append(str(err))
+                    if warning_printer.should_warn():
+                        dist_name_to_invalid_reqs_dict.setdefault(p.project_name, []).append(str(err))
                     continue
                 except StopIteration:
                     break
@@ -78,7 +77,12 @@ class PackageDAG(Mapping[DistPackage, List[ReqPackage]]):
                 reqs.append(pkg)
             m[p] = reqs
 
-        render_invalid_reqs_text_if_necessary(dist_name_to_invalid_reqs_dict)
+        should_print_warning = warning_printer.should_warn() and dist_name_to_invalid_reqs_dict
+        if should_print_warning:
+            warning_printer.print_multi_line(
+                "Invalid requirement strings found for the following distributions",
+                lambda: render_invalid_reqs_text(dist_name_to_invalid_reqs_dict),
+            )
 
         return cls(m)
 

--- a/src/pipdeptree/_validate.py
+++ b/src/pipdeptree/_validate.py
@@ -4,30 +4,28 @@ import sys
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
+from pipdeptree._warning import get_warning_printer
+
 if TYPE_CHECKING:
     from pipdeptree._models.package import Package
 
-    from ._cli import Options
     from ._models import DistPackage, PackageDAG, ReqPackage
 
 
-def validate(args: Options, is_text_output: bool, tree: PackageDAG) -> int:  # noqa: FBT001
+def validate(tree: PackageDAG) -> None:
     # Before any reversing or filtering, show warnings to console, about possibly conflicting or cyclic deps if found
     # and warnings are enabled (i.e. only if output is to be printed to console)
-    if is_text_output and args.warn != "silence":
+    warning_printer = get_warning_printer()
+    if warning_printer.should_warn():
         conflicts = conflicting_deps(tree)
         if conflicts:
-            render_conflicts_text(conflicts)
-            print("-" * 72, file=sys.stderr)  # noqa: T201
+            warning_printer.print_multi_line(
+                "Possibly conflicting dependencies found", lambda: render_conflicts_text(conflicts)
+            )
 
         cycles = cyclic_deps(tree)
         if cycles:
-            render_cycles_text(cycles)
-            print("-" * 72, file=sys.stderr)  # noqa: T201
-
-        if args.warn == "fail" and (conflicts or cycles):
-            return 1
-    return 0
+            warning_printer.print_multi_line("Cyclic dependencies found", lambda: render_cycles_text(cycles))
 
 
 def conflicting_deps(tree: PackageDAG) -> dict[DistPackage, list[ReqPackage]]:
@@ -50,16 +48,14 @@ def conflicting_deps(tree: PackageDAG) -> dict[DistPackage, list[ReqPackage]]:
 
 
 def render_conflicts_text(conflicts: dict[DistPackage, list[ReqPackage]]) -> None:
-    if conflicts:
-        print("Warning!!! Possibly conflicting dependencies found:", file=sys.stderr)  # noqa: T201
-        # Enforce alphabetical order when listing conflicts
-        pkgs = sorted(conflicts.keys())
-        for p in pkgs:
-            pkg = p.render_as_root(frozen=False)
-            print(f"* {pkg}", file=sys.stderr)  # noqa: T201
-            for req in conflicts[p]:
-                req_str = req.render_as_branch(frozen=False)
-                print(f" - {req_str}", file=sys.stderr)  # noqa: T201
+    # Enforce alphabetical order when listing conflicts
+    pkgs = sorted(conflicts.keys())
+    for p in pkgs:
+        pkg = p.render_as_root(frozen=False)
+        print(f"* {pkg}", file=sys.stderr)  # noqa: T201
+        for req in conflicts[p]:
+            req_str = req.render_as_branch(frozen=False)
+            print(f" - {req_str}", file=sys.stderr)  # noqa: T201
 
 
 def cyclic_deps(tree: PackageDAG) -> list[list[Package]]:
@@ -104,20 +100,18 @@ def cyclic_deps(tree: PackageDAG) -> list[list[Package]]:
 
 
 def render_cycles_text(cycles: list[list[Package]]) -> None:
-    if cycles:
-        print("Warning!! Cyclic dependencies found:", file=sys.stderr)  # noqa: T201
-        # List in alphabetical order the dependency that caused the cycle (i.e. the second-to-last Package element)
-        cycles = sorted(cycles, key=lambda c: c[len(c) - 2].key)
-        for cycle in cycles:
-            print("*", end=" ", file=sys.stderr)  # noqa: T201
+    # List in alphabetical order the dependency that caused the cycle (i.e. the second-to-last Package element)
+    cycles = sorted(cycles, key=lambda c: c[len(c) - 2].key)
+    for cycle in cycles:
+        print("*", end=" ", file=sys.stderr)  # noqa: T201
 
-            size = len(cycle) - 1
-            for idx, pkg in enumerate(cycle):
-                if idx == size:
-                    print(f"{pkg.project_name}", end="", file=sys.stderr)  # noqa: T201
-                else:
-                    print(f"{pkg.project_name} =>", end=" ", file=sys.stderr)  # noqa: T201
-            print(file=sys.stderr)  # noqa: T201
+        size = len(cycle) - 1
+        for idx, pkg in enumerate(cycle):
+            if idx == size:
+                print(f"{pkg.project_name}", end="", file=sys.stderr)  # noqa: T201
+            else:
+                print(f"{pkg.project_name} =>", end=" ", file=sys.stderr)  # noqa: T201
+        print(file=sys.stderr)  # noqa: T201
 
 
 __all__ = [

--- a/src/pipdeptree/_warning.py
+++ b/src/pipdeptree/_warning.py
@@ -58,15 +58,4 @@ def get_warning_printer() -> WarningPrinter:
     return _shared_warning_printer
 
 
-def parse_warning_type(type_str: str) -> WarningType:
-    if type_str == "silence":
-        return WarningType.SILENCE
-    if type_str == "fail":
-        return WarningType.FAIL
-
-    # Either type_str == "suppress" or we were given an invalid string. For the latter case, our argparse configuration
-    # shouldn't allow this to happen, but we'll go ahead and use this warning type since it is the default.
-    return WarningType.SUPPRESS
-
-
-__all__ = ["WarningPrinter", "get_warning_printer", "parse_warning_type"]
+__all__ = ["WarningPrinter", "get_warning_printer"]

--- a/src/pipdeptree/_warning.py
+++ b/src/pipdeptree/_warning.py
@@ -8,10 +8,10 @@ WarningType = Enum("WarningType", ["SILENCE", "SUPPRESS", "FAIL"])
 
 
 class WarningPrinter:
-    """Handles printing warning logic. For multi-line warnings, it delegates most of its logic to the caller."""
+    """Non-thread safe class that handles printing warning logic."""
 
-    def __init__(self) -> None:
-        self._warning_type = WarningType.SUPPRESS
+    def __init__(self, warning_type: WarningType = WarningType.SUPPRESS) -> None:
+        self._warning_type = warning_type
         self._has_warned = False
         self._file = sys.stderr
 
@@ -33,16 +33,20 @@ class WarningPrinter:
         self._has_warned = True
         print(line, file=sys.stderr)  # noqa: T201
 
-    def print_multi_line(self, summary: str, print_func: Callable, ignore_fail: bool = False) -> None:  # noqa: FBT001, FBT002
+    def print_multi_line(self, summary: str, print_func: Callable[[], None], ignore_fail: bool = False) -> None:  # noqa: FBT001, FBT002
+        """
+        Print a multi-line warning, delegating most of the printing logic to the caller.
+
+        :param summary: a summary of the warning
+        :param print_func: a callback that the caller passes that performs most of the multi-line printing
+        :param ignore_fail: if True, this warning won't be a fail when `self.warning_type == WarningType.FAIL`
+        """
         print(f"Warning!!! {summary}:", file=sys.stderr)  # noqa: T201
-
         print_func()
-
         if ignore_fail:
             print("NOTE: This warning isn't a failure warning.", file=sys.stderr)  # noqa: T201
         else:
             self._has_warned = True
-
         print("-" * 72, file=sys.stderr)  # noqa: T201
 
 

--- a/src/pipdeptree/_warning.py
+++ b/src/pipdeptree/_warning.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import sys
+from enum import Enum
+from typing import Callable
+
+WarningType = Enum("WarningType", ["SILENCE", "SUPPRESS", "FAIL"])
+
+
+class WarningPrinter:
+    """Handles printing warning logic. For multi-line warnings, it delegates most of its logic to the caller."""
+
+    def __init__(self) -> None:
+        self._warning_type = WarningType.SUPPRESS
+        self._has_warned = False
+        self._file = sys.stderr
+
+    @property
+    def warning_type(self) -> WarningType:
+        return self._warning_type
+
+    @warning_type.setter
+    def warning_type(self, new_warning_type: WarningType) -> None:
+        self._warning_type = new_warning_type
+
+    def should_warn(self) -> bool:
+        return self._warning_type != WarningType.SILENCE
+
+    def has_warned_with_failure(self) -> bool:
+        return self._has_warned and self.warning_type == WarningType.FAIL
+
+    def print_single_line(self, line: str) -> None:
+        self._has_warned = True
+        print(line, file=sys.stderr)  # noqa: T201
+
+    def print_multi_line(self, summary: str, print_func: Callable, ignore_fail: bool = False) -> None:  # noqa: FBT001, FBT002
+        print(f"Warning!!! {summary}:", file=sys.stderr)  # noqa: T201
+
+        print_func()
+
+        if ignore_fail:
+            print("NOTE: This warning isn't a failure warning.", file=sys.stderr)  # noqa: T201
+        else:
+            self._has_warned = True
+
+        print("-" * 72, file=sys.stderr)  # noqa: T201
+
+
+_shared_warning_printer = WarningPrinter()
+
+
+def get_warning_printer() -> WarningPrinter:
+    """Shared warning printer, representing a module-level singleton object."""
+    return _shared_warning_printer
+
+
+def parse_warning_type(type_str: str) -> WarningType:
+    if type_str == "silence":
+        return WarningType.SILENCE
+    if type_str == "fail":
+        return WarningType.FAIL
+
+    # Either type_str == "suppress" or we were given an invalid string. For the latter case, our argparse configuration
+    # shouldn't allow this to happen, but we'll go ahead and use this warning type since it is the default.
+    return WarningType.SUPPRESS
+
+
+__all__ = ["WarningPrinter", "get_warning_printer", "parse_warning_type"]

--- a/src/pipdeptree/_warning.py
+++ b/src/pipdeptree/_warning.py
@@ -13,7 +13,6 @@ class WarningPrinter:
     def __init__(self, warning_type: WarningType = WarningType.SUPPRESS) -> None:
         self._warning_type = warning_type
         self._has_warned = False
-        self._file = sys.stderr
 
     @property
     def warning_type(self) -> WarningType:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+from typing import Any
 
 import pytest
 
@@ -112,32 +113,32 @@ def test_parser_get_options_license_and_freeze_together_not_supported(capsys: py
 
 
 @pytest.mark.parametrize(("bad_type"), [None, str])
-def test_enum_action_type_argument(bad_type: any) -> None:
+def test_enum_action_type_argument(bad_type: Any) -> None:
     with pytest.raises(TypeError, match="type must be a subclass of Enum"):
-        EnumAction("--test", "test", type=bad_type)
+        EnumAction(["--test"], "test", type=bad_type)
 
 
 def test_enum_action_default_argument_not_str() -> None:
     with pytest.raises(TypeError, match="default must be defined with a string value"):
-        EnumAction("--test", "test", type=WarningType)
+        EnumAction(["--test"], "test", type=WarningType)
 
 
 def test_enum_action_default_argument_not_a_valid_choice() -> None:
     with pytest.raises(ValueError, match="default value should be among the enum choices"):
-        EnumAction("--test", "test", type=WarningType, default="bad-warning-type")
+        EnumAction(["--test"], "test", type=WarningType, default="bad-warning-type")
 
 
 def test_enum_action_call_with_value() -> None:
-    action = EnumAction("--test", "test", type=WarningType, default="silence")
+    action = EnumAction(["--test"], "test", type=WarningType, default="silence")
     namespace = argparse.Namespace()
-    action(None, namespace, "suppress")
+    action(argparse.ArgumentParser(), namespace, "suppress")
     assert getattr(namespace, "test", None) == WarningType.SUPPRESS
 
 
 def test_enum_action_call_without_value() -> None:
     # ensures that we end up using the default value in case no value is specified (currently we pass nargs='?' when
     # creating the --warn option, which is why this test exists)
-    action = EnumAction("--test", "test", type=WarningType, default="silence")
+    action = EnumAction(["--test"], "test", type=WarningType, default="silence")
     namespace = argparse.Namespace()
-    action(None, namespace, None)
+    action(argparse.ArgumentParser(), namespace, None)
     assert getattr(namespace, "test", None) == WarningType.SILENCE

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -79,6 +79,7 @@ def test_duplicate_metadata(mocker: MockerFixture, capfd: pytest.CaptureFixture[
     _, err = capfd.readouterr()
     expected = (
         'Warning!!! Duplicate package metadata found:\n"/path/2"\n  foo                              5.9.0       '
-        '     (using 1.2.5, "/path/1")\n------------------------------------------------------------------------\n'
+        '     (using 1.2.5, "/path/1")\nNOTE: This warning isn\'t a failure warning.\n---------------------------------'
+        "---------------------------------------\n"
     )
     assert err == expected

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
                 ("d", "2.0"): [],
             },
             [["a", "b", "a"], ["b", "a", "b"]],
-            ["Warning!! Cyclic dependencies found:", "* b => a => b", "* a => b => a"],
+            ["* b => a => b", "* a => b => a"],
             id="depth-of-2",
         ),
         pytest.param(
@@ -42,7 +42,6 @@ if TYPE_CHECKING:
                 ["a", "b", "c", "d", "a"],
             ],
             [
-                "Warning!! Cyclic dependencies found:",
                 "* b => c => d => a => b",
                 "* c => d => a => b => c",
                 "* d => a => b => c => d",
@@ -90,7 +89,6 @@ def test_cyclic_deps(
             {("a", "1.0.1"): [("b", [(">=", "2.3.0")])], ("b", "1.9.1"): []},
             {"a": ["b"]},
             [
-                "Warning!!! Possibly conflicting dependencies found:",
                 "* a==1.0.1",
                 " - b [required: >=2.3.0, installed: 1.9.1]",
             ],
@@ -99,7 +97,6 @@ def test_cyclic_deps(
             {("a", "1.0.1"): [("c", [(">=", "9.4.1")])], ("b", "2.3.0"): [("c", [(">=", "7.0")])], ("c", "8.0.1"): []},
             {"a": ["c"]},
             [
-                "Warning!!! Possibly conflicting dependencies found:",
                 "* a==1.0.1",
                 " - c [required: >=9.4.1, installed: 8.0.1]",
             ],
@@ -108,7 +105,6 @@ def test_cyclic_deps(
             {("a", "1.0.1"): [("c", [(">=", "9.4.1")])], ("b", "2.3.0"): [("c", [(">=", "9.4.0")])]},
             {"a": ["c"], "b": ["c"]},
             [
-                "Warning!!! Possibly conflicting dependencies found:",
                 "* a==1.0.1",
                 " - c [required: >=9.4.1, installed: ?]",
                 "* b==2.3.0",

--- a/tests/test_warning.py
+++ b/tests/test_warning.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import pytest
+
+from pipdeptree._warning import WarningPrinter, WarningType, parse_warning_type
+
+
+def test_warning_printer_print_single_line(capsys: pytest.CaptureFixture[str]) -> None:
+    # Use WarningType.FAIL so that we can be able to test to see if WarningPrinter remembers it has warned before.
+    warning_printer = WarningPrinter(WarningType.FAIL)
+    warning_printer.print_single_line("test")
+    assert warning_printer.has_warned_with_failure()
+    out, err = capsys.readouterr()
+    assert len(out) == 0
+    assert err == "test\n"
+
+
+@pytest.mark.parametrize(
+    ("warning_type_str", "expected_warning_type"),
+    [
+        ("silence", WarningType.SILENCE),
+        ("suppress", WarningType.SUPPRESS),
+        ("fail", WarningType.FAIL),
+        ("invalid-type", WarningType.SUPPRESS),
+    ],
+)
+def test_parse_warning_type(warning_type_str: str, expected_warning_type: WarningType) -> None:
+    actual_warning_type = parse_warning_type(warning_type_str)
+    assert expected_warning_type == actual_warning_type

--- a/tests/test_warning.py
+++ b/tests/test_warning.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
-import pytest
+from typing import TYPE_CHECKING
 
-from pipdeptree._warning import WarningPrinter, WarningType, parse_warning_type
+from pipdeptree._warning import WarningPrinter, WarningType
+
+if TYPE_CHECKING:
+    import pytest
 
 
 def test_warning_printer_print_single_line(capsys: pytest.CaptureFixture[str]) -> None:
@@ -13,17 +16,3 @@ def test_warning_printer_print_single_line(capsys: pytest.CaptureFixture[str]) -
     out, err = capsys.readouterr()
     assert len(out) == 0
     assert err == "test\n"
-
-
-@pytest.mark.parametrize(
-    ("warning_type_str", "expected_warning_type"),
-    [
-        ("silence", WarningType.SILENCE),
-        ("suppress", WarningType.SUPPRESS),
-        ("fail", WarningType.FAIL),
-        ("invalid-type", WarningType.SUPPRESS),
-    ],
-)
-def test_parse_warning_type(warning_type_str: str, expected_warning_type: WarningType) -> None:
-    actual_warning_type = parse_warning_type(warning_type_str)
-    assert expected_warning_type == actual_warning_type


### PR DESCRIPTION
This resolves #355 by making changes and refactors to the warning logic. It does so by introducing a module-level singleton "WarningPrinter" object and refactors the code in such a way to integrate this object for it to be used.