### PR TITLE
Remove publish job from the check workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,7 +3,6 @@ on:
   workflow_dispatch:
   push:
     branches: "main"
-    tags-ignore: ["**"]
   pull_request:
   schedule:
     - cron: "0 8 * * *"
@@ -81,24 +80,3 @@ jobs:
         run: python -m tox -e ${{ matrix.tox_env }}
         env:
           UPGRADE_ADVISORY: "yes"
-
-  publish:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-    needs: [check, test]
-    runs-on: ubuntu-latest
-    steps:
-      - name: setup python to build package
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - name: install build
-        run: python -m pip install build
-      - uses: actions/checkout@v4
-      - name: build package
-        run: python -m build --sdist --wheel . -o dist
-      - name: publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.8.14
-        with:
-          skip_existing: true
-          user: __token__
-          password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
This appears to be a job that existed before we began publishing new releases using PyPI's [trusted publisher feature](https://docs.pypi.org/trusted-publishers/using-a-publisher/) in release.yml.

From exploring the Actions/Deployments tab, I could not find an instance where this job was ran. Seeing the `check` workflow configuration, we ignore all tag push events because of the `tags-ignore` usage. This would mean that `publish` will always be skipped since we don't listen for tag pushes in the `check` workflow. We also no longer have a `pypi_password` secret so even if it were to run it should fail.

I also decided to just remove the `tags-ignore` as according to the [docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore) (though the wording is a tad weird), tag push events won't trigger a workflow run if we specify only `branch`.