### PR TITLE
Mimic pip when handling --user-only in a virtual environment

### DIFF
--- a/src/pipdeptree/_discovery.py
+++ b/src/pipdeptree/_discovery.py
@@ -6,7 +6,7 @@ import subprocess  # noqa: S404
 import sys
 from importlib.metadata import Distribution, distributions
 from pathlib import Path
-from typing import Iterable, Tuple
+from typing import Tuple
 
 from packaging.utils import canonicalize_name
 
@@ -18,18 +18,18 @@ def get_installed_distributions(
     local_only: bool = False,  # noqa: FBT001, FBT002
     user_only: bool = False,  # noqa: FBT001, FBT002
 ) -> list[Distribution]:
+    # We assign sys.path here as it used by both importlib.metadata.PathDistribution and pip by default.
+    paths = sys.path
+
     # See https://docs.python.org/3/library/venv.html#how-venvs-work for more details.
     in_venv = sys.prefix != sys.base_prefix
-    original_dists: Iterable[Distribution] = []
+
     py_path = Path(interpreter).absolute()
     using_custom_interpreter = py_path != Path(sys.executable).absolute()
 
-    if user_only:
-        original_dists = distributions(path=[site.getusersitepackages()])
-    elif using_custom_interpreter:
-        # We query the interpreter directly to get its `sys.path` list to be used by `distributions()`.
-        # If --python and --local-only are given, we ensure that we are only using paths associated to the interpreter's
-        # environment.
+    if using_custom_interpreter:
+        # We query the interpreter directly to get its `sys.path`. If both --python and --local-only are given, only
+        # snatch metadata associated to the interpreter's environment.
         if local_only:
             cmd = "import sys; print([p for p in sys.path if p.startswith(sys.prefix)])"
         else:
@@ -37,13 +37,14 @@ def get_installed_distributions(
 
         args = [str(py_path), "-c", cmd]
         result = subprocess.run(args, stdout=subprocess.PIPE, check=False, text=True)  # noqa: S603
-        original_dists = distributions(path=ast.literal_eval(result.stdout))
+        paths = ast.literal_eval(result.stdout)
     elif local_only and in_venv:
-        venv_site_packages = [p for p in sys.path if p.startswith(sys.prefix)]
-        original_dists = distributions(path=venv_site_packages)
-    else:
-        original_dists = distributions()
+        paths = [p for p in paths if p.startswith(sys.prefix)]
 
+    if user_only:
+        paths = [p for p in paths if p.startswith(site.getusersitepackages())]
+
+    original_dists = distributions(path=paths)
     warning_printer = get_warning_printer()
 
     # Since importlib.metadata.distributions() can return duplicate packages, we need to handle this. pip's approach is

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from random import shuffle
 from typing import TYPE_CHECKING, Callable, Iterator
 from unittest.mock import Mock
@@ -65,3 +66,16 @@ def randomized_example_dag(example_dag: PackageDAG) -> PackageDAG:
     randomized_dag = PackageDAG(randomized_graph)
     assert len(example_dag) == len(randomized_dag)
     return randomized_dag
+
+
+@pytest.fixture()
+def fake_dist(tmp_path: Path) -> Path:
+    """Creates a fake site package (that you get using Path.parent) and a fake dist-info called bar-2.4.5.dist-info."""
+    fake_site_pkgs = tmp_path / "site-packages"
+    fake_dist_path = fake_site_pkgs / "bar-2.4.5.dist-info"
+    fake_dist_path.mkdir(parents=True)
+    fake_metadata = Path(fake_dist_path) / "METADATA"
+    with Path(fake_metadata).open("w") as f:
+        f.write("Metadata-Version: 2.3\n" "Name: bar\n" "Version: 2.4.5\n")
+
+    return fake_dist_path


### PR DESCRIPTION
In v2.16.1, we would not print any user-site packages if we were:
- In a virtual environment
- Using a custom interpreter

This makes since as we should be isolated away from the system environment. The only case where we should be seeing user-site packages is when these environments have system site packages enabled. This patch brings back this behavior.