### PR TITLE
Use non-deprecated pytest-console-scripts API

### DIFF
--- a/tests/test_pipdeptree.py
+++ b/tests/test_pipdeptree.py
@@ -13,5 +13,5 @@ def test_main() -> None:
 
 
 def test_console(script_runner: ScriptRunner) -> None:
-    result = script_runner.run("pipdeptree", "--help")
+    result = script_runner.run(["pipdeptree", "--help"])
     assert result.success


### PR DESCRIPTION
This removes a deprecation warning message that appears when running the automated tests.