### PR TITLE
Use `__contains__` to avoid `KeyError` with importlib_metadata==8.0.0

### DIFF
--- a/src/pipdeptree/_discovery.py
+++ b/src/pipdeptree/_discovery.py
@@ -93,7 +93,7 @@ def filter_valid_distributions(iterable_dists: Iterable[Distribution]) -> list[D
 
 
 def has_valid_metadata(dist: Distribution) -> bool:
-    return dist.metadata["Name"] is not None
+    return "Name" in dist.metadata
 
 
 def render_invalid_metadata_text(site_dirs_with_invalid_metadata: set[str]) -> None:


### PR DESCRIPTION
We don't actually depend on the backport, but a pytest plugin that we are using, pytest-console-scripts, does.

importlib_metadata==8.0.0 now raises a KeyError when we try to get metadata that doesn't exist (where before it would return None).

When running the automated tests, we would fail because the backport would for some reason take precedence over the stdlib. To resolve this, the current impl is replaced with a __contains__() call.