### PR TITLE
Use is_missing property in ReqPackage.is_conflicting() for DRYness

### DIFF
--- a/src/pipdeptree/_models/package.py
+++ b/src/pipdeptree/_models/package.py
@@ -226,17 +226,17 @@ class ReqPackage(Package):
                 return v
         return self.dist.version
 
-    @property
-    def is_missing(self) -> bool:
-        return self.installed_version == self.UNKNOWN_VERSION
-
     def is_conflicting(self) -> bool:
         """If installed version conflicts with required version."""
         # unknown installed version is also considered conflicting
-        if self.installed_version == self.UNKNOWN_VERSION:
+        if self.is_missing:
             return True
 
         return self.installed_version not in self._obj.specifier
+
+    @property
+    def is_missing(self) -> bool:
+        return self.installed_version == self.UNKNOWN_VERSION
 
     def as_dict(self) -> dict[str, str]:
         return {


### PR DESCRIPTION
Just a small refactor in ReqPackage to keep things DRY.