### PR TITLE
Readd `# noqa: S603` to _detect_env to resolve Ruff error

### DIFF
--- a/src/pipdeptree/_detect_env.py
+++ b/src/pipdeptree/_detect_env.py
@@ -72,7 +72,7 @@ def detect_poetry_env_interpreter() -> Path | None:
     # active interpreter.
     # See https://python-poetry.org/docs/managing-environments/#displaying-the-environment-information.
     try:
-        result = subprocess.run(
+        result = subprocess.run(  # noqa: S603
             ("poetry", "env", "info", "--executable"),
             check=True,
             text=True,


### PR DESCRIPTION
Whoops, not sure why the pre-commit bot decided to remove this ignore rule in the first place.