### PR TITLE
Move pip's frozen requirement API into a single module

### DIFF
--- a/src/pipdeptree/_freeze.py
+++ b/src/pipdeptree/_freeze.py
@@ -16,6 +16,16 @@ if TYPE_CHECKING:
     from importlib.metadata import Distribution
 
 
+def dist_to_frozen_repr(dist: Distribution) -> str:
+    """Return the frozen requirement repr of a `importlib.metadata.Distribution` object."""
+    from pip._internal.operations.freeze import FrozenRequirement  # noqa: PLC0415, PLC2701
+
+    adapter = PipBaseDistributionAdapter(dist)
+    fr = FrozenRequirement.from_dist(adapter)  # type: ignore[arg-type]
+
+    return str(fr).strip()
+
+
 class PipBaseDistributionAdapter:
     """
     An adapter class for pip's `pip._internal.metadata.BaseDistribution` abstract class.
@@ -74,3 +84,6 @@ class PipBaseDistributionAdapter:
             with Path(egg_link_path).open("r", encoding=locale.getpreferredencoding(False)) as f:  # noqa: FBT003
                 result = f.readline().rstrip()
         return result
+
+
+__all__ = ["dist_to_frozen_repr"]

--- a/src/pipdeptree/_models/package.py
+++ b/src/pipdeptree/_models/package.py
@@ -9,10 +9,10 @@ from typing import TYPE_CHECKING, Iterator
 from packaging.requirements import InvalidRequirement, Requirement
 from packaging.utils import canonicalize_name
 
+from pipdeptree._freeze import dist_to_frozen_repr
+
 if TYPE_CHECKING:
     from importlib.metadata import Distribution
-
-from pipdeptree._adapter import PipBaseDistributionAdapter
 
 
 class InvalidRequirementError(ValueError):
@@ -75,12 +75,7 @@ class Package(ABC):
 
     @staticmethod
     def as_frozen_repr(dist: Distribution) -> str:
-        from pip._internal.operations.freeze import FrozenRequirement  # noqa: PLC0415, PLC2701 # pragma: no cover
-
-        adapter = PipBaseDistributionAdapter(dist)
-        fr = FrozenRequirement.from_dist(adapter)  # type: ignore[arg-type]
-
-        return str(fr).strip()
+        return dist_to_frozen_repr(dist)
 
     def __repr__(self) -> str:
         return f'<{self.__class__.__name__}("{self.key}")>'

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+from pipdeptree._freeze import dist_to_frozen_repr
+
+
+def test_dist_to_frozen_repr() -> None:
+    foo = Mock(metadata={"Name": "foo"}, version="20.4.1")
+    foo.read_text = Mock(return_value=None)
+    expected = "foo==20.4.1"
+    assert dist_to_frozen_repr(foo) == expected


### PR DESCRIPTION
This snapshot moves the remaining pip API usage into the `freeze` module since we only use it to render dependency trees in the requirements.txt file format.

It also makes changes to related tests to make them true unit tests and creates an integration test for dist_to_frozen_repr().