### PR TITLE
Remove unused .gitignore rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 dist/
 .tox/
 /src/pipdeptree/version.py
-tests/virtualenvs/equimapper/


### PR DESCRIPTION
This is a relic from an older test design that we no longer follow.