### PR TITLE
Remove unnecessary assertion in render()

### DIFF
--- a/src/pipdeptree/_cli.py
+++ b/src/pipdeptree/_cli.py
@@ -100,7 +100,7 @@ def build_parser() -> ArgumentParser:
     render.add_argument("-f", "--freeze", action="store_true", help="print names so as to write freeze files")
     render.add_argument(
         "--encoding",
-        dest="encoding_type",
+        dest="encoding",
         default=sys.stdout.encoding,
         help="the encoding to use when writing to the output",
         metavar="E",

--- a/src/pipdeptree/_render/__init__.py
+++ b/src/pipdeptree/_render/__init__.py
@@ -21,13 +21,12 @@ def render(options: Options, tree: PackageDAG) -> None:
     elif options.mermaid:
         print(render_mermaid(tree))  # noqa: T201
     elif options.output_format:
-        assert options.output_format is not None
         render_graphviz(tree, output_format=options.output_format, reverse=options.reverse)
     else:
         render_text(
             tree,
             max_depth=options.depth,
-            encoding=options.encoding_type,
+            encoding=options.encoding,
             list_all=options.all,
             frozen=options.freeze,
             include_license=options.license,


### PR DESCRIPTION
This also renames the argparse arg "encoding_type" to "encoding" to match what we have in the `Options` class.