### PR TITLE
Support for License-Expression field

### DIFF
--- a/src/pipdeptree/_models/package.py
+++ b/src/pipdeptree/_models/package.py
@@ -40,12 +40,14 @@ class Package(ABC):
             return self.UNKNOWN_LICENSE_STR
 
         license_strs: list[str] = []
-        classifiers = dist_metadata.get_all("Classifier", [])
+        if license_str := dist_metadata.get("License-Expression"):
+            license_strs.append(license_str)
 
+        classifiers = dist_metadata.get_all("Classifier", [])
         for classifier in classifiers:
             line = str(classifier)
             if line.startswith("License"):
-                license_str = line.split(":: ")[-1]
+                license_str = line.rsplit(":: ", 1)[-1]
                 license_strs.append(license_str)
 
         if len(license_strs) == 0:

--- a/src/pipdeptree/_models/package.py
+++ b/src/pipdeptree/_models/package.py
@@ -39,10 +39,10 @@ class Package(ABC):
         except PackageNotFoundError:
             return self.UNKNOWN_LICENSE_STR
 
-        license_strs: list[str] = []
         if license_str := dist_metadata.get("License-Expression"):
-            license_strs.append(license_str)
+            return f"({license_str})"
 
+        license_strs: list[str] = []
         classifiers = dist_metadata.get_all("Classifier", [])
         for classifier in classifiers:
             line = str(classifier)

--- a/tests/_models/test_package.py
+++ b/tests/_models/test_package.py
@@ -109,7 +109,7 @@ def test_dist_package_as_dict() -> None:
         pytest.param(
             Mock(
                 get=lambda *args, **kwargs: None,  # noqa: ARG005
-                get_all=lambda *args, **kwargs: []  # noqa: ARG005
+                get_all=lambda *args, **kwargs: [],  # noqa: ARG005
             ),
             Package.UNKNOWN_LICENSE_STR,
             id="no-license",
@@ -120,7 +120,7 @@ def test_dist_package_as_dict() -> None:
                 get_all=lambda *args, **kwargs: [  # noqa: ARG005
                     "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
                     "Operating System :: OS Independent",
-                ]
+                ],
             ),
             "(GNU General Public License v2 (GPLv2))",
             id="one-license-with-one-non-license",
@@ -131,7 +131,7 @@ def test_dist_package_as_dict() -> None:
                 get_all=lambda *args, **kwargs: [  # noqa: ARG005
                     "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
                     "License :: OSI Approved :: Apache Software License",
-                ]
+                ],
             ),
             "(GNU General Public License v2 (GPLv2), Apache Software License)",
             id="more-than-one-license",
@@ -139,7 +139,7 @@ def test_dist_package_as_dict() -> None:
         pytest.param(
             Mock(
                 get=lambda *args, **kwargs: "MIT",  # noqa: ARG005
-                get_all=lambda *args, **kwargs: []  # noqa: ARG005
+                get_all=lambda *args, **kwargs: [],  # noqa: ARG005
             ),
             "(MIT)",
             id="license-expression",
@@ -149,7 +149,7 @@ def test_dist_package_as_dict() -> None:
                 get=lambda *args, **kwargs: "MIT",  # noqa: ARG005
                 get_all=lambda *args, **kwargs: [  # noqa: ARG005
                     "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
-                ]
+                ],
             ),
             "(MIT, GNU General Public License v2 (GPLv2))",
             id="license-expression-with-license-classifier",

--- a/tests/_models/test_package.py
+++ b/tests/_models/test_package.py
@@ -107,12 +107,16 @@ def test_dist_package_as_dict() -> None:
     ("mocked_metadata", "expected_output"),
     [
         pytest.param(
-            Mock(get_all=lambda *args, **kwargs: []),  # noqa: ARG005
+            Mock(
+                get=lambda *args, **kwargs: None,  # noqa: ARG005
+                get_all=lambda *args, **kwargs: []  # noqa: ARG005
+            ),
             Package.UNKNOWN_LICENSE_STR,
             id="no-license",
         ),
         pytest.param(
             Mock(
+                get=lambda *args, **kwargs: None,  # noqa: ARG005
                 get_all=lambda *args, **kwargs: [  # noqa: ARG005
                     "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
                     "Operating System :: OS Independent",
@@ -123,6 +127,7 @@ def test_dist_package_as_dict() -> None:
         ),
         pytest.param(
             Mock(
+                get=lambda *args, **kwargs: None,  # noqa: ARG005
                 get_all=lambda *args, **kwargs: [  # noqa: ARG005
                     "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
                     "License :: OSI Approved :: Apache Software License",
@@ -130,6 +135,24 @@ def test_dist_package_as_dict() -> None:
             ),
             "(GNU General Public License v2 (GPLv2), Apache Software License)",
             id="more-than-one-license",
+        ),
+        pytest.param(
+            Mock(
+                get=lambda *args, **kwargs: "MIT",  # noqa: ARG005
+                get_all=lambda *args, **kwargs: []  # noqa: ARG005
+            ),
+            "(MIT)",
+            id="license-expression",
+        ),
+        pytest.param(
+            Mock(
+                get=lambda *args, **kwargs: "MIT",  # noqa: ARG005
+                get_all=lambda *args, **kwargs: [  # noqa: ARG005
+                    "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
+                ]
+            ),
+            "(MIT, GNU General Public License v2 (GPLv2))",
+            id="license-expression-with-license-classifier",
         ),
     ],
 )

--- a/tests/_models/test_package.py
+++ b/tests/_models/test_package.py
@@ -148,10 +148,10 @@ def test_dist_package_as_dict() -> None:
             Mock(
                 get=lambda *args, **kwargs: "MIT",  # noqa: ARG005
                 get_all=lambda *args, **kwargs: [  # noqa: ARG005
-                    "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
+                    "License :: OSI Approved :: MIT License",
                 ],
             ),
-            "(MIT, GNU General Public License v2 (GPLv2))",
+            "(MIT)",
             id="license-expression-with-license-classifier",
         ),
     ],


### PR DESCRIPTION
Allows to display a license for projects with a new License-Expression field. For example, pipdeptree itself.

https://peps.python.org/pep-0639/#add-license-expression-field