### PR TITLE
Replace `pytest-console-scripts` plugin with smaller in-house solution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ optional-dependencies.test = [
   "covdefaults>=2.3",
   "diff-cover>=9.1.1",
   "pytest>=8.3.2",
-  "pytest-console-scripts>=1.4.1",
   "pytest-cov>=5",
   "pytest-mock>=3.14",
   "virtualenv>=20.26.4,<21",

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -180,7 +180,7 @@ def test_paths(fake_dist: Path) -> None:
 
     dists = get_installed_distributions(supplied_paths=mocked_path)
     assert len(dists) == 1
-    assert dists[0].name == "bar"
+    assert dists[0].metadata["Name"] == "bar"
 
 
 def test_paths_when_in_virtual_env(tmp_path: Path, fake_dist: Path) -> None:
@@ -193,4 +193,4 @@ def test_paths_when_in_virtual_env(tmp_path: Path, fake_dist: Path) -> None:
 
     dists = get_installed_distributions(interpreter=str(s.creator.exe), supplied_paths=mocked_path)
     assert len(dists) == 1
-    assert dists[0].name == "bar"
+    assert dists[0].metadata["Name"] == "bar"

--- a/tests/test_pipdeptree.py
+++ b/tests/test_pipdeptree.py
@@ -28,7 +28,7 @@ def test_console_script() -> None:
     entry_points = dist.entry_points
     assert len(entry_points) == 1
 
-    if (sys.version_info >= (3, 11)): # pragma: >=3.11
+    if sys.version_info >= (3, 11):  # pragma: >=3.11
         entry_point = entry_points["pipdeptree"]
     else:
         entry_point = entry_points[0]

--- a/tests/test_pipdeptree.py
+++ b/tests/test_pipdeptree.py
@@ -27,7 +27,11 @@ def test_console_script() -> None:
 
     entry_points = dist.entry_points
     assert len(entry_points) == 1
-    entry_point = entry_points[0]
+
+    if (sys.version_info >= (3, 11)): # pragma: >=3.11
+        entry_point = entry_points["pipdeptree"]
+    else:
+        entry_point = entry_points[0]
 
     try:
         pipdeptree = entry_point.load()

--- a/tests/test_pipdeptree.py
+++ b/tests/test_pipdeptree.py
@@ -1,16 +1,17 @@
 from __future__ import annotations
 
 import sys
+from importlib import metadata
 from subprocess import CompletedProcess, check_call  # noqa: S404
 from typing import TYPE_CHECKING
+
+import pytest
 
 from pipdeptree.__main__ import main
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-    import pytest
-    from pytest_console_scripts import ScriptRunner
     from pytest_mock import MockFixture
 
 
@@ -18,9 +19,23 @@ def test_main() -> None:
     check_call([sys.executable, "-m", "pipdeptree", "--help"])
 
 
-def test_console(script_runner: ScriptRunner) -> None:
-    result = script_runner.run(["pipdeptree", "--help"])
-    assert result.success
+def test_console_script() -> None:
+    try:
+        dist = metadata.distribution("pipdeptree")
+    except Exception as e:  # noqa: BLE001 # pragma: no cover
+        pytest.fail(f"Unexpected error when retrieving pipdeptree metadata: {e}")
+
+    entry_points = dist.entry_points
+    assert len(entry_points) == 1
+    entry_point = entry_points[0]
+
+    try:
+        pipdeptree = entry_point.load()
+    except Exception as e:  # noqa: BLE001 # pragma: no cover
+        pytest.fail(f"Unexpected error: {e}")
+
+    with pytest.raises(SystemExit, match="0"):
+        pipdeptree(["", "--help"])
 
 
 def test_main_log_resolved(tmp_path: Path, mocker: MockFixture, capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
Resolves #474.

Due to us using the stdlib `importlib.metadata` and `pytest-console-scripts` using the backport version for Python versions < 3.10, this has caused some problems when `importlib_metadata` upgrades to a version that makes changes which is incompatible with the stdlib version.

After analyzing this plugin and the stdlib version of `importlib.metadata`, I ultimately decided to remove this plugin in favor of using `Distribution.entry_points()` to get the console script.