### PR TITLE
Remove `wheel` package from tests due to virtualenv v20.31.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ optional-dependencies.test = [
   "pytest>=8.3.2",
   "pytest-cov>=5",
   "pytest-mock>=3.14",
-  "virtualenv>=20.26.4,<21",
+  "virtualenv>=20.31.1,<21",
 ]
 urls.Changelog = "https://github.com/tox-dev/pipdeptree/releases"
 urls.Documentation = "https://github.com/tox-dev/pipdeptree/blob/main/README.md#pipdeptree"

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -35,9 +35,9 @@ def test_local_only(tmp_path: Path, mocker: MockerFixture, capfd: pytest.Capture
     main()
     out, _ = capfd.readouterr()
     found = {i.split("==")[0] for i in out.splitlines()}
-    expected = {"foo", "pip", "setuptools", "wheel"}
+    expected = {"foo", "pip", "setuptools"}
     if sys.version_info >= (3, 12):
-        expected -= {"setuptools", "wheel"}  # pragma: no cover
+        expected -= {"setuptools"}  # pragma: no cover
 
     assert found == expected
 

--- a/tests/test_non_host.py
+++ b/tests/test_non_host.py
@@ -20,15 +20,15 @@ if TYPE_CHECKING:
 def expected_venv_pkgs() -> frozenset[str]:
     implementation = python_implementation()
     if implementation == "CPython":  # pragma: cpython cover
-        expected = {"pip", "setuptools", "wheel"}
+        expected = {"pip", "setuptools"}
     elif implementation == "PyPy":  # pragma: pypy cover
-        expected = {"cffi", "greenlet", "pip", "hpy", "readline", "setuptools", "wheel"}
+        expected = {"cffi", "greenlet", "pip", "hpy", "readline", "setuptools"}
         if sys.version_info >= (3, 10):  # pragma: >=3.10 cover
             expected -= {"readline"}
     else:  # pragma: no cover
         raise ValueError(implementation)
     if sys.version_info >= (3, 12):  # pragma: >=3.12 cover
-        expected -= {"setuptools", "wheel"}
+        expected -= {"setuptools"}
 
     return frozenset(expected)
 
@@ -73,9 +73,9 @@ def test_custom_interpreter_with_local_only(
     main()
     out, _ = capfd.readouterr()
     found = {i.split("==")[0] for i in out.splitlines()}
-    expected = {"pip", "setuptools", "wheel"}
+    expected = {"pip", "setuptools"}
     if sys.version_info >= (3, 12):  # pragma: >=3.12 cover
-        expected -= {"setuptools", "wheel"}
+        expected -= {"setuptools"}
     assert expected == found, out
 
 


### PR DESCRIPTION
virtualenv, as of v20.31.0, is no longer bundled with wheels. This change reflects this in tests that rely on knowing what packages are provided by default in a virtualenv environment.