### PR TITLE
Allow --exclude to be used with --include

### DIFF
--- a/src/pipdeptree/_cli.py
+++ b/src/pipdeptree/_cli.py
@@ -170,8 +170,6 @@ def get_options(args: Sequence[str] | None) -> Options:
     parser = build_parser()
     parsed_args = parser.parse_args(args)
 
-    if parsed_args.exclude and (parsed_args.all or parsed_args.packages):
-        return parser.error("cannot use --exclude with --packages or --all")
     if parsed_args.exclude_dependencies and not parsed_args.exclude:
         return parser.error("must use --exclude-dependencies with --exclude")
     if parsed_args.license and parsed_args.freeze:

--- a/tests/_models/test_dag.py
+++ b/tests/_models/test_dag.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Callable
 import pytest
 
 from pipdeptree._models import DistPackage, PackageDAG, ReqPackage, ReversedPackageDAG
+from pipdeptree._models.dag import IncludeExcludeOverlapError, IncludePatternNotFoundError
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -63,13 +64,18 @@ def test_package_dag_filter_fnmatch_exclude_a(t_fnmatch: PackageDAG) -> None:
     assert graph == {"b-a": ["b-b"], "b-b": []}
 
 
-def test_package_dag_filter_include_exclude_both_used(t_fnmatch: PackageDAG) -> None:
-    with pytest.raises(AssertionError):
+def test_package_dag_filter_include_exclude_normal(t_fnmatch: PackageDAG) -> None:
+    graph = dag_to_dict(t_fnmatch.filter_nodes(["a-*"], {"a-a"}))
+    assert graph == {"a-b": ["a-c"]}
+
+
+def test_package_dag_filter_include_exclude_overlap(t_fnmatch: PackageDAG) -> None:
+    with pytest.raises(IncludeExcludeOverlapError):
         t_fnmatch.filter_nodes(["a-a", "a-b"], {"a-b"})
 
 
-def test_package_dag_filter_nonexistent_packages(t_fnmatch: PackageDAG) -> None:
-    with pytest.raises(ValueError, match="No packages matched using the following patterns: x, y, z"):
+def test_package_dag_filter_include_nonexistent_packages(t_fnmatch: PackageDAG) -> None:
+    with pytest.raises(IncludePatternNotFoundError, match="No packages matched using the following patterns: x, y, z"):
         t_fnmatch.filter_nodes(["x", "y", "z"], None)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -81,28 +81,6 @@ def test_parser_depth(should_be_error: bool, depth_arg: list[str], expected_valu
         assert args.depth == expected_value
 
 
-@pytest.mark.parametrize(
-    "args",
-    [
-        pytest.param(["--exclude", "py", "--all"], id="exclude-all"),
-        pytest.param(["-e", "py", "--packages", "py2"], id="exclude-packages"),
-        pytest.param(["-e", "py", "-p", "py2", "-a"], id="exclude-packages-all"),
-    ],
-)
-def test_parser_get_options_exclude_combine_not_supported(args: list[str], capsys: pytest.CaptureFixture[str]) -> None:
-    with pytest.raises(SystemExit, match="2"):
-        get_options(args)
-
-    out, err = capsys.readouterr()
-    assert not out
-    assert "cannot use --exclude with --packages or --all" in err
-
-
-def test_parser_get_options_exclude_only() -> None:
-    parsed_args = get_options(["--exclude", "py"])
-    assert parsed_args.exclude == "py"
-
-
 def test_parser_get_options_license_and_freeze_together_not_supported(capsys: pytest.CaptureFixture[str]) -> None:
     with pytest.raises(SystemExit, match="2"):
         get_options(["--license", "--freeze"])

--- a/tests/test_pipdeptree.py
+++ b/tests/test_pipdeptree.py
@@ -58,3 +58,13 @@ def test_main_log_resolved(tmp_path: Path, mocker: MockFixture, capsys: pytest.C
 
     captured = capsys.readouterr()
     assert captured.err.startswith(f"(resolved python: {tmp_path!s}")
+
+
+def test_main_include_and_exclude_overlap(mocker: MockFixture, capsys: pytest.CaptureFixture[str]) -> None:
+    cmd = ["", "--packages", "a,b,c", "--exclude", "a"]
+    mocker.patch("pipdeptree.__main__.sys.argv", cmd)
+
+    main()
+
+    captured = capsys.readouterr()
+    assert "Cannot have --packages and --exclude contain the same entries" in captured.err


### PR DESCRIPTION
#273 removed the ability to use --include and --exclude together. I now disagree with this change since not only was that a (accidental) breaking change but I now see it makes sense to allow them to be used together (e.g using pattern matching: `pidpeptree -p pytest* -e pytest-mock`).

This change allows them to be used together and adds a few tests to ensure that they continue to do so.