### PR TITLE
Have render functions call print() themselves rather than the caller

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,8 +78,6 @@ lint.select = [
 ]
 lint.ignore = [
   "A005",   # Don't care about shadowing builtin modules
-  "ANN101", # No type annotation for self
-  "ANN102", # Missing type annotation for `cls` in classmethod
   "ANN401", # Dynamically typed expressions (typing.Any) are disallowed in
   "COM812", # Conflict with formatter
   "CPY",    # No copyright statements

--- a/src/pipdeptree/_render/__init__.py
+++ b/src/pipdeptree/_render/__init__.py
@@ -16,11 +16,11 @@ if TYPE_CHECKING:
 
 def render(options: Options, tree: PackageDAG) -> None:
     if options.json:
-        print(render_json(tree))  # noqa: T201
+        render_json(tree)
     elif options.json_tree:
-        print(render_json_tree(tree))  # noqa: T201
+        render_json_tree(tree)
     elif options.mermaid:
-        print(render_mermaid(tree))  # noqa: T201
+        render_mermaid(tree)
     elif options.output_format:
         render_graphviz(tree, output_format=options.output_format, reverse=options.reverse)
     elif options.freeze:

--- a/src/pipdeptree/_render/json.py
+++ b/src/pipdeptree/_render/json.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     from pipdeptree._models import PackageDAG
 
 
-def render_json(tree: PackageDAG) -> str:
+def render_json(tree: PackageDAG) -> None:
     """
     Convert the tree into a flat json representation.
 
@@ -20,10 +20,11 @@ def render_json(tree: PackageDAG) -> str:
 
     """
     tree = tree.sort()
-    return json.dumps(
+    output = json.dumps(
         [{"package": k.as_dict(), "dependencies": [v.as_dict() for v in vs]} for k, vs in tree.items()],
         indent=4,
     )
+    print(output)  # noqa: T201
 
 
 __all__ = [

--- a/src/pipdeptree/_render/json_tree.py
+++ b/src/pipdeptree/_render/json_tree.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from pipdeptree._models import DistPackage, PackageDAG
 
 
-def render_json_tree(tree: PackageDAG) -> str:
+def render_json_tree(tree: PackageDAG) -> None:
     """
     Convert the tree into a nested json representation.
 
@@ -52,7 +52,7 @@ def render_json_tree(tree: PackageDAG) -> str:
 
         return d
 
-    return json.dumps([aux(p) for p in nodes], indent=4)
+    print(json.dumps([aux(p) for p in nodes], indent=4))  # noqa: T201
 
 
 __all__ = [

--- a/src/pipdeptree/_render/mermaid.py
+++ b/src/pipdeptree/_render/mermaid.py
@@ -34,7 +34,7 @@ _RESERVED_IDS: Final[frozenset[str]] = frozenset(
 )
 
 
-def render_mermaid(tree: PackageDAG) -> str:  # noqa: C901
+def render_mermaid(tree: PackageDAG) -> None:  # noqa: C901
     """
     Produce a Mermaid flowchart from the dependency graph.
 
@@ -105,7 +105,7 @@ def render_mermaid(tree: PackageDAG) -> str:  # noqa: C901
         *sorted(nodes),
         *sorted(edges),
     ]
-    return "".join(f"{'    ' if i else ''}{line}\n" for i, line in enumerate(lines))
+    print("".join(f"{'    ' if i else ''}{line}\n" for i, line in enumerate(lines)))  # noqa: T201
 
 
 __all__ = [

--- a/tests/render/test_json.py
+++ b/tests/render/test_json.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from textwrap import dedent
+from typing import TYPE_CHECKING, Callable
+
+from pipdeptree._models.dag import PackageDAG
+from pipdeptree._render.json import render_json
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from unittest.mock import Mock
+
+    import pytest
+
+    from tests.our_types import MockGraph
+
+
+def test_render_json(mock_pkgs: Callable[[MockGraph], Iterator[Mock]], capsys: pytest.CaptureFixture[str]) -> None:
+    graph: MockGraph = {
+        ("a", "1.2.3"): [("b", [(">=", "4.0.0")])],
+        ("b", "4.5.6"): [],
+    }
+    expected_output = dedent("""\
+     [
+         {
+             "package": {
+                 "key": "a",
+                 "package_name": "a",
+                 "installed_version": "1.2.3"
+             },
+             "dependencies": [
+                 {
+                     "key": "b",
+                     "package_name": "b",
+                     "installed_version": "4.5.6",
+                     "required_version": ">=4.0.0"
+                 }
+             ]
+         },
+         {
+             "package": {
+                 "key": "b",
+                 "package_name": "b",
+                 "installed_version": "4.5.6"
+             },
+             "dependencies": []
+         }
+     ]
+    """)
+    package_dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
+
+    render_json(package_dag)
+
+    output = capsys.readouterr()
+    assert output.out == expected_output

--- a/tests/render/test_json_tree.py
+++ b/tests/render/test_json_tree.py
@@ -25,11 +25,15 @@ def test_json_tree_given_req_package_with_version_spec(
     mock_pkgs: Callable[[MockGraph], Iterator[Mock]],
     version_spec_tuple: tuple[str, str],
     expected_version_spec: str,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     graph: MockGraph = {
         ("a", "1.2.3"): [("b", [version_spec_tuple])],
         ("b", "2.2.0"): [],
     }
     package_dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
-    json_tree_str = render_json_tree(package_dag)
-    assert json_tree_str.find(expected_version_spec) != -1
+
+    render_json_tree(package_dag)
+
+    captured = capsys.readouterr()
+    assert captured.out.find(expected_version_spec) != -1


### PR DESCRIPTION
It makes more sense to call print() inside the render functions because that’s their purpose. Some were already doing this anyways.

This change also adds a coverage test for the --json render.