### PR TITLE
Replace large EnumAction class with simpler logic

### DIFF
--- a/src/pipdeptree/__main__.py
+++ b/src/pipdeptree/__main__.py
@@ -25,9 +25,9 @@ def main(args: Sequence[str] | None = None) -> int | None:
     # Warnings are only enabled when using text output.
     is_text_output = not any([options.json, options.json_tree, options.output_format])
     if not is_text_output:
-        options.warn = WarningType.SILENCE
+        options.warn = "silence"
     warning_printer = get_warning_printer()
-    warning_printer.warning_type = options.warn
+    warning_printer.warning_type = WarningType.from_str(options.warn)
 
     if options.python == "auto":
         resolved_path = detect_active_interpreter()

--- a/src/pipdeptree/_warning.py
+++ b/src/pipdeptree/_warning.py
@@ -1,10 +1,25 @@
 from __future__ import annotations
 
 import sys
-from enum import Enum
+from enum import StrEnum, auto
 from typing import Callable
 
-WarningType = Enum("WarningType", ["SILENCE", "SUPPRESS", "FAIL"])
+
+class WarningType(StrEnum):
+    FAIL = auto()
+    SILENCE = auto()
+    SUPPRESS = auto()
+
+    @classmethod
+    def from_str(cls, string: str) -> WarningType:
+        if string == "silence":
+            return WarningType.SILENCE
+        if string == "suppress":
+            return WarningType.SUPPRESS
+        if string == "fail":
+            return WarningType.FAIL
+        msg = "Unknown WarningType string value provided"
+        raise ValueError(msg)
 
 
 class WarningPrinter:

--- a/tests/test_warning.py
+++ b/tests/test_warning.py
@@ -1,11 +1,26 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import pytest
 
 from pipdeptree._warning import WarningPrinter, WarningType
 
-if TYPE_CHECKING:
-    import pytest
+
+@pytest.mark.parametrize(
+    ("warning", "expected_type"),
+    [
+        ("silence", WarningType.SILENCE),
+        ("suppress", WarningType.SUPPRESS),
+        ("fail", WarningType.FAIL),
+    ],
+)
+def test_warning_type_from_str_normal(warning: str, expected_type: WarningType) -> None:
+    warning_type = WarningType.from_str(warning)
+    assert expected_type == warning_type
+
+
+def test_warning_type_from_str_invalid_warning() -> None:
+    with pytest.raises(ValueError, match="Unknown WarningType string value provided"):
+        WarningType.from_str("non-existent-warning-type")
 
 
 def test_warning_printer_print_single_line(capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
These changes make setting `--warn` easier to reason about without the need for the more complex `EnumAction` class.

The only downside is the duplication of the warning type strings in the CLI module, but I believe this is fine as I do not see a reason for adding more warning types anytime soon.