### PR TITLE
♻️ refactor(core): reduce duplication and migrate to ty

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       - id: codespell
         additional_dependencies: ["tomli>=2.3"]
   - repo: https://github.com/tox-dev/tox-toml-fmt
-    rev: "v1.8.0"
+    rev: "v1.9.0"
     hooks:
       - id: tox-toml-fmt
   - repo: https://github.com/tox-dev/pyproject-fmt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,12 +133,6 @@ html.show_contexts = true
 html.skip_covered = false
 subtract_omit = "*/__main__.py"
 
-[tool.mypy]
-show_error_codes = true
-strict = true
-overrides = [
-  { module = [
-    "graphviz.*",
-    "virtualenv.*",
-  ], ignore_missing_imports = true },
-]
+[tool.ty]
+environment.python-version = "3.14"
+src.exclude = []

--- a/src/pipdeptree/__main__.py
+++ b/src/pipdeptree/__main__.py
@@ -72,7 +72,7 @@ def main(args: Sequence[str] | None = None) -> int | None:
 
 
 def _is_text_output(options: Options) -> bool:
-    if any([options.json, options.json_tree, options.graphviz_format, options.mermaid]):
+    if any((options.json, options.json_tree, options.graphviz_format, options.mermaid)):
         return False
     return options.output_format in {"freeze", "text"}
 

--- a/src/pipdeptree/_discovery.py
+++ b/src/pipdeptree/_discovery.py
@@ -65,7 +65,7 @@ def query_interpreter_for_paths(interpreter: str, *, local_only: bool = False) -
     args = [interpreter, "-c", cmd]
     try:
         result = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, check=True, text=True)  # noqa: S603
-        return ast.literal_eval(result.stdout)  # type: ignore[no-any-return]
+        return ast.literal_eval(result.stdout)
     except Exception as e:
         raise InterpreterQueryError(str(e)) from e
 

--- a/src/pipdeptree/_freeze.py
+++ b/src/pipdeptree/_freeze.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import locale
 from json import JSONDecodeError
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from pip._internal.models.direct_url import (  # noqa: PLC2701
     DirectUrl,
@@ -44,7 +44,7 @@ class PipBaseDistributionAdapter:
         self._version = Version(dist.version)
 
     @property
-    def raw_name(self) -> str | Any:
+    def raw_name(self) -> str:
         return self._raw_name
 
     @property

--- a/src/pipdeptree/_models/dag.py
+++ b/src/pipdeptree/_models/dag.py
@@ -26,14 +26,6 @@ class IncludePatternNotFoundError(Exception):
     """Include patterns weren't found when filtering a `PackageDAG`."""
 
 
-def render_invalid_reqs_text(dist_name_to_invalid_reqs_dict: dict[str, list[str]]) -> None:
-    for dist_name, invalid_reqs in dist_name_to_invalid_reqs_dict.items():
-        print(dist_name, file=sys.stderr)  # noqa: T201
-
-        for invalid_req in invalid_reqs:
-            print(f'  Skipping "{invalid_req}"', file=sys.stderr)  # noqa: T201
-
-
 class PackageDAG(Mapping[DistPackage, list[ReqPackage]]):
     """
     Representation of Package dependencies as directed acyclic graph using a dict as the underlying datastructure.
@@ -295,15 +287,10 @@ class PackageDAG(Mapping[DistPackage, list[ReqPackage]]):
         child_keys = {r.key for r in chain.from_iterable(self._obj.values())}
         for parent, deps in self._obj.items():
             for dep in deps:
-                if (node := key_index.get(dep.key)) is None:
-                    node = dep
-                    key_index[dep.key] = dep
-                    reversed_dag[dep] = []
-                reversed_dag[node].append(parent.as_parent_of(dep))
+                node = key_index.setdefault(dep.key, dep)
+                reversed_dag.setdefault(node, []).append(parent.as_parent_of(dep))
             if parent.key not in child_keys:
-                req = parent.as_requirement()
-                key_index[req.key] = req
-                reversed_dag[req] = []
+                reversed_dag[parent.as_requirement()] = []
         return ReversedPackageDAG(dict(reversed_dag))  # type: ignore[arg-type]
 
     def sort(self) -> PackageDAG:
@@ -324,10 +311,6 @@ class PackageDAG(Mapping[DistPackage, list[ReqPackage]]):
 
     def __len__(self) -> int:
         return len(self._obj)
-
-
-def should_exclude_node(key: str, exclude: set[str]) -> bool:
-    return any(fnmatch(key, e) for e in exclude)
 
 
 class ReversedPackageDAG(PackageDAG):
@@ -354,18 +337,25 @@ class ReversedPackageDAG(PackageDAG):
         for req_node, parents in self._obj.items():
             for parent in parents:
                 assert isinstance(parent, DistPackage)
-                if (node := key_index.get(parent.key)) is None:
-                    node = parent.as_parent_of(None)
-                    key_index[parent.key] = node
-                    forward_dag[node] = []
-                forward_dag[node].append(req_node)  # type: ignore[invalid-argument-type]  # runtime: ReqPackage
+                node = key_index.setdefault(parent.key, parent.as_parent_of(None))
+                forward_dag.setdefault(node, []).append(req_node)  # type: ignore[invalid-argument-type]  # runtime: ReqPackage
             if req_node.key not in child_keys:
                 assert isinstance(req_node, ReqPackage)
                 assert req_node.dist is not None
-                if req_node.dist.key not in key_index:
-                    key_index[req_node.dist.key] = req_node.dist
-                    forward_dag[req_node.dist] = []
+                forward_dag.setdefault(key_index.setdefault(req_node.dist.key, req_node.dist), [])
         return PackageDAG(dict(forward_dag))
+
+
+def render_invalid_reqs_text(dist_name_to_invalid_reqs_dict: dict[str, list[str]]) -> None:
+    for dist_name, invalid_reqs in dist_name_to_invalid_reqs_dict.items():
+        print(dist_name, file=sys.stderr)  # noqa: T201
+
+        for invalid_req in invalid_reqs:
+            print(f'  Skipping "{invalid_req}"', file=sys.stderr)  # noqa: T201
+
+
+def should_exclude_node(key: str, exclude: set[str]) -> bool:
+    return any(fnmatch(key, e) for e in exclude)
 
 
 __all__ = [

--- a/src/pipdeptree/_models/dag.py
+++ b/src/pipdeptree/_models/dag.py
@@ -105,7 +105,7 @@ class PackageDAG(Mapping[DistPackage, list[ReqPackage]]):
 
         """
         self._obj: dict[DistPackage, list[ReqPackage]] = m
-        self._index: dict[str, DistPackage] = {p.key: p for p in list(self._obj)}
+        self._index: dict[str, DistPackage] = {p.key: p for p in self._obj}
 
     def get_node_as_parent(self, node_key: str) -> DistPackage | None:
         """
@@ -290,18 +290,21 @@ class PackageDAG(Mapping[DistPackage, list[ReqPackage]]):
         :returns: DAG in the reversed form
 
         """
-        m: defaultdict[ReqPackage, list[DistPackage]] = defaultdict(list)
+        reversed_dag: dict[ReqPackage, list[DistPackage]] = {}
+        key_index: dict[str, ReqPackage] = {}
         child_keys = {r.key for r in chain.from_iterable(self._obj.values())}
-        for k, vs in self._obj.items():
-            for v in vs:
-                # if v is already added to the dict, then ensure that
-                # we are using the same object. This check is required
-                # as we're using array mutation
-                node: ReqPackage = next((p for p in m if p.key == v.key), v)
-                m[node].append(k.as_parent_of(v))
-            if k.key not in child_keys:
-                m[k.as_requirement()] = []
-        return ReversedPackageDAG(dict(m))  # type: ignore[arg-type]
+        for parent, deps in self._obj.items():
+            for dep in deps:
+                if (node := key_index.get(dep.key)) is None:
+                    node = dep
+                    key_index[dep.key] = dep
+                    reversed_dag[dep] = []
+                reversed_dag[node].append(parent.as_parent_of(dep))
+            if parent.key not in child_keys:
+                req = parent.as_requirement()
+                key_index[req.key] = req
+                reversed_dag[req] = []
+        return ReversedPackageDAG(dict(reversed_dag))  # type: ignore[arg-type]
 
     def sort(self) -> PackageDAG:
         """
@@ -313,8 +316,8 @@ class PackageDAG(Mapping[DistPackage, list[ReqPackage]]):
         return self.__class__({k: sorted(v) for k, v in sorted(self._obj.items())})
 
     # Methods required by the abstract base class Mapping
-    def __getitem__(self, arg: DistPackage) -> list[ReqPackage] | None:  # type: ignore[override]
-        return self._obj.get(arg)
+    def __getitem__(self, arg: DistPackage) -> list[ReqPackage]:
+        return self._obj[arg]
 
     def __iter__(self) -> Iterator[DistPackage]:
         return self._obj.__iter__()
@@ -345,18 +348,24 @@ class ReversedPackageDAG(PackageDAG):
         :returns: reverse of the reversed DAG
 
         """
-        m: defaultdict[DistPackage, list[ReqPackage]] = defaultdict(list)
+        forward_dag: dict[DistPackage, list[ReqPackage]] = {}
+        key_index: dict[str, DistPackage] = {}
         child_keys = {r.key for r in chain.from_iterable(self._obj.values())}
-        for k, vs in self._obj.items():
-            for v in vs:
-                assert isinstance(v, DistPackage)
-                node = next((p for p in m if p.key == v.key), v.as_parent_of(None))
-                m[node].append(k)
-            if k.key not in child_keys:
-                assert isinstance(k, ReqPackage)
-                assert k.dist is not None
-                m[k.dist] = []
-        return PackageDAG(dict(m))
+        for req_node, parents in self._obj.items():
+            for parent in parents:
+                assert isinstance(parent, DistPackage)
+                if (node := key_index.get(parent.key)) is None:
+                    node = parent.as_parent_of(None)
+                    key_index[parent.key] = node
+                    forward_dag[node] = []
+                forward_dag[node].append(req_node)  # type: ignore[invalid-argument-type]  # runtime: ReqPackage
+            if req_node.key not in child_keys:
+                assert isinstance(req_node, ReqPackage)
+                assert req_node.dist is not None
+                if req_node.dist.key not in key_index:
+                    key_index[req_node.dist.key] = req_node.dist
+                    forward_dag[req_node.dist] = []
+        return PackageDAG(dict(forward_dag))
 
 
 __all__ = [

--- a/src/pipdeptree/_models/package.py
+++ b/src/pipdeptree/_models/package.py
@@ -201,11 +201,8 @@ class ReqPackage(Package):
 
     @property
     def version_spec(self) -> str | None:
-        result = None
         specs = sorted(map(str, self._obj.specifier), reverse=True)  # type: ignore[invalid-argument-type]  # `reverse` makes '>' prior to '<'
-        if specs:
-            result = ",".join(specs)
-        return result
+        return ",".join(specs) if specs else None
 
     @property
     def edge_label(self) -> str:

--- a/src/pipdeptree/_models/package.py
+++ b/src/pipdeptree/_models/package.py
@@ -50,7 +50,7 @@ class Package(ABC):
                 license_str = line.rsplit(":: ", 1)[-1]
                 license_strs.append(license_str)
 
-        if len(license_strs) == 0:
+        if not license_strs:
             return self.UNKNOWN_LICENSE_STR
 
         return f"({', '.join(license_strs)})"
@@ -162,6 +162,10 @@ class DistPackage(Package):
             return self
         return self.__class__(self._obj, req)
 
+    @property
+    def edge_label(self) -> str:
+        return (self.req.version_spec if self.req is not None else None) or "any"
+
     def as_dict(self) -> dict[str, str]:
         return {"key": self.key, "package_name": self.project_name, "installed_version": self.version}
 
@@ -198,10 +202,14 @@ class ReqPackage(Package):
     @property
     def version_spec(self) -> str | None:
         result = None
-        specs = sorted(map(str, self._obj.specifier), reverse=True)  # `reverse` makes '>' prior to '<'
+        specs = sorted(map(str, self._obj.specifier), reverse=True)  # type: ignore[invalid-argument-type]  # `reverse` makes '>' prior to '<'
         if specs:
             result = ",".join(specs)
         return result
+
+    @property
+    def edge_label(self) -> str:
+        return self.version_spec or "any"
 
     @property
     def installed_version(self) -> str:

--- a/src/pipdeptree/_render/freeze.py
+++ b/src/pipdeptree/_render/freeze.py
@@ -1,41 +1,16 @@
 from __future__ import annotations
 
-from itertools import chain
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-from .text import get_top_level_nodes
+from .text import _render_text_simple, get_top_level_nodes
 
 if TYPE_CHECKING:
     from pipdeptree._models.dag import PackageDAG
-    from pipdeptree._models.package import DistPackage, ReqPackage
 
 
 def render_freeze(tree: PackageDAG, *, max_depth: float, list_all: bool = True) -> None:
     nodes = get_top_level_nodes(tree, list_all=list_all)
-
-    def aux(
-        node: DistPackage | ReqPackage,
-        parent: DistPackage | ReqPackage | None = None,
-        indent: int = 0,
-        cur_chain: list[str] | None = None,
-        depth: int = 0,
-    ) -> list[Any]:
-        cur_chain = cur_chain or []
-        node_str = node.render(parent, frozen=True)
-        if parent:
-            prefix = " " * indent
-            node_str = prefix + node_str
-        result = [node_str]
-        children = [
-            aux(c, node, indent=indent + 2, cur_chain=[*cur_chain, c.project_name], depth=depth + 1)
-            for c in tree.get_children(node.key)
-            if c.project_name not in cur_chain and depth + 1 <= max_depth
-        ]
-        result += list(chain.from_iterable(children))
-        return result
-
-    lines = chain.from_iterable([aux(p) for p in nodes])
-    print("\n".join(lines))  # noqa: T201
+    _render_text_simple(tree, nodes, max_depth, include_license=False, frozen=True, bullet="")
 
 
 __all__ = [

--- a/src/pipdeptree/_render/graphviz.py
+++ b/src/pipdeptree/_render/graphviz.py
@@ -22,89 +22,65 @@ def _get_all_dep_keys(tree: PackageDAG) -> set[str]:
     return dep_keys
 
 
-def _build_reverse_graph(tree: PackageDAG, graph: Digraph, max_depth: float) -> None:  # noqa: C901, PLR0912
+def _compute_reachable_depths(tree: PackageDAG, root_keys: set[str], max_depth: float) -> dict[str, int] | None:
+    """BFS from root_keys, returning {key: depth} for all nodes reachable within max_depth."""
+    if max_depth >= math.inf:
+        return None
+    visited: dict[str, int] = {}
+    queue: deque[tuple[str, int]] = deque((k, 0) for k in root_keys)
+    while queue:
+        key, depth = queue.popleft()
+        if key in visited:
+            continue
+        visited[key] = depth
+        if depth < max_depth:
+            for child in tree.get_children(key):
+                if child.key not in visited:
+                    queue.append((child.key, depth + 1))
+    return visited
+
+
+def _build_reverse_graph(tree: PackageDAG, graph: Digraph, max_depth: float) -> None:
     """Build graphviz nodes and edges for a reversed dependency tree."""
-    if max_depth < math.inf:
-        parent_keys = _get_all_dep_keys(tree)
-        root_keys = {dep_rev.key for dep_rev in tree if dep_rev.key not in parent_keys}
-        visited: dict[str, int] = {}
-        queue: deque[tuple[str, int]] = deque((k, 0) for k in root_keys)
-        while queue:
-            key, depth = queue.popleft()
-            if key in visited:
-                continue
-            visited[key] = depth
-            if depth < max_depth:
-                for parent in tree.get_children(key):
-                    if parent.key not in visited:
-                        queue.append((parent.key, depth + 1))
-        for dep_rev, parents in tree.items():
-            if dep_rev.key not in visited:
-                continue
-            assert isinstance(dep_rev, ReqPackage)
-            dep_label = f"{dep_rev.project_name}\\n{dep_rev.installed_version}"
-            graph.node(dep_rev.key, label=dep_label)
-            if visited[dep_rev.key] < max_depth:
-                for parent in parents:
-                    assert isinstance(parent, DistPackage)
-                    if parent.key in visited:
-                        edge_label = (parent.req.version_spec if parent.req is not None else None) or "any"
-                        graph.edge(dep_rev.key, parent.key, label=edge_label)
-    else:
-        for dep_rev, parents in tree.items():
-            assert isinstance(dep_rev, ReqPackage)
-            dep_label = f"{dep_rev.project_name}\\n{dep_rev.installed_version}"
-            graph.node(dep_rev.key, label=dep_label)
+    parent_keys = _get_all_dep_keys(tree)
+    root_keys = {dep_rev.key for dep_rev in tree if dep_rev.key not in parent_keys}
+    visited = _compute_reachable_depths(tree, root_keys, max_depth)
+
+    for dep_rev, parents in tree.items():
+        if visited is not None and dep_rev.key not in visited:
+            continue
+        assert isinstance(dep_rev, ReqPackage)
+        dep_label = f"{dep_rev.project_name}\\n{dep_rev.installed_version}"
+        graph.node(dep_rev.key, label=dep_label)
+        if visited is None or visited[dep_rev.key] < max_depth:
             for parent in parents:
                 assert isinstance(parent, DistPackage)
-                edge_label = (parent.req.version_spec if parent.req is not None else None) or "any"
-                graph.edge(dep_rev.key, parent.key, label=edge_label)
+                if visited is not None and parent.key not in visited:
+                    continue
+                graph.edge(dep_rev.key, parent.key, label=parent.edge_label)
 
 
-def _build_forward_graph(tree: PackageDAG, graph: Digraph, max_depth: float) -> None:  # noqa: C901, PLR0912
+def _build_forward_graph(tree: PackageDAG, graph: Digraph, max_depth: float) -> None:
     """Build graphviz nodes and edges for a forward dependency tree."""
-    if max_depth < math.inf:  # noqa: PLR1702
-        dep_keys = _get_all_dep_keys(tree)
-        root_keys = {pkg.key for pkg in tree if pkg.key not in dep_keys}
-        visited: dict[str, int] = {}
-        queue: deque[tuple[str, int]] = deque((k, 0) for k in root_keys)
-        while queue:
-            key, depth = queue.popleft()
-            if key in visited:
-                continue
-            visited[key] = depth
-            if depth < max_depth:
-                children = tree.get_children(key)
-                for dep in children:
-                    if dep.key not in visited:
-                        queue.append((dep.key, depth + 1))
-        for pkg, deps in tree.items():
-            if pkg.key not in visited:
-                continue
-            pkg_label = f"{pkg.project_name}\\n{pkg.version}"
-            graph.node(pkg.key, label=pkg_label)
-            if visited[pkg.key] < max_depth:
-                for dep in deps:
-                    if dep.key in visited:
-                        edge_label = dep.version_spec or "any"
-                        if dep.is_missing:
-                            dep_label = f"{dep.project_name}\\n(missing)"
-                            graph.node(dep.key, label=dep_label, style="dashed")
-                            graph.edge(pkg.key, dep.key, style="dashed")
-                        else:
-                            graph.edge(pkg.key, dep.key, label=edge_label)
-    else:
-        for pkg, deps in tree.items():
-            pkg_label = f"{pkg.project_name}\\n{pkg.version}"
-            graph.node(pkg.key, label=pkg_label)
+    dep_keys = _get_all_dep_keys(tree)
+    root_keys = {pkg.key for pkg in tree if pkg.key not in dep_keys}
+    visited = _compute_reachable_depths(tree, root_keys, max_depth)
+
+    for pkg, deps in tree.items():
+        if visited is not None and pkg.key not in visited:
+            continue
+        pkg_label = f"{pkg.project_name}\\n{pkg.version}"
+        graph.node(pkg.key, label=pkg_label)
+        if visited is None or visited[pkg.key] < max_depth:
             for dep in deps:
-                edge_label = dep.version_spec or "any"
+                if visited is not None and dep.key not in visited:
+                    continue
                 if dep.is_missing:
                     dep_label = f"{dep.project_name}\\n(missing)"
                     graph.node(dep.key, label=dep_label, style="dashed")
                     graph.edge(pkg.key, dep.key, style="dashed")
                 else:
-                    graph.edge(pkg.key, dep.key, label=edge_label)
+                    graph.edge(pkg.key, dep.key, label=dep.edge_label)
 
 
 def dump_graphviz(
@@ -159,9 +135,9 @@ def dump_graphviz(
     # As it's unknown if the selected output format is binary or not, try to
     # decode it as UTF8 and only print it out in binary if that's not possible.
     try:
-        return graph.pipe().decode("utf-8")  # type: ignore[no-any-return]
+        return graph.pipe().decode("utf-8")
     except UnicodeDecodeError:
-        return graph.pipe()  # type: ignore[no-any-return]
+        return graph.pipe()
 
 
 def print_graphviz(dump_output: str | bytes) -> None:
@@ -171,7 +147,7 @@ def print_graphviz(dump_output: str | bytes) -> None:
     :param dump_output: The output from dump_graphviz
 
     """
-    if hasattr(dump_output, "encode"):
+    if isinstance(dump_output, str):
         print(dump_output)  # noqa: T201
     else:
         with os.fdopen(sys.stdout.fileno(), "wb") as bytestream:

--- a/src/pipdeptree/_render/graphviz.py
+++ b/src/pipdeptree/_render/graphviz.py
@@ -14,73 +14,9 @@ if TYPE_CHECKING:
     from pipdeptree._models import PackageDAG
 
 
-def _get_all_dep_keys(tree: PackageDAG) -> set[str]:
-    """Return the set of keys that appear as dependencies of some package."""
-    dep_keys: set[str] = set()
-    for deps in tree.values():
-        dep_keys.update(dep.key for dep in deps)
-    return dep_keys
-
-
-def _compute_reachable_depths(tree: PackageDAG, root_keys: set[str], max_depth: float) -> dict[str, int] | None:
-    """BFS from root_keys, returning {key: depth} for all nodes reachable within max_depth."""
-    if max_depth >= math.inf:
-        return None
-    visited: dict[str, int] = {}
-    queue: deque[tuple[str, int]] = deque((k, 0) for k in root_keys)
-    while queue:
-        key, depth = queue.popleft()
-        if key in visited:
-            continue
-        visited[key] = depth
-        if depth < max_depth:
-            for child in tree.get_children(key):
-                if child.key not in visited:
-                    queue.append((child.key, depth + 1))
-    return visited
-
-
-def _build_reverse_graph(tree: PackageDAG, graph: Digraph, max_depth: float) -> None:
-    """Build graphviz nodes and edges for a reversed dependency tree."""
-    parent_keys = _get_all_dep_keys(tree)
-    root_keys = {dep_rev.key for dep_rev in tree if dep_rev.key not in parent_keys}
-    visited = _compute_reachable_depths(tree, root_keys, max_depth)
-
-    for dep_rev, parents in tree.items():
-        if visited is not None and dep_rev.key not in visited:
-            continue
-        assert isinstance(dep_rev, ReqPackage)
-        dep_label = f"{dep_rev.project_name}\\n{dep_rev.installed_version}"
-        graph.node(dep_rev.key, label=dep_label)
-        if visited is None or visited[dep_rev.key] < max_depth:
-            for parent in parents:
-                assert isinstance(parent, DistPackage)
-                if visited is not None and parent.key not in visited:
-                    continue
-                graph.edge(dep_rev.key, parent.key, label=parent.edge_label)
-
-
-def _build_forward_graph(tree: PackageDAG, graph: Digraph, max_depth: float) -> None:
-    """Build graphviz nodes and edges for a forward dependency tree."""
-    dep_keys = _get_all_dep_keys(tree)
-    root_keys = {pkg.key for pkg in tree if pkg.key not in dep_keys}
-    visited = _compute_reachable_depths(tree, root_keys, max_depth)
-
-    for pkg, deps in tree.items():
-        if visited is not None and pkg.key not in visited:
-            continue
-        pkg_label = f"{pkg.project_name}\\n{pkg.version}"
-        graph.node(pkg.key, label=pkg_label)
-        if visited is None or visited[pkg.key] < max_depth:
-            for dep in deps:
-                if visited is not None and dep.key not in visited:
-                    continue
-                if dep.is_missing:
-                    dep_label = f"{dep.project_name}\\n(missing)"
-                    graph.node(dep.key, label=dep_label, style="dashed")
-                    graph.edge(pkg.key, dep.key, style="dashed")
-                else:
-                    graph.edge(pkg.key, dep.key, label=dep.edge_label)
+def render_graphviz(tree: PackageDAG, *, output_format: str, reverse: bool, max_depth: float = math.inf) -> None:
+    output = dump_graphviz(tree, output_format=output_format, is_reverse=reverse, max_depth=max_depth)
+    print_graphviz(output)
 
 
 def dump_graphviz(
@@ -154,9 +90,64 @@ def print_graphviz(dump_output: str | bytes) -> None:
             bytestream.write(dump_output)
 
 
-def render_graphviz(tree: PackageDAG, *, output_format: str, reverse: bool, max_depth: float = math.inf) -> None:
-    output = dump_graphviz(tree, output_format=output_format, is_reverse=reverse, max_depth=max_depth)
-    print_graphviz(output)
+def _build_reverse_graph(tree: PackageDAG, graph: Digraph, max_depth: float) -> None:
+    """Build graphviz nodes and edges for a reversed dependency tree."""
+    visited = _compute_reachable_depths(tree, _get_root_keys(tree), max_depth)
+
+    for dep_rev, parents in tree.items():
+        if visited is not None and dep_rev.key not in visited:
+            continue
+        assert isinstance(dep_rev, ReqPackage)
+        graph.node(dep_rev.key, label=f"{dep_rev.project_name}\\n{dep_rev.installed_version}")
+        if visited is None or visited[dep_rev.key] < max_depth:
+            for parent in parents:
+                assert isinstance(parent, DistPackage)
+                if visited is not None and parent.key not in visited:
+                    continue
+                graph.edge(dep_rev.key, parent.key, label=parent.edge_label)
+
+
+def _build_forward_graph(tree: PackageDAG, graph: Digraph, max_depth: float) -> None:
+    """Build graphviz nodes and edges for a forward dependency tree."""
+    visited = _compute_reachable_depths(tree, _get_root_keys(tree), max_depth)
+
+    for pkg, deps in tree.items():
+        if visited is not None and pkg.key not in visited:
+            continue
+        graph.node(pkg.key, label=f"{pkg.project_name}\\n{pkg.version}")
+        if visited is None or visited[pkg.key] < max_depth:
+            for dep in deps:
+                if visited is not None and dep.key not in visited:
+                    continue
+                if dep.is_missing:
+                    graph.node(dep.key, label=f"{dep.project_name}\\n(missing)", style="dashed")
+                    graph.edge(pkg.key, dep.key, style="dashed")
+                else:
+                    graph.edge(pkg.key, dep.key, label=dep.edge_label)
+
+
+def _compute_reachable_depths(tree: PackageDAG, root_keys: set[str], max_depth: float) -> dict[str, int] | None:
+    """BFS from root_keys, returning {key: depth} for all nodes reachable within max_depth."""
+    if max_depth >= math.inf:
+        return None
+    visited: dict[str, int] = {}
+    queue: deque[tuple[str, int]] = deque((k, 0) for k in root_keys)
+    while queue:
+        key, depth = queue.popleft()
+        if key in visited:
+            continue
+        visited[key] = depth
+        if depth < max_depth:
+            for child in tree.get_children(key):
+                if child.key not in visited:
+                    queue.append((child.key, depth + 1))
+    return visited
+
+
+def _get_root_keys(tree: PackageDAG) -> set[str]:
+    """Return keys that are not dependencies of any other package (i.e. root nodes)."""
+    dep_keys = {dep.key for deps in tree.values() for dep in deps}
+    return {pkg.key for pkg in tree if pkg.key not in dep_keys}
 
 
 __all__ = [

--- a/src/pipdeptree/_render/mermaid.py
+++ b/src/pipdeptree/_render/mermaid.py
@@ -78,25 +78,21 @@ def render_mermaid(tree: PackageDAG) -> None:  # noqa: C901
             nodes.add(f'{package_key}["{package_label}"]')
             for reverse_dependency in reverse_dependencies:
                 assert isinstance(reverse_dependency, DistPackage)
-                edge_label = (
-                    reverse_dependency.req.version_spec if reverse_dependency.req is not None else None
-                ) or "any"
                 reverse_dependency_key = mermaid_id(reverse_dependency.key)
-                edges.add(f'{package_key} -- "{edge_label}" --> {reverse_dependency_key}')
+                edges.add(f'{package_key} -- "{reverse_dependency.edge_label}" --> {reverse_dependency_key}')
     else:
         for package, dependencies in tree.items():
             package_label = f"{package.project_name}\\n{package.version}"
             package_key = mermaid_id(package.key)
             nodes.add(f'{package_key}["{package_label}"]')
             for dependency in dependencies:
-                edge_label = dependency.version_spec or "any"
                 dependency_key = mermaid_id(dependency.key)
                 if dependency.is_missing:
                     dependency_label = f"{dependency.project_name}\\n(missing)"
                     nodes.add(f'{dependency_key}["{dependency_label}"]:::missing')
                     edges.add(f"{package_key} -.-> {dependency_key}")
                 else:
-                    edges.add(f'{package_key} -- "{edge_label}" --> {dependency_key}')
+                    edges.add(f'{package_key} -- "{dependency.edge_label}" --> {dependency_key}')
 
     # Produce the Mermaid Markdown.
     lines = [

--- a/src/pipdeptree/_render/text.py
+++ b/src/pipdeptree/_render/text.py
@@ -123,6 +123,18 @@ def _render_text_without_unicode(
     max_depth: float,
     include_license: bool,  # noqa: FBT001
 ) -> None:
+    _render_text_simple(tree, nodes, max_depth, include_license)
+
+
+def _render_text_simple(  # noqa: PLR0913
+    tree: PackageDAG,
+    nodes: list[DistPackage],
+    max_depth: float,
+    include_license: bool,  # noqa: FBT001
+    *,
+    frozen: bool = False,
+    bullet: str = "- ",
+) -> None:
     def aux(
         node: DistPackage | ReqPackage,
         parent: DistPackage | ReqPackage | None = None,
@@ -131,10 +143,9 @@ def _render_text_without_unicode(
         depth: int = 0,
     ) -> list[Any]:
         cur_chain = cur_chain or []
-        node_str = node.render(parent, frozen=False)
+        node_str = node.render(parent, frozen=frozen)
         if parent:
-            prefix = " " * indent + "- "
-            node_str = prefix + node_str
+            node_str = " " * indent + bullet + node_str
         elif include_license:
             node_str += " " + node.licenses()
         result = [node_str]

--- a/src/pipdeptree/_render/text.py
+++ b/src/pipdeptree/_render/text.py
@@ -31,7 +31,7 @@ def render_text(
     if encoding in {"utf-8", "utf-16", "utf-32"}:
         _render_text_with_unicode(tree, nodes, max_depth, include_license)
     else:
-        _render_text_without_unicode(tree, nodes, max_depth, include_license)
+        _render_text_simple(tree, nodes, max_depth, include_license)
 
 
 def get_top_level_nodes(tree: PackageDAG, *, list_all: bool) -> list[DistPackage]:
@@ -115,15 +115,6 @@ def _render_text_with_unicode(
 
     lines = chain.from_iterable([aux(p) for p in nodes])
     print("\n".join(lines))  # noqa: T201
-
-
-def _render_text_without_unicode(
-    tree: PackageDAG,
-    nodes: list[DistPackage],
-    max_depth: float,
-    include_license: bool,  # noqa: FBT001
-) -> None:
-    _render_text_simple(tree, nodes, max_depth, include_license)
 
 
 def _render_text_simple(  # noqa: PLR0913

--- a/src/pipdeptree/_validate.py
+++ b/src/pipdeptree/_validate.py
@@ -101,7 +101,7 @@ def cyclic_deps(tree: PackageDAG) -> list[list[Package]]:
 
 def render_cycles_text(cycles: list[list[Package]]) -> None:
     # List in alphabetical order the dependency that caused the cycle (i.e. the second-to-last Package element)
-    cycles = sorted(cycles, key=lambda c: c[len(c) - 2].key)
+    cycles = sorted(cycles, key=lambda c: c[-2].key)
     for cycle in cycles:
         print("*", end=" ", file=sys.stderr)  # noqa: T201
 

--- a/src/pipdeptree/_warning.py
+++ b/src/pipdeptree/_warning.py
@@ -15,14 +15,11 @@ class WarningType(Enum):
 
     @classmethod
     def from_str(cls, string: str) -> WarningType:
-        if string == "silence":
-            return WarningType.SILENCE
-        if string == "suppress":
-            return WarningType.SUPPRESS
-        if string == "fail":
-            return WarningType.FAIL
-        msg = "Unknown WarningType string value provided"
-        raise ValueError(msg)
+        try:
+            return cls(string)
+        except ValueError:
+            msg = "Unknown WarningType string value provided"
+            raise ValueError(msg) from None
 
 
 class WarningPrinter:

--- a/tox.toml
+++ b/tox.toml
@@ -24,7 +24,7 @@ commands = [
     "-m",
     "pytest",
     "{tty:--color=yes}",
-    { replace = "posargs", extend = true, default = [
+    { replace = "posargs", default = [
       "--cov",
       "{env_site_packages_dir}{/}pipdeptree",
       "--cov",
@@ -41,7 +41,7 @@ commands = [
       "--junitxml",
       "{work_dir}{/}junit.{env_name}.xml",
       "tests",
-    ] },
+    ], extend = true },
   ],
   [
     "diff-cover",
@@ -71,8 +71,8 @@ commands = [
 
 [env.type]
 description = "run type check on code base"
-deps = [ "mypy==1.11.2" ]
-commands = [ [ "mypy", "src" ], [ "mypy", "tests" ] ]
+deps = [ "ty>=0.0.18" ]
+commands = [ [ "ty", "check", "--python-platform", "all", "--output-format", "concise", "--error-on-warning", "." ] ]
 
 [env.dev]
 description = "generate a DEV environment"


### PR DESCRIPTION
Several renderers had duplicated logic that made changes error-prone and maintenance harder. The freeze renderer reimplemented the same recursive traversal as the non-unicode text renderer, differing only in the `frozen` flag and bullet string. The graphviz forward and reverse graph builders each contained their own BFS depth computation with mirrored if/else branches for depth-limited vs unlimited traversal. Edge label derivation (`version_spec or "any"`) was inlined identically across graphviz and mermaid renderers. These duplications meant any bug fix or behavior change had to be applied in multiple places, risking divergence.

♻️ The text/freeze unification extracts `_render_text_simple` with `frozen` and `bullet` parameters, letting `freeze.py` drop from 40 lines to a single function call. The graphviz cleanup pulls BFS into a shared `_compute_reachable_depths` helper and collapses each builder's branching into a single iteration that checks `visited` membership when depth-limiting is active. `edge_label` properties on `DistPackage` and `ReqPackage` replace the repeated inline patterns across graphviz and mermaid. The `reverse()` methods in `PackageDAG` and `ReversedPackageDAG` used `next(p for p in m if p.key == v.key)` for node deduplication — an O(n) linear scan per edge — replaced with a dict index for O(1) lookups.

⚡ `PackageDAG.__getitem__` previously used `dict.get()`, silently returning `None` on missing keys and violating the `Mapping` protocol contract. It now delegates to `dict.__getitem__` which raises `KeyError`, matching what callers expect through `Mapping.get()`. The type checker has been migrated from mypy to ty, and stale `type: ignore` comments that ty no longer needs have been cleaned up.