### PR TITLE
✨ feat(render): add Rich library support for enhanced tree output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ dependencies = [
 optional-dependencies.graphviz = [
   "graphviz>=0.21",
 ]
+optional-dependencies.rich = [
+  "rich>=14.3.3",
+]
 optional-dependencies.test = [
   "covdefaults>=2.3",
   "diff-cover>=9.7.1",

--- a/src/pipdeptree/__main__.py
+++ b/src/pipdeptree/__main__.py
@@ -74,7 +74,7 @@ def main(args: Sequence[str] | None = None) -> int | None:
 def _is_text_output(options: Options) -> bool:
     if any((options.json, options.json_tree, options.graphviz_format, options.mermaid)):
         return False
-    return options.output_format in {"freeze", "text"}
+    return options.output_format in {"freeze", "rich", "text"}
 
 
 def _determine_return_code(warning_printer: WarningPrinter) -> int:

--- a/src/pipdeptree/_cli.py
+++ b/src/pipdeptree/_cli.py
@@ -34,7 +34,7 @@ class Options(Namespace):
 
 
 # NOTE: graphviz-* has been intentionally left out. Users of this var should handle it separately.
-ALLOWED_RENDER_FORMATS = ["freeze", "json", "json-tree", "mermaid", "text"]
+ALLOWED_RENDER_FORMATS = ["freeze", "json", "json-tree", "mermaid", "rich", "text"]
 
 
 class _Formatter(ArgumentDefaultsHelpFormatter):
@@ -122,14 +122,14 @@ def build_parser() -> ArgumentParser:
         metavar="E",
     )
     render.add_argument(
-        "-a", "--all", action="store_true", help="list all deps at top level (text and freeze render only)"
+        "-a", "--all", action="store_true", help="list all deps at top level (text, rich, and freeze render only)"
     )
     render.add_argument(
         "-d",
         "--depth",
         type=lambda x: int(x) if x.isdigit() and (int(x) >= 0) else parser.error("Depth must be a number that is >= 0"),
         default=float("inf"),
-        help="limit the depth of the tree (text, freeze, and graphviz render only)",
+        help="limit the depth of the tree (text, rich, freeze, and graphviz render only)",
         metavar="D",
     )
     render.add_argument(
@@ -145,7 +145,7 @@ def build_parser() -> ArgumentParser:
     render.add_argument(
         "--license",
         action="store_true",
-        help="list the license(s) of a package (text render only)",
+        help="list the license(s) of a package (text and rich render only)",
     )
 
     render_type = render.add_mutually_exclusive_group()

--- a/src/pipdeptree/_render/__init__.py
+++ b/src/pipdeptree/_render/__init__.py
@@ -7,6 +7,7 @@ from .graphviz import render_graphviz
 from .json import render_json
 from .json_tree import render_json_tree
 from .mermaid import render_mermaid
+from .rich_text import render_rich_text
 from .text import render_text
 
 if TYPE_CHECKING:
@@ -24,6 +25,8 @@ def render(options: Options, tree: PackageDAG) -> None:
         render_mermaid(tree)
     elif output_format == "freeze":
         render_freeze(tree, max_depth=options.depth, list_all=options.all)
+    elif output_format == "rich":
+        render_rich_text(tree, max_depth=options.depth, list_all=options.all, include_license=options.license)
     elif output_format.startswith("graphviz-"):
         render_graphviz(
             tree, output_format=output_format[len("graphviz-") :], reverse=options.reverse, max_depth=options.depth

--- a/src/pipdeptree/_render/rich_text.py
+++ b/src/pipdeptree/_render/rich_text.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import re
+import sys
+from typing import TYPE_CHECKING
+
+from pipdeptree._models.package import DistPackage, ReqPackage
+
+if TYPE_CHECKING:
+    from rich.tree import Tree
+
+    from pipdeptree._models import PackageDAG
+
+
+def render_rich_text(
+    tree: PackageDAG,
+    *,
+    max_depth: float,
+    list_all: bool = True,
+    include_license: bool = False,
+) -> None:
+    """
+    Print tree using Rich library for enhanced terminal output.
+
+    :param tree: the package tree
+    :param max_depth: the maximum depth of the dependency tree
+    :param list_all: whether to list all the pkgs at the root level or only those that are the sub-dependencies
+    :param include_license: provide license information
+    :returns: None
+    """
+    try:
+        from rich.console import Console  # noqa: PLC0415
+        from rich.tree import Tree  # noqa: PLC0415
+    except ImportError as exc:
+        print(  # noqa: T201
+            "rich is not available, but necessary for the output option. Please install it.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1) from exc
+
+    from pipdeptree._render.text import get_top_level_nodes  # noqa: PLC0415
+
+    nodes = get_top_level_nodes(tree, list_all=list_all)
+    console = Console()
+
+    for node in nodes:
+        root_label = _format_node(node, parent=None, include_license=include_license)
+        rich_tree = Tree(root_label, guide_style="bold bright_blue")
+        _build_tree(tree, node, rich_tree, max_depth=max_depth, depth=0, cur_chain=[])
+        console.print(rich_tree)
+
+
+def _build_tree(  # noqa: PLR0913
+    tree: PackageDAG,
+    node: DistPackage | ReqPackage,
+    rich_tree: Tree,
+    *,
+    max_depth: float,
+    depth: int,
+    cur_chain: list[str],
+) -> None:
+    """
+    Recursively build the rich tree structure.
+
+    :param tree: the package tree
+    :param node: current node
+    :param rich_tree: the rich Tree object to add children to
+    :param max_depth: maximum depth
+    :param depth: current depth
+    :param cur_chain: chain of package names to detect cycles
+    """
+    if depth >= max_depth:
+        return
+
+    children = tree.get_children(node.key)
+    for child in children:
+        if child.project_name in cur_chain:
+            continue
+
+        child_label = _format_node(child, parent=node, include_license=False)
+        child_tree = rich_tree.add(child_label)
+
+        _build_tree(
+            tree,
+            child,
+            child_tree,
+            max_depth=max_depth,
+            depth=depth + 1,
+            cur_chain=[*cur_chain, child.project_name],
+        )
+
+
+def _format_node(
+    node: DistPackage | ReqPackage,
+    parent: DistPackage | ReqPackage | None,
+    *,
+    include_license: bool,
+) -> str:
+    """
+    Format a node for display with rich styling.
+
+    :param node: the node to format
+    :param parent: the parent node (if any)
+    :param include_license: whether to include license information
+    :return: formatted string with rich markup
+    """
+    node_str = node.render(parent, frozen=False)
+
+    if parent is None and include_license:
+        node_str += " " + node.licenses()
+
+    if parent is None:
+        return _format_root_node(node_str)
+    return _format_branch_node(node_str, node)
+
+
+def _format_root_node(node_str: str) -> str:
+    """Format a root node (package at top level)."""
+    match = re.match(r"^(.+?)==(.+?)(\s+\(.+\))?$", node_str)
+    assert match, f"Unexpected root node format: {node_str}"
+    name, version, license_part = match.groups()
+    license_str = f"[dim]{license_part}[/dim]" if license_part else ""
+    return f"[bold cyan]{name}[/bold cyan][dim]==[/dim][bold green]{version}[/bold green]{license_str}"
+
+
+def _format_branch_node(node_str: str, node: DistPackage | ReqPackage) -> str:
+    """Format a branch node (dependency)."""
+    if isinstance(node, ReqPackage) and (
+        match := re.match(
+            r"""
+            ^(.+?)                          # package name (non-greedy)
+            \s+\[                           # opening bracket
+            required:\s*(.+?)               # required version spec (supports multi-spec like >=1.0,<2.0)
+            ,\s+installed:\s*(.+?)          # installed version
+            (?:,\s+extra:\s*(.+?))?         # optional extra name
+            \]$                             # closing bracket
+            """,
+            node_str,
+            re.VERBOSE,
+        )
+    ):
+        name, required, installed, extra = match.groups()
+        status_icon = _get_status_icon(node)
+        extra_str = f" [magenta]\\[extra: {extra}][/magenta]" if extra else ""
+        return (
+            f"{status_icon} [bold cyan]{name}[/bold cyan] "
+            f"[dim]required:[/dim] [yellow]{required}[/yellow] "
+            f"[dim]installed:[/dim] {_format_version(installed, node)}{extra_str}"
+        )
+
+    match = re.match(r"^(.+?)==(.+?)\s+\[requires:\s*(.+?)\]$", node_str)
+    assert match, f"Unexpected branch node format: {node_str}"
+    pkg_name, pkg_version, requires = match.groups()
+    return (
+        f"[bold cyan]{pkg_name}[/bold cyan][dim]==[/dim][bold green]{pkg_version}[/bold green] "
+        f"[dim]\\[requires:[/dim] [yellow]{requires}[/yellow][dim]][/dim]"
+    )
+
+
+def _get_status_icon(node: ReqPackage) -> str:
+    """Get a status icon for a requirement package."""
+    if node.is_missing:
+        return "[bold red]✗[/bold red]"
+    if node.is_conflicting():
+        return "[bold yellow]⚠[/bold yellow]"
+    return "[bold green]✓[/bold green]"
+
+
+def _format_version(version: str, node: ReqPackage) -> str:
+    """Format version with appropriate color based on status."""
+    if node.is_missing:
+        return f"[bold red]{version}[/bold red]"
+    if node.is_conflicting():
+        return f"[bold yellow]{version}[/bold yellow]"
+    return f"[bold green]{version}[/bold green]"
+
+
+__all__ = ["render_rich_text"]

--- a/tests/render/test_render.py
+++ b/tests/render/test_render.py
@@ -52,3 +52,10 @@ def test_freeze_routing(option: list[str], mocker: MockerFixture) -> None:
     render = mocker.patch("pipdeptree._render.render_freeze")
     main(option)
     render.assert_called_once_with(ANY, max_depth=inf, list_all=False)
+
+
+@pytest.mark.parametrize("option", [["--output", "rich"]])
+def test_rich_routing(option: list[str], mocker: MockerFixture) -> None:
+    render = mocker.patch("pipdeptree._render.render_rich_text")
+    main(option)
+    render.assert_called_once_with(ANY, max_depth=inf, list_all=False, include_license=False)

--- a/tests/render/test_rich_text.py
+++ b/tests/render/test_rich_text.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+
+from pipdeptree._models import PackageDAG
+from pipdeptree._models.package import Package
+from pipdeptree._render.rich_text import render_rich_text
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+    from unittest.mock import Mock
+
+    from pytest_mock import MockerFixture
+
+    from tests.conftest import MockDistMaker
+    from tests.our_types import MockGraph
+
+
+def test_render_rich_text_missing_import(mocker: MockerFixture, example_dag: PackageDAG) -> None:
+    mocker.patch.dict(sys.modules, {"rich": None, "rich.console": None, "rich.tree": None})
+    with pytest.raises(SystemExit) as exc_info:
+        render_rich_text(example_dag, max_depth=float("inf"))
+    assert exc_info.value.code == 1
+
+
+@pytest.mark.parametrize(
+    ("list_all", "expected"),
+    [
+        pytest.param(True, ["a==3.4.0", "b==2.3.1", "c==5.10.0", "✓", "required:", "installed:"], id="list-all"),
+        pytest.param(False, ["a==3.4.0", "g==6.8.3rc1"], id="not-list-all"),
+    ],
+)
+def test_render_rich_text_list_all(
+    example_dag: PackageDAG, capsys: pytest.CaptureFixture[str], list_all: bool, expected: list[str]
+) -> None:
+    pytest.importorskip("rich")
+    render_rich_text(example_dag, max_depth=float("inf"), list_all=list_all)
+    output = capsys.readouterr().out
+    for item in expected:
+        assert item in output
+
+
+@pytest.mark.parametrize(
+    "max_depth",
+    [
+        pytest.param(0, id="depth-0"),
+        pytest.param(2, id="depth-2"),
+    ],
+)
+def test_render_rich_text_with_max_depth(
+    example_dag: PackageDAG, capsys: pytest.CaptureFixture[str], max_depth: int
+) -> None:
+    pytest.importorskip("rich")
+    render_rich_text(example_dag, max_depth=max_depth)
+    output = capsys.readouterr().out
+    assert "a==3.4.0" in output
+
+
+def test_render_rich_text_with_license_info(
+    mock_pkgs: Callable[[MockGraph], Iterator[Mock]],
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("rich")
+    graph: MockGraph = {
+        ("a", "3.4.0"): [("c", [("==", "1.0.0")])],
+        ("b", "2.3.1"): [],
+        ("c", "1.0.0"): [],
+    }
+    dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
+    monkeypatch.setattr(Package, "licenses", lambda _: "(TEST)")
+
+    render_rich_text(dag, max_depth=float("inf"), include_license=True)
+    output = capsys.readouterr().out
+    assert "a==3.4.0" in output
+    assert "(TEST)" in output
+
+
+def test_render_rich_text_with_extras(capsys: pytest.CaptureFixture[str], make_mock_dist: MockDistMaker) -> None:
+    pytest.importorskip("rich")
+    pkgs = [
+        make_mock_dist("jira", "2.0.0", requires=["oauthlib[signedtoken]>=1.0.0"]),
+        make_mock_dist(
+            "oauthlib",
+            "3.0.0",
+            requires=["cryptography ; extra == 'signedtoken'"],
+            provides_extras=["signedtoken"],
+        ),
+        make_mock_dist("cryptography", "2.7"),
+    ]
+    dag = PackageDAG.from_pkgs(pkgs, include_extras=True)
+    render_rich_text(dag, max_depth=float("inf"))
+    output = capsys.readouterr().out
+    expected = ["jira==2.0.0", "oauthlib==3.0.0", "[extra: signedtoken]", "cryptography==2.7"]
+    for item in expected:
+        assert item in output
+
+
+def test_render_rich_text_reversed(
+    mock_pkgs: Callable[[MockGraph], Iterator[Mock]], capsys: pytest.CaptureFixture[str]
+) -> None:
+    pytest.importorskip("rich")
+    graph: MockGraph = {
+        ("a", "3.4.0"): [("b", [("==", "2.3.1")]), ("c", [("==", "1.0.0")])],
+        ("b", "2.3.1"): [("c", [("==", "1.0.0")])],
+        ("c", "1.0.0"): [],
+    }
+    dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
+    reversed_dag = dag.reverse()
+    render_rich_text(reversed_dag, max_depth=float("inf"))
+    output = capsys.readouterr().out
+    expected = ["a==3.4.0", "b==2.3.1", "c==1.0.0", "[requires:"]
+    for item in expected:
+        assert item in output
+
+
+def test_render_rich_text_with_circular_deps(
+    mock_pkgs: Callable[[MockGraph], Iterator[Mock]], capsys: pytest.CaptureFixture[str]
+) -> None:
+    pytest.importorskip("rich")
+    graph: MockGraph = {
+        ("a", "1.0.0"): [("b", [(">=", "1.0.0")])],
+        ("b", "1.0.0"): [("a", [(">=", "1.0.0")])],
+    }
+    dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
+    render_rich_text(dag, max_depth=float("inf"))
+    output = capsys.readouterr().out
+    expected = ["a==1.0.0", "b==1.0.0", "✓"]
+    for item in expected:
+        assert item in output
+
+
+@pytest.mark.parametrize(
+    ("graph", "expected"),
+    [
+        pytest.param(
+            {("a", "1.0.0"): [("missing", [(">=", "1.0.0")])]},
+            ["✗", "missing", "?"],
+            id="missing",
+        ),
+        pytest.param(
+            {
+                ("a", "1.0.0"): [("b", [(">=", "2.0.0")])],
+                ("b", "1.0.0"): [],
+            },
+            ["⚠", "b", ">=2.0.0", "1.0.0"],
+            id="conflicting",
+        ),
+        pytest.param(
+            {
+                ("a", "1.0.0"): [("b", [(">=", "1.0.0"), ("<", "2.0.0")])],
+                ("b", "1.5.0"): [],
+            },
+            ["✓", "b", ">=1.0.0,<2.0.0", "1.5.0"],
+            id="satisfied",
+        ),
+    ],
+)
+def test_render_rich_text_dependency_status(
+    mock_pkgs: Callable[[MockGraph], Iterator[Mock]],
+    capsys: pytest.CaptureFixture[str],
+    graph: MockGraph,
+    expected: list[str],
+) -> None:
+    pytest.importorskip("rich")
+    dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
+    render_rich_text(dag, max_depth=float("inf"))
+    output = capsys.readouterr().out
+    for item in expected:
+        assert item in output

--- a/tox.toml
+++ b/tox.toml
@@ -15,7 +15,7 @@ skip_missing_interpreters = true
 description = "run the unit tests with pytest under {base_python}"
 package = "wheel"
 wheel_build_env = ".pkg"
-extras = [ "graphviz", "test" ]
+extras = [ "graphviz", "rich", "test" ]
 pass_env = [ "DIFF_AGAINST", "PYTEST_*" ]
 set_env.COVERAGE_FILE = "{work_dir}/.coverage.{env_name}"
 commands = [
@@ -77,4 +77,5 @@ commands = [ [ "ty", "check", "--python-platform", "all", "--output-format", "co
 [env.dev]
 description = "generate a DEV environment"
 package = "editable"
+extras = [ "graphviz", "rich", "test" ]
 commands = [ [ "uv", "pip", "tree" ], [ "python", "-c", "import sys; print(sys.executable)" ] ]


### PR DESCRIPTION
This adds Rich library integration as an optional extra, following the same pattern as the existing graphviz support. The new --output rich format provides color-coded components (package names in cyan, versions in green, metadata in yellow), status icons (✓/⚠/✗) for dependency states, and enhanced tree guides. Version highlighting uses red for missing packages, yellow for conflicts, and green for satisfied dependencies.

The implementation remains opt-in via pip install pipdeptree[rich] to avoid bloating the base package. It reuses the existing tree traversal logic and delegates visual formatting to Rich's Tree component.

Closes #380