### PR TITLE
✨ feat(cli): add --metadata and --computed options

### DIFF
--- a/docs/how-to/output-formats.rst
+++ b/docs/how-to/output-formats.rst
@@ -81,6 +81,47 @@ Flat JSON array with package and dependency objects:
         }
     ]
 
+With ``--metadata`` or ``--computed``, package dicts include extra fields:
+
+.. code-block:: console
+
+    $ pipdeptree --packages rich -o json --metadata license --computed size,unique-deps-count,unique-deps-names
+
+.. code-block:: json
+
+    {
+        "package": {
+            "key": "rich",
+            "package_name": "rich",
+            "installed_version": "14.3.3",
+            "metadata": {
+                "license": "MIT License"
+            },
+            "computed": {
+                "size": "1.2 MB",
+                "unique_deps_count": 2,
+                "unique_deps_names": [
+                    "markdown-it-py",
+                    "mdurl"
+                ]
+            }
+        },
+        "dependencies": [
+            {
+                "key": "markdown-it-py",
+                "package_name": "markdown-it-py",
+                "installed_version": "4.0.0",
+                "required_version": ">=2.2.0"
+            },
+            {
+                "key": "pygments",
+                "package_name": "Pygments",
+                "installed_version": "2.19.2",
+                "required_version": ">=2.13.0,<3.0.0"
+            }
+        ]
+    }
+
 json-tree
 ---------
 

--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -248,22 +248,22 @@ Package metadata
 ----------------
 
 Display metadata fields from the package's ``METADATA`` file with ``--metadata`` (``-m``). Pass a comma-separated list
-of field names. Metadata is shown on every package in the tree in brackets:
+of field names. Metadata is shown on every package in the tree in parentheses:
 
 .. code-block:: console
 
     $ pipdeptree --metadata license --packages rich
-    rich==14.3.3 [MIT License]
-    ├── markdown-it-py [required: >=2.2.0, installed: 4.0.0] [MIT License]
-    │   └── mdurl [required: ~=0.1, installed: 0.1.2] [MIT License]
-    └── Pygments [required: >=2.13.0,<3.0.0, installed: 2.19.2] [BSD License]
+    rich==14.3.3 (MIT License)
+    ├── markdown-it-py [required: >=2.2.0, installed: 4.0.0] (MIT License)
+    │   └── mdurl [required: ~=0.1, installed: 0.1.2] (MIT License)
+    └── Pygments [required: >=2.13.0,<3.0.0, installed: 2.19.2] (BSD License)
 
 Multiple fields can be combined:
 
 .. code-block:: console
 
     $ pipdeptree --metadata license,summary --packages rich -d 0
-    rich==14.3.3 [MIT License, Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal]
+    rich==14.3.3 (MIT License, Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal)
 
 Common metadata fields: ``license``, ``summary``, ``author``, ``author-email``, ``home-page``, ``requires-python``.
 Any field from the package's ``METADATA`` file is accepted.
@@ -285,18 +285,19 @@ Display computed package information with ``--computed`` (``-c``):
 - ``unique-deps-size`` -- total installed size of exclusive dependencies (hidden when 0)
 
 Unique dependencies are transitive: if removing a package would orphan a dependency, and that orphaned dependency
-would in turn orphan its own dependencies, all of them are counted.
+would in turn orphan its own dependencies, all of them are counted. In rich output, unique dependencies are marked
+with a ⭐ icon (alongside ✗ or ⚠ if applicable).
 
 .. code-block:: console
 
     $ pipdeptree --computed size --packages rich -d 0
-    rich==14.3.3 [1.2 MB]
+    rich==14.3.3 (1.2 MB)
 
 .. code-block:: console
 
     $ pipdeptree --computed unique-deps-count,unique-deps-names,unique-deps-size --packages rich
-    rich==14.3.3 [2 unique deps, unique: markdown-it-py, mdurl, unique size: 248.2 KB]
-    ├── markdown-it-py [required: >=2.2.0, installed: 4.0.0] [1 unique deps, unique: mdurl, unique size: 22.9 KB]
+    rich==14.3.3 (2 unique deps, unique: markdown-it-py | mdurl, unique size: 248.2 KB)
+    ├── markdown-it-py [required: >=2.2.0, installed: 4.0.0] (1 unique deps, unique: mdurl, unique size: 22.9 KB)
     │   └── mdurl [required: ~=0.1, installed: 0.1.2]
     └── Pygments [required: >=2.13.0,<3.0.0, installed: 2.19.2]
 

--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -244,25 +244,64 @@ Use ``-d 0`` to show only top-level packages with no dependencies:
     pytest-cov==7.0.0
     rich==14.3.3
 
-License display
----------------
+Package metadata
+----------------
 
-Show the license metadata for each package (text and rich output only):
+Display metadata fields from the package's ``METADATA`` file with ``--metadata`` (``-m``). Pass a comma-separated list
+of field names. Metadata is shown on every package in the tree in brackets:
 
 .. code-block:: console
 
-    $ pipdeptree --license --packages pytest,rich
-    pytest==9.0.2 (MIT)
-    ├── iniconfig [required: >=1.0.1, installed: 2.3.0]
-    ├── packaging [required: >=22, installed: 26.0]
-    ├── pluggy [required: >=1.5,<2, installed: 1.6.0]
-    └── Pygments [required: >=2.7.2, installed: 2.19.2]
-    rich==14.3.3 (MIT License)
-    ├── markdown-it-py [required: >=2.2.0, installed: 4.0.0]
+    $ pipdeptree --metadata license --packages rich
+    rich==14.3.3 [MIT License]
+    ├── markdown-it-py [required: >=2.2.0, installed: 4.0.0] [MIT License]
+    │   └── mdurl [required: ~=0.1, installed: 0.1.2] [MIT License]
+    └── Pygments [required: >=2.13.0,<3.0.0, installed: 2.19.2] [BSD License]
+
+Multiple fields can be combined:
+
+.. code-block:: console
+
+    $ pipdeptree --metadata license,summary --packages rich -d 0
+    rich==14.3.3 [MIT License, Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal]
+
+Common metadata fields: ``license``, ``summary``, ``author``, ``author-email``, ``home-page``, ``requires-python``.
+Any field from the package's ``METADATA`` file is accepted.
+
+.. note::
+
+   The ``--license`` flag still works for backwards compatibility but is deprecated. Use ``--metadata license``
+   instead.
+
+Computed fields
+---------------
+
+Display computed package information with ``--computed`` (``-c``):
+
+- ``size`` -- installed size on disk (human-readable)
+- ``size-raw`` -- installed size in bytes (integer, useful for JSON output)
+- ``unique-deps-count`` -- number of dependencies exclusive to this package (hidden when 0)
+- ``unique-deps-names`` -- names of dependencies exclusive to this package (hidden when empty)
+- ``unique-deps-size`` -- total installed size of exclusive dependencies (hidden when 0)
+
+Unique dependencies are transitive: if removing a package would orphan a dependency, and that orphaned dependency
+would in turn orphan its own dependencies, all of them are counted.
+
+.. code-block:: console
+
+    $ pipdeptree --computed size --packages rich -d 0
+    rich==14.3.3 [1.2 MB]
+
+.. code-block:: console
+
+    $ pipdeptree --computed unique-deps-count,unique-deps-names,unique-deps-size --packages rich
+    rich==14.3.3 [2 unique deps, unique: markdown-it-py, mdurl, unique size: 248.2 KB]
+    ├── markdown-it-py [required: >=2.2.0, installed: 4.0.0] [1 unique deps, unique: mdurl, unique size: 22.9 KB]
     │   └── mdurl [required: ~=0.1, installed: 0.1.2]
     └── Pygments [required: >=2.13.0,<3.0.0, installed: 2.19.2]
 
-The license is shown in parentheses after the version on the top-level package line.
+Both ``--metadata`` and ``--computed`` can be combined and work with all output formats. In JSON output, ``size_raw``
+and ``unique_deps_count`` are native integers, ``unique_deps_names`` is a list of strings.
 
 Including extras
 ----------------

--- a/src/pipdeptree/__main__.py
+++ b/src/pipdeptree/__main__.py
@@ -48,6 +48,9 @@ def main(args: Sequence[str] | None = None) -> int | None:
 
     validate(tree)
 
+    if options.context.active:
+        options.context.full_tree = tree
+
     # Reverse the tree (if applicable) before filtering, thus ensuring, that the filter will be applied on ReverseTree
     if options.reverse:
         tree = tree.reverse()

--- a/src/pipdeptree/_cli.py
+++ b/src/pipdeptree/_cli.py
@@ -255,7 +255,9 @@ def get_options(args: Sequence[str] | None) -> Options:
     options.output_format = _handle_legacy_render_options(options)
     raw_metadata: str = cast("str", options.metadata)
     raw_computed: str = cast("str", options.computed)
-    options.metadata = [f.strip() for f in raw_metadata.split(",") if f.strip()] if raw_metadata else []
+    options.metadata = (
+        list(dict.fromkeys(f.strip() for f in raw_metadata.split(",") if f.strip())) if raw_metadata else []
+    )
     options.computed = [f.strip() for f in raw_computed.split(",") if f.strip()] if raw_computed else []
 
     if options.license:

--- a/src/pipdeptree/_cli.py
+++ b/src/pipdeptree/_cli.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
 import sys
+import warnings
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, ArgumentTypeError, Namespace
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, cast
 
 from .version import __version__
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+
+    from pipdeptree._models import PackageDAG
 
 
 class Options(Namespace):
@@ -31,10 +35,27 @@ class Options(Namespace):
     depth: float
     encoding: str
     license: bool
+    metadata: list[str]
+    computed: list[str]
+    context: RenderContext
+
+
+@dataclass
+class RenderContext:
+    """Bundles metadata and computed fields that augment package display."""
+
+    metadata: list[str] = field(default_factory=list)
+    computed: list[str] = field(default_factory=list)
+    full_tree: PackageDAG | None = field(default=None, repr=False, compare=False)
+
+    @property
+    def active(self) -> bool:
+        return bool(self.metadata or self.computed)
 
 
 # NOTE: graphviz-* has been intentionally left out. Users of this var should handle it separately.
 ALLOWED_RENDER_FORMATS = ["freeze", "json", "json-tree", "mermaid", "rich", "text"]
+ALLOWED_COMPUTED_FIELDS = frozenset({"size", "size-raw", "unique-deps-count", "unique-deps-names", "unique-deps-size"})
 
 
 class _Formatter(ArgumentDefaultsHelpFormatter):
@@ -147,7 +168,22 @@ def build_parser() -> ArgumentParser:
     render.add_argument(
         "--license",
         action="store_true",
-        help="list the license(s) of a package (text and rich render only)",
+        help="(Deprecated, use --metadata license) list the license(s) of a package",
+    )
+    render.add_argument(
+        "-m",
+        "--metadata",
+        default="",
+        help="comma separated list of metadata fields to display from the package METADATA file"
+        " (e.g. license,summary,author,home-page,requires-python)",
+        metavar="M",
+    )
+    render.add_argument(
+        "-c",
+        "--computed",
+        default="",
+        help=f"comma separated list of computed fields to display: {', '.join(sorted(ALLOWED_COMPUTED_FIELDS))}",
+        metavar="C",
     )
 
     render_type = render.add_mutually_exclusive_group()
@@ -196,11 +232,25 @@ def get_options(args: Sequence[str] | None) -> Options:
     options = cast("Options", parsed_args)
 
     options.output_format = _handle_legacy_render_options(options)
+    raw_metadata: str = cast("str", options.metadata)
+    raw_computed: str = cast("str", options.computed)
+    options.metadata = [f.strip() for f in raw_metadata.split(",") if f.strip()] if raw_metadata else []
+    options.computed = [f.strip() for f in raw_computed.split(",") if f.strip()] if raw_computed else []
+
+    if options.license:
+        if "license" in options.metadata:
+            return parser.error("cannot use --license with --metadata license")
+        warnings.warn("--license is deprecated, use --metadata license instead", DeprecationWarning, stacklevel=1)
+        options.metadata = ["license", *options.metadata]
+
+    if invalid := set(options.computed) - ALLOWED_COMPUTED_FIELDS:
+        allowed = ", ".join(sorted(ALLOWED_COMPUTED_FIELDS))
+        return parser.error(f"invalid --computed values: {', '.join(sorted(invalid))}. Allowed: {allowed}")
+
+    options.context = RenderContext(metadata=options.metadata, computed=options.computed)
 
     if options.exclude_dependencies and not options.exclude:
         return parser.error("must use --exclude-dependencies with --exclude")
-    if options.license and options.freeze:
-        return parser.error("cannot use --license with --freeze")
     if options.path and (options.local_only or options.user_only):
         return parser.error("cannot use --path with --user-only or --local-only")
 

--- a/src/pipdeptree/_cli.py
+++ b/src/pipdeptree/_cli.py
@@ -66,6 +66,10 @@ class RenderContext:
                 parts.append(f"{field_key}: {field_value}")
         return separator.join(parts)
 
+    def with_metadata(self, metadata: list[str]) -> RenderContext:
+        """Return a copy with a different metadata field list."""
+        return RenderContext(metadata=metadata, computed=self.computed, full_tree=self.full_tree)
+
     @staticmethod
     def _get_metadata_label_parts(key: str, fields: list[str], tree: PackageDAG) -> list[str]:
         for pkg in tree:

--- a/src/pipdeptree/_cli.py
+++ b/src/pipdeptree/_cli.py
@@ -6,6 +6,8 @@ from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, ArgumentType
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, cast
 
+from pipdeptree._computed import ComputedValues
+
 from .version import __version__
 
 if TYPE_CHECKING:
@@ -51,6 +53,25 @@ class RenderContext:
     @property
     def active(self) -> bool:
         return bool(self.metadata or self.computed)
+
+    def build_node_extra_label(self, key: str, tree: PackageDAG, separator: str) -> str:
+        if not self.active:
+            return ""
+        parts: list[str] = []
+        if self.metadata:
+            parts.extend(self._get_metadata_label_parts(key, self.metadata, tree))
+        if self.computed:
+            computed = ComputedValues(key, tree, self.full_tree)
+            for field_key, field_value in computed.as_dict(self.computed).items():
+                parts.append(f"{field_key}: {field_value}")
+        return separator.join(parts)
+
+    @staticmethod
+    def _get_metadata_label_parts(key: str, fields: list[str], tree: PackageDAG) -> list[str]:
+        for pkg in tree:
+            if pkg.key == key:
+                return pkg.get_metadata_values(fields)
+        return []
 
 
 # NOTE: graphviz-* has been intentionally left out. Users of this var should handle it separately.

--- a/src/pipdeptree/_computed.py
+++ b/src/pipdeptree/_computed.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import pathlib
+from importlib.metadata import PackageNotFoundError, distribution
+from importlib.metadata import metadata as get_pkg_metadata
+from typing import TYPE_CHECKING, TypedDict
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from pipdeptree._cli import RenderContext
+    from pipdeptree._models import PackageDAG
+
+
+class ComputedValues(TypedDict, total=False):
+    size: str
+    size_raw: int
+    unique_deps_count: int
+    unique_deps_names: list[str]
+    unique_deps_size: str
+
+
+def build_node_extra_label(key: str, context: RenderContext | None, tree: PackageDAG, separator: str) -> str:
+    if not context or not context.active:
+        return ""
+    parts: list[str] = []
+    if context.metadata:
+        parts.extend(get_metadata_label_parts(key, context.metadata, tree))
+    if context.computed:
+        for field_key, field_value in get_computed_values(key, context.computed, tree, context.full_tree).items():
+            parts.append(f"{field_key}: {field_value}")
+    return separator.join(parts)
+
+
+def get_metadata_label_parts(key: str, fields: Sequence[str], tree: PackageDAG) -> list[str]:
+    parts: list[str] = []
+    for field in fields:
+        if field == "license":
+            for pkg in tree:
+                if pkg.key == key:
+                    parts.append(pkg.licenses().strip("()"))
+                    break
+            continue
+        try:
+            dist_metadata = get_pkg_metadata(key)
+            if value := dist_metadata[field]:
+                parts.append(str(value))
+        except PackageNotFoundError:
+            pass
+    return parts
+
+
+def format_computed_display(
+    key: str, fields: Sequence[str], tree: PackageDAG, full_tree: PackageDAG | None = None
+) -> list[str]:
+    values = get_computed_values(key, fields, tree, full_tree)
+    result: list[str] = []
+    for field in fields:
+        if field == "size" and "size" in values:
+            result.append(str(values["size"]))
+        elif field == "size-raw" and "size_raw" in values:
+            result.append(str(values["size_raw"]))
+        elif field == "unique-deps-count" and "unique_deps_count" in values and values["unique_deps_count"]:
+            result.append(f"{values['unique_deps_count']} unique deps")
+        elif field == "unique-deps-names" and "unique_deps_names" in values and values["unique_deps_names"]:
+            result.append(f"unique: {', '.join(values['unique_deps_names'])}")
+        elif field == "unique-deps-size" and "unique_deps_size" in values and values["unique_deps_size"] != "0 B":
+            result.append(f"unique size: {values['unique_deps_size']}")
+    return result
+
+
+def get_computed_values(
+    key: str, fields: Sequence[str], tree: PackageDAG, full_tree: PackageDAG | None = None
+) -> ComputedValues:
+    result: ComputedValues = {}
+    size_bytes: int | None = None
+    if {"size", "size-raw"} & set(fields):
+        size_bytes = compute_installed_size_bytes(key)
+    unique: set[str] | None = None
+    if {"unique-deps-count", "unique-deps-names", "unique-deps-size"} & set(fields):
+        unique = compute_unique_deps(key, full_tree or tree)
+    for field in fields:
+        if field == "size":
+            result["size"] = _format_size(size_bytes) if size_bytes is not None else "0 B"
+        elif field == "size-raw":
+            result["size_raw"] = size_bytes or 0
+        elif field == "unique-deps-count" and unique is not None:
+            result["unique_deps_count"] = len(unique)
+        elif field == "unique-deps-names" and unique is not None:
+            result["unique_deps_names"] = sorted(unique)
+        elif field == "unique-deps-size" and unique is not None:
+            total = sum(compute_installed_size_bytes(dep) or 0 for dep in unique)
+            result["unique_deps_size"] = _format_size(total)
+    return result
+
+
+def compute_installed_size_bytes(key: str) -> int | None:
+    dist = distribution(key)
+    if not (files := dist.files):
+        return None
+    return sum(_file_size(str(dist.locate_file(file_entry))) for file_entry in files)
+
+
+def _file_size(path: str) -> int:
+    try:
+        return pathlib.Path(path).stat().st_size
+    except OSError:
+        return 0
+
+
+def _format_size(size_bytes: int) -> str:
+    for unit in ("B", "KB", "MB", "GB"):
+        if size_bytes < 1024 or unit == "GB":
+            return f"{size_bytes:.1f} {unit}" if unit != "B" else f"{size_bytes} B"
+        size_bytes /= 1024  # ty: ignore[invalid-assignment]
+    return f"{size_bytes:.1f} GB"  # pragma: no cover
+
+
+def compute_unique_deps(key: str, tree: PackageDAG) -> set[str]:
+    own_deps = _transitive_deps(key, tree)
+    removed = {key}
+    changed = True
+    while changed:
+        changed = False
+        reachable: set[str] = set()
+        for pkg in tree:
+            if pkg.key not in removed:
+                reachable |= _transitive_deps(pkg.key, tree, exclude=removed)
+        newly_orphaned = own_deps - reachable - removed
+        if newly_orphaned:
+            removed |= newly_orphaned
+            changed = True
+    return removed - {key}
+
+
+def _transitive_deps(key: str, tree: PackageDAG, exclude: set[str] | None = None) -> set[str]:
+    result: set[str] = set()
+    excluded = exclude or set()
+    stack = [c.key for c in tree.get_children(key) if c.key not in excluded]
+    while stack:
+        if (dep := stack.pop()) not in result:
+            result.add(dep)
+            stack.extend(c.key for c in tree.get_children(dep) if c.key not in excluded)
+    return result
+
+
+__all__ = [
+    "ComputedValues",
+    "build_node_extra_label",
+    "compute_installed_size_bytes",
+    "compute_unique_deps",
+    "format_computed_display",
+    "get_computed_values",
+    "get_metadata_label_parts",
+]

--- a/src/pipdeptree/_computed.py
+++ b/src/pipdeptree/_computed.py
@@ -1,155 +1,119 @@
 from __future__ import annotations
 
 import pathlib
-from importlib.metadata import PackageNotFoundError, distribution
-from importlib.metadata import metadata as get_pkg_metadata
-from typing import TYPE_CHECKING, TypedDict
+from dataclasses import dataclass
+from functools import cached_property
+from importlib.metadata import distribution
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from pipdeptree._cli import RenderContext
     from pipdeptree._models import PackageDAG
 
 
-class ComputedValues(TypedDict, total=False):
-    size: str
-    size_raw: int
-    unique_deps_count: int
-    unique_deps_names: list[str]
-    unique_deps_size: str
+@dataclass
+class ComputedValues:
+    key: str
+    tree: PackageDAG
+    full_tree: PackageDAG | None = None
 
+    def as_dict(self, fields: Sequence[str]) -> dict[str, Any]:
+        return {
+            (attr := field.replace("-", "_")): getattr(self, attr)
+            for field in fields
+            if hasattr(self, field.replace("-", "_"))
+        }
 
-def build_node_extra_label(key: str, context: RenderContext | None, tree: PackageDAG, separator: str) -> str:
-    if not context or not context.active:
-        return ""
-    parts: list[str] = []
-    if context.metadata:
-        parts.extend(get_metadata_label_parts(key, context.metadata, tree))
-    if context.computed:
-        for field_key, field_value in get_computed_values(key, context.computed, tree, context.full_tree).items():
-            parts.append(f"{field_key}: {field_value}")
-    return separator.join(parts)
+    def format_display(self, fields: Sequence[str], exclude: frozenset[str] = frozenset()) -> list[str]:
+        result: list[str] = []
+        for field in fields:
+            if field in exclude:
+                continue
+            if field == "size":
+                result.append(self.size)
+            elif field == "size-raw":
+                result.append(str(self.size_raw))
+            elif field == "unique-deps-count" and self.unique_deps_count:
+                result.append(f"{self.unique_deps_count} unique deps")
+            elif field == "unique-deps-names" and self.unique_deps_names:
+                result.append(f"unique: {' | '.join(self.unique_deps_names)}")
+            elif field == "unique-deps-size" and self.unique_deps_size != "0 B":
+                result.append(f"unique size: {self.unique_deps_size}")
+        return result
 
+    @cached_property
+    def size(self) -> str:
+        return self._format_size(self.size_bytes) if self.size_bytes is not None else "0 B"
 
-def get_metadata_label_parts(key: str, fields: Sequence[str], tree: PackageDAG) -> list[str]:
-    parts: list[str] = []
-    for field in fields:
-        if field == "license":
-            for pkg in tree:
-                if pkg.key == key:
-                    parts.append(pkg.licenses().strip("()"))
-                    break
-            continue
+    @cached_property
+    def size_raw(self) -> int:
+        return self.size_bytes or 0
+
+    @cached_property
+    def size_bytes(self) -> int | None:
+        dist = distribution(self.key)
+        if not (files := dist.files):
+            return None
+        return sum(self._file_size(str(dist.locate_file(f))) for f in files)
+
+    @staticmethod
+    def _file_size(path: str) -> int:
         try:
-            dist_metadata = get_pkg_metadata(key)
-            if value := dist_metadata[field]:
-                parts.append(str(value))
-        except PackageNotFoundError:
-            pass
-    return parts
+            return pathlib.Path(path).stat().st_size
+        except OSError:
+            return 0
 
+    @staticmethod
+    def _format_size(size_bytes: int) -> str:
+        for unit in ("B", "KB", "MB", "GB"):
+            if size_bytes < 1024 or unit == "GB":
+                return f"{size_bytes:.1f} {unit}" if unit != "B" else f"{size_bytes} B"
+            size_bytes /= 1024  # ty: ignore[invalid-assignment]
+        return f"{size_bytes:.1f} GB"  # pragma: no cover
 
-def format_computed_display(
-    key: str, fields: Sequence[str], tree: PackageDAG, full_tree: PackageDAG | None = None
-) -> list[str]:
-    values = get_computed_values(key, fields, tree, full_tree)
-    result: list[str] = []
-    for field in fields:
-        if field == "size" and "size" in values:
-            result.append(str(values["size"]))
-        elif field == "size-raw" and "size_raw" in values:
-            result.append(str(values["size_raw"]))
-        elif field == "unique-deps-count" and "unique_deps_count" in values and values["unique_deps_count"]:
-            result.append(f"{values['unique_deps_count']} unique deps")
-        elif field == "unique-deps-names" and "unique_deps_names" in values and values["unique_deps_names"]:
-            result.append(f"unique: {', '.join(values['unique_deps_names'])}")
-        elif field == "unique-deps-size" and "unique_deps_size" in values and values["unique_deps_size"] != "0 B":
-            result.append(f"unique size: {values['unique_deps_size']}")
-    return result
+    @cached_property
+    def unique_deps_count(self) -> int:
+        return len(self.unique_deps)
 
+    @cached_property
+    def unique_deps_names(self) -> list[str]:
+        return sorted(self.unique_deps)
 
-def get_computed_values(
-    key: str, fields: Sequence[str], tree: PackageDAG, full_tree: PackageDAG | None = None
-) -> ComputedValues:
-    result: ComputedValues = {}
-    size_bytes: int | None = None
-    if {"size", "size-raw"} & set(fields):
-        size_bytes = compute_installed_size_bytes(key)
-    unique: set[str] | None = None
-    if {"unique-deps-count", "unique-deps-names", "unique-deps-size"} & set(fields):
-        unique = compute_unique_deps(key, full_tree or tree)
-    for field in fields:
-        if field == "size":
-            result["size"] = _format_size(size_bytes) if size_bytes is not None else "0 B"
-        elif field == "size-raw":
-            result["size_raw"] = size_bytes or 0
-        elif field == "unique-deps-count" and unique is not None:
-            result["unique_deps_count"] = len(unique)
-        elif field == "unique-deps-names" and unique is not None:
-            result["unique_deps_names"] = sorted(unique)
-        elif field == "unique-deps-size" and unique is not None:
-            total = sum(compute_installed_size_bytes(dep) or 0 for dep in unique)
-            result["unique_deps_size"] = _format_size(total)
-    return result
+    @cached_property
+    def unique_deps_size(self) -> str:
+        total = sum(ComputedValues(dep, self.tree, self.full_tree).size_raw for dep in self.unique_deps)
+        return self._format_size(total)
 
+    @cached_property
+    def unique_deps(self) -> set[str]:
+        tree = self.full_tree or self.tree
+        own_deps = self._transitive_deps(self.key, tree)
+        removed = {self.key}
+        changed = True
+        while changed:
+            changed = False
+            reachable: set[str] = set()
+            for pkg in tree:
+                if pkg.key not in removed:
+                    reachable |= self._transitive_deps(pkg.key, tree, exclude=removed)
+            if newly_orphaned := own_deps - reachable - removed:
+                removed |= newly_orphaned
+                changed = True
+        return removed - {self.key}
 
-def compute_installed_size_bytes(key: str) -> int | None:
-    dist = distribution(key)
-    if not (files := dist.files):
-        return None
-    return sum(_file_size(str(dist.locate_file(file_entry))) for file_entry in files)
-
-
-def _file_size(path: str) -> int:
-    try:
-        return pathlib.Path(path).stat().st_size
-    except OSError:
-        return 0
-
-
-def _format_size(size_bytes: int) -> str:
-    for unit in ("B", "KB", "MB", "GB"):
-        if size_bytes < 1024 or unit == "GB":
-            return f"{size_bytes:.1f} {unit}" if unit != "B" else f"{size_bytes} B"
-        size_bytes /= 1024  # ty: ignore[invalid-assignment]
-    return f"{size_bytes:.1f} GB"  # pragma: no cover
-
-
-def compute_unique_deps(key: str, tree: PackageDAG) -> set[str]:
-    own_deps = _transitive_deps(key, tree)
-    removed = {key}
-    changed = True
-    while changed:
-        changed = False
-        reachable: set[str] = set()
-        for pkg in tree:
-            if pkg.key not in removed:
-                reachable |= _transitive_deps(pkg.key, tree, exclude=removed)
-        newly_orphaned = own_deps - reachable - removed
-        if newly_orphaned:
-            removed |= newly_orphaned
-            changed = True
-    return removed - {key}
-
-
-def _transitive_deps(key: str, tree: PackageDAG, exclude: set[str] | None = None) -> set[str]:
-    result: set[str] = set()
-    excluded = exclude or set()
-    stack = [c.key for c in tree.get_children(key) if c.key not in excluded]
-    while stack:
-        if (dep := stack.pop()) not in result:
-            result.add(dep)
-            stack.extend(c.key for c in tree.get_children(dep) if c.key not in excluded)
-    return result
+    @staticmethod
+    def _transitive_deps(key: str, tree: PackageDAG, exclude: set[str] | None = None) -> set[str]:
+        result: set[str] = set()
+        excluded = exclude or set()
+        stack = [c.key for c in tree.get_children(key) if c.key not in excluded]
+        while stack:
+            if (dep := stack.pop()) not in result:
+                result.add(dep)
+                stack.extend(c.key for c in tree.get_children(dep) if c.key not in excluded)
+        return result
 
 
 __all__ = [
     "ComputedValues",
-    "build_node_extra_label",
-    "compute_installed_size_bytes",
-    "compute_unique_deps",
-    "format_computed_display",
-    "get_computed_values",
-    "get_metadata_label_parts",
 ]

--- a/src/pipdeptree/_models/package.py
+++ b/src/pipdeptree/_models/package.py
@@ -55,7 +55,7 @@ class Package(ABC):
 
         return f"({', '.join(license_strs)})"
 
-    def get_metadata(self, field: str) -> str:
+    def get_metadata(self, field: str) -> str | list[str]:
         if field == "license":
             raw = self.licenses().strip("()")
             return raw if "license" in raw.lower() else f"{raw} License"
@@ -63,14 +63,24 @@ class Package(ABC):
             dist_metadata = metadata(self.key)
         except PackageNotFoundError:
             return "Unknown"
-        if value := dist_metadata[field]:
-            return str(value)
-        return "Unknown"
+        values = dist_metadata.get_all(field)
+        if not values:
+            return "Unknown"
+        if len(values) == 1:
+            return str(values[0])
+        return [str(v) for v in values]
 
     def get_metadata_values(self, fields: list[str]) -> list[str]:
-        return [self.get_metadata(f) for f in fields]
+        result: list[str] = []
+        for f in fields:
+            value = self.get_metadata(f)
+            if isinstance(value, list):
+                result.extend(value)
+            else:
+                result.append(value)
+        return result
 
-    def get_metadata_dict(self, fields: list[str]) -> dict[str, str]:
+    def get_metadata_dict(self, fields: list[str]) -> dict[str, str | list[str]]:
         return {field: self.get_metadata(field) for field in fields}
 
     @abstractmethod

--- a/src/pipdeptree/_models/package.py
+++ b/src/pipdeptree/_models/package.py
@@ -78,7 +78,7 @@ class Package(ABC):
                 result.extend(value)
             else:
                 result.append(value)
-        return result
+        return [r"\n".join(" ".join(line.split()) for line in v.splitlines()) for v in result]
 
     def get_metadata_dict(self, fields: list[str]) -> dict[str, str | list[str]]:
         return {field: self.get_metadata(field) for field in fields}

--- a/src/pipdeptree/_models/package.py
+++ b/src/pipdeptree/_models/package.py
@@ -57,7 +57,8 @@ class Package(ABC):
 
     def get_metadata(self, field: str) -> str:
         if field == "license":
-            return self.licenses().strip("()")
+            raw = self.licenses().strip("()")
+            return raw if "license" in raw.lower() else f"{raw} License"
         try:
             dist_metadata = metadata(self.key)
         except PackageNotFoundError:

--- a/src/pipdeptree/_models/package.py
+++ b/src/pipdeptree/_models/package.py
@@ -55,6 +55,23 @@ class Package(ABC):
 
         return f"({', '.join(license_strs)})"
 
+    def get_metadata(self, field: str) -> str:
+        if field == "license":
+            return self.licenses().strip("()")
+        try:
+            dist_metadata = metadata(self.key)
+        except PackageNotFoundError:
+            return "Unknown"
+        if value := dist_metadata[field]:
+            return str(value)
+        return "Unknown"
+
+    def get_metadata_values(self, fields: list[str]) -> list[str]:
+        return [self.get_metadata(f) for f in fields]
+
+    def get_metadata_dict(self, fields: list[str]) -> dict[str, str]:
+        return {field: self.get_metadata(field) for field in fields}
+
     @abstractmethod
     def render_as_root(self, *, frozen: bool) -> str:
         raise NotImplementedError

--- a/src/pipdeptree/_render/__init__.py
+++ b/src/pipdeptree/_render/__init__.py
@@ -18,18 +18,22 @@ if TYPE_CHECKING:
 def render(options: Options, tree: PackageDAG) -> None:
     output_format = options.output_format
     if output_format == "json":
-        render_json(tree)
+        render_json(tree, context=options.context)
     elif output_format == "json-tree":
-        render_json_tree(tree)
+        render_json_tree(tree, context=options.context)
     elif output_format == "mermaid":
-        render_mermaid(tree)
+        render_mermaid(tree, context=options.context)
     elif output_format == "freeze":
         render_freeze(tree, max_depth=options.depth, list_all=options.all)
     elif output_format == "rich":
-        render_rich_text(tree, max_depth=options.depth, list_all=options.all, include_license=options.license)
+        render_rich_text(tree, max_depth=options.depth, list_all=options.all, context=options.context)
     elif output_format.startswith("graphviz-"):
         render_graphviz(
-            tree, output_format=output_format[len("graphviz-") :], reverse=options.reverse, max_depth=options.depth
+            tree,
+            output_format=output_format[len("graphviz-") :],
+            reverse=options.reverse,
+            max_depth=options.depth,
+            context=options.context,
         )
     else:
         render_text(
@@ -37,7 +41,7 @@ def render(options: Options, tree: PackageDAG) -> None:
             max_depth=options.depth,
             encoding=options.encoding,
             list_all=options.all,
-            include_license=options.license,
+            context=options.context,
         )
 
 

--- a/src/pipdeptree/_render/freeze.py
+++ b/src/pipdeptree/_render/freeze.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
 def render_freeze(tree: PackageDAG, *, max_depth: float, list_all: bool = True) -> None:
     nodes = get_top_level_nodes(tree, list_all=list_all)
-    _render_text_simple(tree, nodes, max_depth, include_license=False, frozen=True, bullet="")
+    _render_text_simple(tree, nodes, max_depth, context=None, frozen=True, bullet="")
 
 
 __all__ = [

--- a/src/pipdeptree/_render/graphviz.py
+++ b/src/pipdeptree/_render/graphviz.py
@@ -13,11 +13,19 @@ from pipdeptree._models import DistPackage, ReqPackage
 if TYPE_CHECKING:
     from graphviz import Digraph
 
+    from pipdeptree._cli import RenderContext
     from pipdeptree._models import PackageDAG
 
 
-def render_graphviz(tree: PackageDAG, *, output_format: str, reverse: bool, max_depth: float = math.inf) -> None:
-    output = dump_graphviz(tree, output_format=output_format, is_reverse=reverse, max_depth=max_depth)
+def render_graphviz(
+    tree: PackageDAG,
+    *,
+    output_format: str,
+    reverse: bool,
+    max_depth: float = math.inf,
+    context: RenderContext | None = None,
+) -> None:
+    output = dump_graphviz(tree, output_format=output_format, is_reverse=reverse, max_depth=max_depth, context=context)
     if isinstance(output, bytes):
         print_graphviz(output, output_format=output_format)
     else:
@@ -29,6 +37,7 @@ def dump_graphviz(
     output_format: str = "dot",
     is_reverse: bool = False,  # noqa: FBT001, FBT002
     max_depth: float = math.inf,
+    context: RenderContext | None = None,
 ) -> str | bytes:
     """
     Output dependency graph as one of the supported GraphViz output formats.
@@ -37,6 +46,7 @@ def dump_graphviz(
     :param string output_format: output format
     :param bool is_reverse: reverse or not
     :param float max_depth: maximum depth of the dependency tree to include
+    :param context: metadata and computed fields to include in node labels
     :returns: representation of tree in the specified output format
     :rtype: str or binary representation depending on the output format
     """
@@ -61,9 +71,9 @@ def dump_graphviz(
     graph = Digraph(format=output_format)
 
     if is_reverse:
-        _build_reverse_graph(tree, graph, max_depth)
+        _build_reverse_graph(tree, graph, max_depth, context)
     else:
-        _build_forward_graph(tree, graph, max_depth)
+        _build_forward_graph(tree, graph, max_depth, context)
 
     # Allow output of dot format, even if GraphViz isn't installed.
     if output_format == "dot":
@@ -110,7 +120,12 @@ def print_graphviz(dump_output: str | bytes, *, output_format: str = "dot") -> N
             bytestream.write(dump_output)
 
 
-def _build_reverse_graph(tree: PackageDAG, graph: Digraph, max_depth: float) -> None:
+def _build_reverse_graph(
+    tree: PackageDAG,
+    graph: Digraph,
+    max_depth: float,
+    context: RenderContext | None,
+) -> None:
     """Build graphviz nodes and edges for a reversed dependency tree."""
     visited = _compute_reachable_depths(tree, _get_root_keys(tree), max_depth)
 
@@ -118,7 +133,10 @@ def _build_reverse_graph(tree: PackageDAG, graph: Digraph, max_depth: float) -> 
         if visited is not None and dep_rev.key not in visited:
             continue
         assert isinstance(dep_rev, ReqPackage)
-        graph.node(dep_rev.key, label=f"{dep_rev.project_name}\\n{dep_rev.installed_version}")
+        label = f"{dep_rev.project_name}\\n{dep_rev.installed_version}"
+        if extra := build_node_extra_label(dep_rev.key, context, tree, "\\n"):
+            label += f"\\n{extra}"
+        graph.node(dep_rev.key, label=label)
         if visited is None or visited[dep_rev.key] < max_depth:
             for parent in parents:
                 assert isinstance(parent, DistPackage)
@@ -127,14 +145,22 @@ def _build_reverse_graph(tree: PackageDAG, graph: Digraph, max_depth: float) -> 
                 graph.edge(dep_rev.key, parent.key, label=parent.edge_label)
 
 
-def _build_forward_graph(tree: PackageDAG, graph: Digraph, max_depth: float) -> None:
+def _build_forward_graph(
+    tree: PackageDAG,
+    graph: Digraph,
+    max_depth: float,
+    context: RenderContext | None,
+) -> None:
     """Build graphviz nodes and edges for a forward dependency tree."""
     visited = _compute_reachable_depths(tree, _get_root_keys(tree), max_depth)
 
     for pkg, deps in tree.items():
         if visited is not None and pkg.key not in visited:
             continue
-        graph.node(pkg.key, label=f"{pkg.project_name}\\n{pkg.version}")
+        label = f"{pkg.project_name}\\n{pkg.version}"
+        if extra := build_node_extra_label(pkg.key, context, tree, "\\n"):
+            label += f"\\n{extra}"
+        graph.node(pkg.key, label=label)
         if visited is None or visited[pkg.key] < max_depth:
             for dep in deps:
                 if visited is not None and dep.key not in visited:

--- a/src/pipdeptree/_render/graphviz.py
+++ b/src/pipdeptree/_render/graphviz.py
@@ -134,7 +134,7 @@ def _build_reverse_graph(
             continue
         assert isinstance(dep_rev, ReqPackage)
         label = f"{dep_rev.project_name}\\n{dep_rev.installed_version}"
-        if extra := build_node_extra_label(dep_rev.key, context, tree, "\\n"):
+        if context and (extra := context.build_node_extra_label(dep_rev.key, tree, "\\n")):
             label += f"\\n{extra}"
         graph.node(dep_rev.key, label=label)
         if visited is None or visited[dep_rev.key] < max_depth:
@@ -158,7 +158,7 @@ def _build_forward_graph(
         if visited is not None and pkg.key not in visited:
             continue
         label = f"{pkg.project_name}\\n{pkg.version}"
-        if extra := build_node_extra_label(pkg.key, context, tree, "\\n"):
+        if context and (extra := context.build_node_extra_label(pkg.key, tree, "\\n")):
             label += f"\\n{extra}"
         graph.node(pkg.key, label=label)
         if visited is None or visited[pkg.key] < max_depth:

--- a/src/pipdeptree/_render/json.py
+++ b/src/pipdeptree/_render/json.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, Any
 
-from pipdeptree._computed import get_computed_values
+from pipdeptree._computed import ComputedValues
 
 if TYPE_CHECKING:
     from pipdeptree._cli import RenderContext
@@ -34,7 +34,7 @@ def render_json(
         if context and context.metadata:
             d["metadata"] = k.get_metadata_dict(list(context.metadata))
         if context and context.computed:
-            d["computed"] = get_computed_values(k.key, context.computed, tree, context.full_tree)
+            d["computed"] = ComputedValues(k.key, tree, context.full_tree).as_dict(context.computed)
         return d
 
     output = json.dumps(

--- a/src/pipdeptree/_render/json.py
+++ b/src/pipdeptree/_render/json.py
@@ -1,27 +1,44 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
+
+from pipdeptree._computed import get_computed_values
 
 if TYPE_CHECKING:
+    from pipdeptree._cli import RenderContext
     from pipdeptree._models import PackageDAG
 
 
-def render_json(tree: PackageDAG) -> None:
+def render_json(
+    tree: PackageDAG,
+    *,
+    context: RenderContext | None = None,
+) -> None:
     """
     Convert the tree into a flat json representation.
 
     The json repr will be a list of hashes, each hash having 2 fields:
       - package
-      - dependencies: list of dependencies
+      - dependencies
 
     :param tree: dependency tree
+    :param context: metadata and computed fields to include
     :returns: JSON representation of the tree
 
     """
     tree = tree.sort()
+
+    def _package_dict(k: Any) -> dict[str, Any]:
+        d: dict[str, Any] = k.as_dict()
+        if context and context.metadata:
+            d["metadata"] = k.get_metadata_dict(list(context.metadata))
+        if context and context.computed:
+            d["computed"] = get_computed_values(k.key, context.computed, tree, context.full_tree)
+        return d
+
     output = json.dumps(
-        [{"package": k.as_dict(), "dependencies": [v.as_dict() for v in vs]} for k, vs in tree.items()],
+        [{"package": _package_dict(k), "dependencies": [v.as_dict() for v in vs]} for k, vs in tree.items()],
         indent=4,
     )
     print(output)  # noqa: T201

--- a/src/pipdeptree/_render/json_tree.py
+++ b/src/pipdeptree/_render/json_tree.py
@@ -4,13 +4,19 @@ import json
 from itertools import chain
 from typing import TYPE_CHECKING, Any
 
+from pipdeptree._computed import get_computed_values
 from pipdeptree._models import ReqPackage
 
 if TYPE_CHECKING:
+    from pipdeptree._cli import RenderContext
     from pipdeptree._models import DistPackage, PackageDAG
 
 
-def render_json_tree(tree: PackageDAG) -> None:
+def render_json_tree(
+    tree: PackageDAG,
+    *,
+    context: RenderContext | None = None,
+) -> None:
     """
     Convert the tree into a nested json representation.
 
@@ -23,6 +29,7 @@ def render_json_tree(tree: PackageDAG) -> None:
       - dependencies: list of dependencies
 
     :param tree: dependency tree
+    :param context: metadata and computed fields to include
     :returns: json representation of the tree
 
     """
@@ -43,6 +50,11 @@ def render_json_tree(tree: PackageDAG) -> None:
             d["required_version"] = node.version_spec if isinstance(node, ReqPackage) and node.version_spec else "Any"
         else:
             d["required_version"] = d["installed_version"]
+
+        if context and context.metadata:
+            d["metadata"] = node.get_metadata_dict(list(context.metadata))  # ty: ignore[invalid-assignment]
+        if context and context.computed:
+            d["computed"] = get_computed_values(node.key, context.computed, tree, context.full_tree)  # ty: ignore[invalid-assignment]
 
         d["dependencies"] = [
             aux(c, parent=node, cur_chain=[*cur_chain, c.project_name])

--- a/src/pipdeptree/_render/json_tree.py
+++ b/src/pipdeptree/_render/json_tree.py
@@ -4,7 +4,7 @@ import json
 from itertools import chain
 from typing import TYPE_CHECKING, Any
 
-from pipdeptree._computed import get_computed_values
+from pipdeptree._computed import ComputedValues
 from pipdeptree._models import ReqPackage
 
 if TYPE_CHECKING:
@@ -54,7 +54,7 @@ def render_json_tree(
         if context and context.metadata:
             d["metadata"] = node.get_metadata_dict(list(context.metadata))  # ty: ignore[invalid-assignment]
         if context and context.computed:
-            d["computed"] = get_computed_values(node.key, context.computed, tree, context.full_tree)  # ty: ignore[invalid-assignment]
+            d["computed"] = ComputedValues(node.key, tree, context.full_tree).as_dict(context.computed)  # ty: ignore[invalid-assignment]
 
         d["dependencies"] = [
             aux(c, parent=node, cur_chain=[*cur_chain, c.project_name])

--- a/src/pipdeptree/_render/mermaid.py
+++ b/src/pipdeptree/_render/mermaid.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import itertools as it
 from typing import TYPE_CHECKING, Final
 
-from pipdeptree._computed import build_node_extra_label
 from pipdeptree._models import DistPackage, ReqPackage, ReversedPackageDAG
 
 if TYPE_CHECKING:
@@ -79,7 +78,7 @@ def _build_reversed_mermaid(
             package.project_name,
             "(missing)" if package.is_missing else package.installed_version,
         ]
-        if extra := build_node_extra_label(package.key, context, tree, "<br/>"):
+        if extra := context and context.build_node_extra_label(package.key, tree, "<br/>"):
             label_parts.append(extra)
         package_key = _mermaid_id(package.key, node_ids_map)
         nodes.add(f'{package_key}["{"<br/>".join(label_parts)}"]')
@@ -98,7 +97,7 @@ def _build_forward_mermaid(
 ) -> None:
     for package, dependencies in tree.items():
         label_parts = [package.project_name, package.version]
-        if extra := build_node_extra_label(package.key, context, tree, "<br/>"):
+        if extra := context and context.build_node_extra_label(package.key, tree, "<br/>"):
             label_parts.append(extra)
         package_key = _mermaid_id(package.key, node_ids_map)
         nodes.add(f'{package_key}["{"<br/>".join(label_parts)}"]')

--- a/src/pipdeptree/_render/mermaid.py
+++ b/src/pipdeptree/_render/mermaid.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import itertools as it
 from typing import TYPE_CHECKING, Final
 
+from pipdeptree._computed import build_node_extra_label
 from pipdeptree._models import DistPackage, ReqPackage, ReversedPackageDAG
 
 if TYPE_CHECKING:
+    from pipdeptree._cli import RenderContext
     from pipdeptree._models import PackageDAG
 
 _RESERVED_IDS: Final[frozenset[str]] = frozenset(
@@ -34,67 +36,27 @@ _RESERVED_IDS: Final[frozenset[str]] = frozenset(
 )
 
 
-def render_mermaid(tree: PackageDAG) -> None:  # noqa: C901
+def render_mermaid(
+    tree: PackageDAG,
+    *,
+    context: RenderContext | None = None,
+) -> None:
     """
     Produce a Mermaid flowchart from the dependency graph.
 
     :param tree: dependency graph
+    :param context: metadata and computed fields to include in node labels
 
     """
-    # List of reserved keywords in Mermaid that cannot be used as node names.
-    # See: https://github.com/mermaid-js/mermaid/issues/4182#issuecomment-1454787806
-
     node_ids_map: dict[str, str] = {}
-
-    def mermaid_id(key: str) -> str:
-        """Return a valid Mermaid node ID from a string."""
-        # If we have already seen this key, return the canonical ID.
-        canonical_id = node_ids_map.get(key)
-        if canonical_id is not None:
-            return canonical_id
-        # If the key is not a reserved keyword, return it as is, and update the map.
-        if key not in _RESERVED_IDS:
-            node_ids_map[key] = key
-            return key
-        # If the key is a reserved keyword, append a number to it.
-        for number in it.count():
-            new_id = f"{key}_{number}"
-            if new_id not in node_ids_map:
-                node_ids_map[key] = new_id
-                return new_id
-        raise NotImplementedError
-
-    # Use a sets to avoid duplicate entries.
     nodes: set[str] = set()
     edges: set[str] = set()
 
     if isinstance(tree, ReversedPackageDAG):
-        for package, reverse_dependencies in tree.items():
-            assert isinstance(package, ReqPackage)
-            package_label = "<br/>".join(
-                (package.project_name, "(missing)" if package.is_missing else package.installed_version),
-            )
-            package_key = mermaid_id(package.key)
-            nodes.add(f'{package_key}["{package_label}"]')
-            for reverse_dependency in reverse_dependencies:
-                assert isinstance(reverse_dependency, DistPackage)
-                reverse_dependency_key = mermaid_id(reverse_dependency.key)
-                edges.add(f'{package_key} -- "{reverse_dependency.edge_label}" --> {reverse_dependency_key}')
+        _build_reversed_mermaid(tree, nodes, edges, node_ids_map, context)
     else:
-        for package, dependencies in tree.items():
-            package_label = f"{package.project_name}<br/>{package.version}"
-            package_key = mermaid_id(package.key)
-            nodes.add(f'{package_key}["{package_label}"]')
-            for dependency in dependencies:
-                dependency_key = mermaid_id(dependency.key)
-                if dependency.is_missing:
-                    dependency_label = f"{dependency.project_name}<br/>(missing)"
-                    nodes.add(f'{dependency_key}["{dependency_label}"]:::missing')
-                    edges.add(f"{package_key} -.-> {dependency_key}")
-                else:
-                    edges.add(f'{package_key} -- "{dependency.edge_label}" --> {dependency_key}')
+        _build_forward_mermaid(tree, nodes, edges, node_ids_map, context)
 
-    # Produce the Mermaid Markdown.
     lines = [
         "flowchart TD",
         "classDef missing stroke-dasharray: 5",
@@ -102,6 +64,67 @@ def render_mermaid(tree: PackageDAG) -> None:  # noqa: C901
         *sorted(edges),
     ]
     print("".join(f"{'    ' if i else ''}{line}\n" for i, line in enumerate(lines)))  # noqa: T201
+
+
+def _build_reversed_mermaid(
+    tree: PackageDAG,
+    nodes: set[str],
+    edges: set[str],
+    node_ids_map: dict[str, str],
+    context: RenderContext | None,
+) -> None:
+    for package, reverse_dependencies in tree.items():
+        assert isinstance(package, ReqPackage)
+        label_parts = [
+            package.project_name,
+            "(missing)" if package.is_missing else package.installed_version,
+        ]
+        if extra := build_node_extra_label(package.key, context, tree, "<br/>"):
+            label_parts.append(extra)
+        package_key = _mermaid_id(package.key, node_ids_map)
+        nodes.add(f'{package_key}["{"<br/>".join(label_parts)}"]')
+        for reverse_dependency in reverse_dependencies:
+            assert isinstance(reverse_dependency, DistPackage)
+            rev_key = _mermaid_id(reverse_dependency.key, node_ids_map)
+            edges.add(f'{package_key} -- "{reverse_dependency.edge_label}" --> {rev_key}')
+
+
+def _build_forward_mermaid(
+    tree: PackageDAG,
+    nodes: set[str],
+    edges: set[str],
+    node_ids_map: dict[str, str],
+    context: RenderContext | None,
+) -> None:
+    for package, dependencies in tree.items():
+        label_parts = [package.project_name, package.version]
+        if extra := build_node_extra_label(package.key, context, tree, "<br/>"):
+            label_parts.append(extra)
+        package_key = _mermaid_id(package.key, node_ids_map)
+        nodes.add(f'{package_key}["{"<br/>".join(label_parts)}"]')
+        for dependency in dependencies:
+            dependency_key = _mermaid_id(dependency.key, node_ids_map)
+            if dependency.is_missing:
+                dependency_label = f"{dependency.project_name}<br/>(missing)"
+                nodes.add(f'{dependency_key}["{dependency_label}"]:::missing')
+                edges.add(f"{package_key} -.-> {dependency_key}")
+            else:
+                edges.add(f'{package_key} -- "{dependency.edge_label}" --> {dependency_key}')
+
+
+def _mermaid_id(key: str, node_ids_map: dict[str, str]) -> str:
+    """Return a valid Mermaid node ID from a string."""
+    if (canonical_id := node_ids_map.get(key)) is not None:
+        return canonical_id
+    if key not in _RESERVED_IDS:
+        node_ids_map[key] = key
+        return key
+    for number in it.count():
+        new_id = f"{key}_{number}"
+        if new_id not in node_ids_map:
+            node_ids_map[key] = new_id
+            return new_id
+    raise NotImplementedError
 
 
 __all__ = [

--- a/src/pipdeptree/_render/rich_text.py
+++ b/src/pipdeptree/_render/rich_text.py
@@ -47,6 +47,7 @@ def render_rich_text(
     for node in nodes:
         root_label = _format_node(node, parent=None, context=context, tree=tree)
         rich_tree = Tree(root_label, guide_style="bold bright_blue")
+        _add_metadata_leaves(node, rich_tree, context)
         _build_tree(tree, node, rich_tree, max_depth=max_depth, depth=0, cur_chain=[], context=context)
         console.print(rich_tree)
 
@@ -82,6 +83,7 @@ def _build_tree(  # noqa: PLR0913
 
         child_label = _format_node(child, parent=node, context=context, tree=tree)
         child_tree = rich_tree.add(child_label)
+        _add_metadata_leaves(child, child_tree, context)
 
         _build_tree(
             tree,
@@ -116,7 +118,13 @@ def _format_node(
 
     suffix = ""
     if context and context.active:
-        suffix = _build_suffix(node, context, tree, exclude=rich_exclude)
+        # Only include single-line, single-value metadata in the inline suffix;
+        # multi-value and multiline fields render as sub-tree leaves.
+        single_value_fields = [
+            f for f in context.metadata if not isinstance(v := node.get_metadata(f), list) and "\n" not in v
+        ]
+        filtered = context.with_metadata(single_value_fields)
+        suffix = _build_suffix(node, filtered, tree, exclude=rich_exclude)
 
     if parent is None:
         return _format_root_node(node_str, suffix)
@@ -126,6 +134,24 @@ def _format_node(
         and node.key in ComputedValues(parent.key, tree, context.full_tree if context else None).unique_deps
     )
     return _format_branch_node(node_str, node, suffix, is_unique=is_unique)
+
+
+def _add_metadata_leaves(
+    node: DistPackage | ReqPackage,
+    rich_tree: Tree,
+    context: RenderContext | None,
+) -> None:
+    """Add multi-value metadata fields as styled sub-tree leaves."""
+    if not context or not context.metadata:
+        return
+    for f in context.metadata:
+        value = node.get_metadata(f)
+        if isinstance(value, list):
+            field_tree = rich_tree.add(f"[dim]{f}[/dim]", guide_style="dim")
+            for v in value:
+                field_tree.add(f"[dim blue]{v}[/dim blue]")
+        elif "\n" in value:
+            rich_tree.add(f"[dim]{f}:[/dim]\n[dim blue]{value}[/dim blue]")
 
 
 def _format_root_node(node_str: str, suffix: str = "") -> str:

--- a/src/pipdeptree/_render/rich_text.py
+++ b/src/pipdeptree/_render/rich_text.py
@@ -4,6 +4,7 @@ import re
 import sys
 from typing import TYPE_CHECKING
 
+from pipdeptree._computed import ComputedValues
 from pipdeptree._models.package import DistPackage, ReqPackage
 from pipdeptree._render.text import _build_suffix, get_top_level_nodes
 
@@ -111,13 +112,20 @@ def _format_node(
     """
     node_str = node.render(parent, frozen=False)
 
+    rich_exclude = frozenset({"unique-deps-names"})
+
     suffix = ""
     if context and context.active:
-        suffix = _build_suffix(node, context, tree)
+        suffix = _build_suffix(node, context, tree, exclude=rich_exclude)
 
     if parent is None:
         return _format_root_node(node_str, suffix)
-    return _format_branch_node(node_str, node, suffix)
+    is_unique = (
+        context is not None
+        and any(f.startswith("unique-deps") for f in context.computed)
+        and node.key in ComputedValues(parent.key, tree, context.full_tree if context else None).unique_deps
+    )
+    return _format_branch_node(node_str, node, suffix, is_unique=is_unique)
 
 
 def _format_root_node(node_str: str, suffix: str = "") -> str:
@@ -129,7 +137,9 @@ def _format_root_node(node_str: str, suffix: str = "") -> str:
     return f"[bold cyan]{name}[/bold cyan][dim]==[/dim][bold green]{version}[/bold green]{suffix_str}"
 
 
-def _format_branch_node(node_str: str, node: DistPackage | ReqPackage, suffix: str = "") -> str:
+def _format_branch_node(
+    node_str: str, node: DistPackage | ReqPackage, suffix: str = "", *, is_unique: bool = False
+) -> str:
     """Format a branch node (dependency)."""
     suffix_str = f" [dim blue]{suffix.strip()}[/dim blue]" if suffix else ""
     if isinstance(node, ReqPackage) and (
@@ -147,10 +157,10 @@ def _format_branch_node(node_str: str, node: DistPackage | ReqPackage, suffix: s
         )
     ):
         name, required, installed, extra = match.groups()
-        status_icon = _get_status_icon(node)
+        status_icon = _get_status_icon(node, is_unique=is_unique)
         extra_str = f" [magenta]\\[extra: {extra}][/magenta]" if extra else ""
         return (
-            f"{status_icon} [bold cyan]{name}[/bold cyan] "
+            f"{status_icon}[bold cyan]{name}[/bold cyan] "
             f"[dim]required:[/dim] [yellow]{required}[/yellow] "
             f"[dim]installed:[/dim] {_format_version(installed, node)}{extra_str}{suffix_str}"
         )
@@ -164,13 +174,16 @@ def _format_branch_node(node_str: str, node: DistPackage | ReqPackage, suffix: s
     )
 
 
-def _get_status_icon(node: ReqPackage) -> str:
+def _get_status_icon(node: ReqPackage, *, is_unique: bool = False) -> str:
     """Get a status icon for a requirement package."""
+    icons: list[str] = []
     if node.is_missing:
-        return "[bold red]✗[/bold red]"
-    if node.is_conflicting():
-        return "[bold yellow]⚠[/bold yellow]"
-    return "[bold green]✓[/bold green]"
+        icons.append("[bold red]✗[/bold red]")
+    elif node.is_conflicting():
+        icons.append("[bold yellow]⚠[/bold yellow]")
+    if is_unique:
+        icons.append("[bold yellow]⭐[/bold yellow]")
+    return "".join(f"{icon} " for icon in icons)
 
 
 def _format_version(version: str, node: ReqPackage) -> str:

--- a/src/pipdeptree/_render/rich_text.py
+++ b/src/pipdeptree/_render/rich_text.py
@@ -5,10 +5,12 @@ import sys
 from typing import TYPE_CHECKING
 
 from pipdeptree._models.package import DistPackage, ReqPackage
+from pipdeptree._render.text import _build_suffix, get_top_level_nodes
 
 if TYPE_CHECKING:
     from rich.tree import Tree
 
+    from pipdeptree._cli import RenderContext
     from pipdeptree._models import PackageDAG
 
 
@@ -17,7 +19,7 @@ def render_rich_text(
     *,
     max_depth: float,
     list_all: bool = True,
-    include_license: bool = False,
+    context: RenderContext | None = None,
 ) -> None:
     """
     Print tree using Rich library for enhanced terminal output.
@@ -25,7 +27,7 @@ def render_rich_text(
     :param tree: the package tree
     :param max_depth: the maximum depth of the dependency tree
     :param list_all: whether to list all the pkgs at the root level or only those that are the sub-dependencies
-    :param include_license: provide license information
+    :param context: metadata and computed fields to display
     :returns: None
     """
     try:
@@ -38,15 +40,13 @@ def render_rich_text(
         )
         raise SystemExit(1) from exc
 
-    from pipdeptree._render.text import get_top_level_nodes  # noqa: PLC0415
-
     nodes = get_top_level_nodes(tree, list_all=list_all)
     console = Console()
 
     for node in nodes:
-        root_label = _format_node(node, parent=None, include_license=include_license)
+        root_label = _format_node(node, parent=None, context=context, tree=tree)
         rich_tree = Tree(root_label, guide_style="bold bright_blue")
-        _build_tree(tree, node, rich_tree, max_depth=max_depth, depth=0, cur_chain=[])
+        _build_tree(tree, node, rich_tree, max_depth=max_depth, depth=0, cur_chain=[], context=context)
         console.print(rich_tree)
 
 
@@ -58,6 +58,7 @@ def _build_tree(  # noqa: PLR0913
     max_depth: float,
     depth: int,
     cur_chain: list[str],
+    context: RenderContext | None,
 ) -> None:
     """
     Recursively build the rich tree structure.
@@ -68,6 +69,7 @@ def _build_tree(  # noqa: PLR0913
     :param max_depth: maximum depth
     :param depth: current depth
     :param cur_chain: chain of package names to detect cycles
+    :param context: metadata and computed fields to display
     """
     if depth >= max_depth:
         return
@@ -77,7 +79,7 @@ def _build_tree(  # noqa: PLR0913
         if child.project_name in cur_chain:
             continue
 
-        child_label = _format_node(child, parent=node, include_license=False)
+        child_label = _format_node(child, parent=node, context=context, tree=tree)
         child_tree = rich_tree.add(child_label)
 
         _build_tree(
@@ -87,6 +89,7 @@ def _build_tree(  # noqa: PLR0913
             max_depth=max_depth,
             depth=depth + 1,
             cur_chain=[*cur_chain, child.project_name],
+            context=context,
         )
 
 
@@ -94,37 +97,41 @@ def _format_node(
     node: DistPackage | ReqPackage,
     parent: DistPackage | ReqPackage | None,
     *,
-    include_license: bool,
+    context: RenderContext | None,
+    tree: PackageDAG,
 ) -> str:
     """
     Format a node for display with rich styling.
 
     :param node: the node to format
     :param parent: the parent node (if any)
-    :param include_license: whether to include license information
+    :param context: metadata and computed fields to display
+    :param tree: the package tree (needed for computed fields)
     :return: formatted string with rich markup
     """
     node_str = node.render(parent, frozen=False)
 
-    if parent is None and include_license:
-        node_str += " " + node.licenses()
+    suffix = ""
+    if context and context.active:
+        suffix = _build_suffix(node, context, tree)
 
     if parent is None:
-        return _format_root_node(node_str)
-    return _format_branch_node(node_str, node)
+        return _format_root_node(node_str, suffix)
+    return _format_branch_node(node_str, node, suffix)
 
 
-def _format_root_node(node_str: str) -> str:
+def _format_root_node(node_str: str, suffix: str = "") -> str:
     """Format a root node (package at top level)."""
-    match = re.match(r"^(.+?)==(.+?)(\s+\(.+\))?$", node_str)
+    match = re.match(r"^(.+?)==(.+?)$", node_str)
     assert match, f"Unexpected root node format: {node_str}"
-    name, version, license_part = match.groups()
-    license_str = f"[dim]{license_part}[/dim]" if license_part else ""
-    return f"[bold cyan]{name}[/bold cyan][dim]==[/dim][bold green]{version}[/bold green]{license_str}"
+    name, version = match.groups()
+    suffix_str = f" [dim blue]{suffix.strip()}[/dim blue]" if suffix else ""
+    return f"[bold cyan]{name}[/bold cyan][dim]==[/dim][bold green]{version}[/bold green]{suffix_str}"
 
 
-def _format_branch_node(node_str: str, node: DistPackage | ReqPackage) -> str:
+def _format_branch_node(node_str: str, node: DistPackage | ReqPackage, suffix: str = "") -> str:
     """Format a branch node (dependency)."""
+    suffix_str = f" [dim blue]{suffix.strip()}[/dim blue]" if suffix else ""
     if isinstance(node, ReqPackage) and (
         match := re.match(
             r"""
@@ -145,7 +152,7 @@ def _format_branch_node(node_str: str, node: DistPackage | ReqPackage) -> str:
         return (
             f"{status_icon} [bold cyan]{name}[/bold cyan] "
             f"[dim]required:[/dim] [yellow]{required}[/yellow] "
-            f"[dim]installed:[/dim] {_format_version(installed, node)}{extra_str}"
+            f"[dim]installed:[/dim] {_format_version(installed, node)}{extra_str}{suffix_str}"
         )
 
     match = re.match(r"^(.+?)==(.+?)\s+\[requires:\s*(.+?)\]$", node_str)
@@ -153,7 +160,7 @@ def _format_branch_node(node_str: str, node: DistPackage | ReqPackage) -> str:
     pkg_name, pkg_version, requires = match.groups()
     return (
         f"[bold cyan]{pkg_name}[/bold cyan][dim]==[/dim][bold green]{pkg_version}[/bold green] "
-        f"[dim]\\[requires:[/dim] [yellow]{requires}[/yellow][dim]][/dim]"
+        f"[dim]\\[requires:[/dim] [yellow]{requires}[/yellow][dim]][/dim]{suffix_str}"
     )
 
 

--- a/src/pipdeptree/_render/text.py
+++ b/src/pipdeptree/_render/text.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from itertools import chain
 from typing import TYPE_CHECKING, Any
 
-from pipdeptree._computed import format_computed_display
+from pipdeptree._computed import ComputedValues
 
 if TYPE_CHECKING:
     from pipdeptree._cli import RenderContext
@@ -159,13 +159,15 @@ def _build_suffix(
     node: DistPackage | ReqPackage,
     context: RenderContext,
     tree: PackageDAG,
+    *,
+    exclude: frozenset[str] = frozenset(),
 ) -> str:
     parts: list[str] = []
     if context.metadata:
         parts.extend(node.get_metadata_values(list(context.metadata)))
     if context.computed:
-        parts.extend(format_computed_display(node.key, context.computed, tree, context.full_tree))
-    return f" [{', '.join(parts)}]" if parts else ""
+        parts.extend(ComputedValues(node.key, tree, context.full_tree).format_display(context.computed, exclude))
+    return f" ({', '.join(parts)})" if parts else ""
 
 
 __all__ = ["get_top_level_nodes", "render_text"]

--- a/src/pipdeptree/_render/text.py
+++ b/src/pipdeptree/_render/text.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from itertools import chain
 from typing import TYPE_CHECKING, Any
 
+from pipdeptree._computed import format_computed_display
+
 if TYPE_CHECKING:
+    from pipdeptree._cli import RenderContext
     from pipdeptree._models import DistPackage, PackageDAG, ReqPackage
 
 
@@ -13,7 +16,7 @@ def render_text(
     max_depth: float,
     encoding: str,
     list_all: bool = True,
-    include_license: bool = False,
+    context: RenderContext | None = None,
 ) -> None:
     """
     Print tree as text on console.
@@ -22,16 +25,16 @@ def render_text(
     :param max_depth: the maximum depth of the dependency tree
     :param encoding: encoding to use (use "utf-8", "utf-16", "utf-32" for unicode or anything else for legacy output)
     :param list_all: whether to list all the pkgs at the root level or only those that are the sub-dependencies
-    :param include_license: provide license information
+    :param context: metadata and computed fields to display
     :returns: None
 
     """
     nodes = get_top_level_nodes(tree, list_all=list_all)
 
     if encoding in {"utf-8", "utf-16", "utf-32"}:
-        _render_text_with_unicode(tree, nodes, max_depth, include_license)
+        _render_text_with_unicode(tree, nodes, max_depth, context)
     else:
-        _render_text_simple(tree, nodes, max_depth, include_license)
+        _render_text_simple(tree, nodes, max_depth, context=context)
 
 
 def get_top_level_nodes(tree: PackageDAG, *, list_all: bool) -> list[DistPackage]:
@@ -55,7 +58,7 @@ def _render_text_with_unicode(
     tree: PackageDAG,
     nodes: list[DistPackage],
     max_depth: float,
-    include_license: bool,  # noqa: FBT001
+    context: RenderContext | None,
 ) -> None:
     def aux(  # noqa: PLR0913, PLR0917
         node: DistPackage | ReqPackage,
@@ -70,6 +73,8 @@ def _render_text_with_unicode(
     ) -> list[Any]:
         cur_chain = cur_chain or []
         node_str = node.render(parent, frozen=False)
+        if context and context.active:
+            node_str += _build_suffix(node, context, tree)
         next_prefix = ""
         next_indent = indent + 2
 
@@ -88,8 +93,6 @@ def _render_text_with_unicode(
                 prefix += " "
             next_prefix = prefix
             node_str = prefix + bullet + node_str
-        elif include_license:
-            node_str += " " + node.licenses()
 
         result = [node_str]
 
@@ -121,8 +124,8 @@ def _render_text_simple(  # noqa: PLR0913
     tree: PackageDAG,
     nodes: list[DistPackage],
     max_depth: float,
-    include_license: bool,  # noqa: FBT001
     *,
+    context: RenderContext | None = None,
     frozen: bool = False,
     bullet: str = "- ",
 ) -> None:
@@ -135,10 +138,10 @@ def _render_text_simple(  # noqa: PLR0913
     ) -> list[Any]:
         cur_chain = cur_chain or []
         node_str = node.render(parent, frozen=frozen)
+        if context and context.active:
+            node_str += _build_suffix(node, context, tree)
         if parent:
             node_str = " " * indent + bullet + node_str
-        elif include_license:
-            node_str += " " + node.licenses()
         result = [node_str]
         children = [
             aux(c, node, indent=indent + 2, cur_chain=[*cur_chain, c.project_name], depth=depth + 1)
@@ -150,6 +153,19 @@ def _render_text_simple(  # noqa: PLR0913
 
     lines = chain.from_iterable([aux(p) for p in nodes])
     print("\n".join(lines))  # noqa: T201
+
+
+def _build_suffix(
+    node: DistPackage | ReqPackage,
+    context: RenderContext,
+    tree: PackageDAG,
+) -> str:
+    parts: list[str] = []
+    if context.metadata:
+        parts.extend(node.get_metadata_values(list(context.metadata)))
+    if context.computed:
+        parts.extend(format_computed_display(node.key, context.computed, tree, context.full_tree))
+    return f" [{', '.join(parts)}]" if parts else ""
 
 
 __all__ = ["get_top_level_nodes", "render_text"]

--- a/tests/_models/test_package.py
+++ b/tests/_models/test_package.py
@@ -372,3 +372,43 @@ def test_dist_package_edge_label_with_extra() -> None:
     rp = ReqPackage(bar_req, extra="signedtoken")
     dp = DistPackage(foo).as_parent_of(rp)
     assert dp.edge_label == "[signedtoken] >=4.0"
+
+
+def test_get_metadata_license(mocker: MockerFixture) -> None:
+    mocker.patch.object(Package, "licenses", return_value="(MIT)")
+    dist = MagicMock(metadata={"Name": "foo"}, version="1.0")
+    assert DistPackage(dist).get_metadata("license") == "MIT License"
+
+
+def test_get_metadata_arbitrary_field(mocker: MockerFixture) -> None:
+    mocker.patch("pipdeptree._models.package.metadata", return_value={"Summary": "A package"})
+    dist = MagicMock(metadata={"Name": "foo"}, version="1.0")
+    assert DistPackage(dist).get_metadata("Summary") == "A package"
+
+
+def test_get_metadata_missing_field(mocker: MockerFixture) -> None:
+    mock_meta = MagicMock()
+    mock_meta.__getitem__ = lambda *_args: None
+    mocker.patch("pipdeptree._models.package.metadata", return_value=mock_meta)
+    dist = MagicMock(metadata={"Name": "foo"}, version="1.0")
+    assert DistPackage(dist).get_metadata("Nonexistent") == "Unknown"
+
+
+def test_get_metadata_unknown_package(mocker: MockerFixture) -> None:
+    mocker.patch("pipdeptree._models.package.metadata", side_effect=PackageNotFoundError("x"))
+    dist = MagicMock(metadata={"Name": "foo"}, version="1.0")
+    assert DistPackage(dist).get_metadata("Summary") == "Unknown"
+
+
+def test_get_metadata_dict(mocker: MockerFixture) -> None:
+    mocker.patch.object(Package, "licenses", return_value="(MIT)")
+    mocker.patch("pipdeptree._models.package.metadata", return_value={"Summary": "A package"})
+    dist = MagicMock(metadata={"Name": "foo"}, version="1.0")
+    result = DistPackage(dist).get_metadata_dict(["license", "Summary"])
+    assert result == {"license": "MIT License", "Summary": "A package"}
+
+
+def test_get_metadata_values(mocker: MockerFixture) -> None:
+    mocker.patch.object(Package, "licenses", return_value="(MIT)")
+    dist = MagicMock(metadata={"Name": "foo"}, version="1.0")
+    assert DistPackage(dist).get_metadata_values(["license"]) == ["MIT License"]

--- a/tests/_models/test_package.py
+++ b/tests/_models/test_package.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from email.message import Message
 from importlib.metadata import PackageNotFoundError
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, Mock
@@ -381,15 +382,17 @@ def test_get_metadata_license(mocker: MockerFixture) -> None:
 
 
 def test_get_metadata_arbitrary_field(mocker: MockerFixture) -> None:
-    mocker.patch("pipdeptree._models.package.metadata", return_value={"Summary": "A package"})
+
+    msg = Message()
+    msg["Summary"] = "A package"
+    mocker.patch("pipdeptree._models.package.metadata", return_value=msg)
     dist = MagicMock(metadata={"Name": "foo"}, version="1.0")
     assert DistPackage(dist).get_metadata("Summary") == "A package"
 
 
 def test_get_metadata_missing_field(mocker: MockerFixture) -> None:
-    mock_meta = MagicMock()
-    mock_meta.__getitem__ = lambda *_args: None
-    mocker.patch("pipdeptree._models.package.metadata", return_value=mock_meta)
+
+    mocker.patch("pipdeptree._models.package.metadata", return_value=Message())
     dist = MagicMock(metadata={"Name": "foo"}, version="1.0")
     assert DistPackage(dist).get_metadata("Nonexistent") == "Unknown"
 
@@ -401,11 +404,62 @@ def test_get_metadata_unknown_package(mocker: MockerFixture) -> None:
 
 
 def test_get_metadata_dict(mocker: MockerFixture) -> None:
+
     mocker.patch.object(Package, "licenses", return_value="(MIT)")
-    mocker.patch("pipdeptree._models.package.metadata", return_value={"Summary": "A package"})
+    msg = Message()
+    msg["Summary"] = "A package"
+    mocker.patch("pipdeptree._models.package.metadata", return_value=msg)
     dist = MagicMock(metadata={"Name": "foo"}, version="1.0")
     result = DistPackage(dist).get_metadata_dict(["license", "Summary"])
     assert result == {"license": "MIT License", "Summary": "A package"}
+
+
+def test_get_metadata_multi_value(mocker: MockerFixture) -> None:
+
+    msg = Message()
+    msg["Classifier"] = "Development Status :: 5 - Production/Stable"
+    msg["Classifier"] = "License :: OSI Approved :: MIT License"
+    msg["Classifier"] = "Programming Language :: Python :: 3"
+    mocker.patch("pipdeptree._models.package.metadata", return_value=msg)
+    dist = MagicMock(metadata={"Name": "foo"}, version="1.0")
+    result = DistPackage(dist).get_metadata("Classifier")
+    assert result == [
+        "Development Status :: 5 - Production/Stable",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3",
+    ]
+
+
+def test_get_metadata_values_with_multi_value(mocker: MockerFixture) -> None:
+
+    msg = Message()
+    msg["Classifier"] = "Development Status :: 5 - Production/Stable"
+    msg["Classifier"] = "License :: OSI Approved :: MIT License"
+    mocker.patch("pipdeptree._models.package.metadata", return_value=msg)
+    mocker.patch.object(Package, "licenses", return_value="(MIT)")
+    dist = MagicMock(metadata={"Name": "foo"}, version="1.0")
+    result = DistPackage(dist).get_metadata_values(["license", "Classifier"])
+    assert result == [
+        "MIT License",
+        "Development Status :: 5 - Production/Stable",
+        "License :: OSI Approved :: MIT License",
+    ]
+
+
+def test_get_metadata_dict_with_multi_value(mocker: MockerFixture) -> None:
+
+    msg = Message()
+    msg["Classifier"] = "Development Status :: 5 - Production/Stable"
+    msg["Classifier"] = "License :: OSI Approved :: MIT License"
+    mocker.patch("pipdeptree._models.package.metadata", return_value=msg)
+    dist = MagicMock(metadata={"Name": "foo"}, version="1.0")
+    result = DistPackage(dist).get_metadata_dict(["Classifier"])
+    assert result == {
+        "Classifier": [
+            "Development Status :: 5 - Production/Stable",
+            "License :: OSI Approved :: MIT License",
+        ],
+    }
 
 
 def test_get_metadata_values(mocker: MockerFixture) -> None:

--- a/tests/_models/test_package.py
+++ b/tests/_models/test_package.py
@@ -466,3 +466,19 @@ def test_get_metadata_values(mocker: MockerFixture) -> None:
     mocker.patch.object(Package, "licenses", return_value="(MIT)")
     dist = MagicMock(metadata={"Name": "foo"}, version="1.0")
     assert DistPackage(dist).get_metadata_values(["license"]) == ["MIT License"]
+
+
+def test_get_metadata_values_escapes_newlines(mocker: MockerFixture) -> None:
+    msg = Message()
+    msg["Description"] = "A long\nmulti-line\ndescription"
+    mocker.patch("pipdeptree._models.package.metadata", return_value=msg)
+    dist = MagicMock(metadata={"Name": "foo"}, version="1.0")
+    assert DistPackage(dist).get_metadata_values(["Description"]) == [r"A long\nmulti-line\ndescription"]
+
+
+def test_get_metadata_dict_preserves_newlines(mocker: MockerFixture) -> None:
+    msg = Message()
+    msg["Description"] = "A long\nmulti-line\ndescription"
+    mocker.patch("pipdeptree._models.package.metadata", return_value=msg)
+    dist = MagicMock(metadata={"Name": "foo"}, version="1.0")
+    assert DistPackage(dist).get_metadata_dict(["Description"]) == {"Description": "A long\nmulti-line\ndescription"}

--- a/tests/render/test_graphviz.py
+++ b/tests/render/test_graphviz.py
@@ -6,14 +6,19 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from pipdeptree._render.graphviz import dump_graphviz, print_graphviz
+from pipdeptree._cli import RenderContext
+from pipdeptree._models import PackageDAG
+from pipdeptree._models.package import Package
+from pipdeptree._render.graphviz import dump_graphviz, print_graphviz, render_graphviz
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
     from pathlib import Path
+    from unittest.mock import Mock
 
     from pytest_mock import MockerFixture
 
-    from pipdeptree._models import PackageDAG
+    from tests.our_types import MockGraph
 
 
 def test_render_dot(
@@ -189,3 +194,31 @@ def test_print_graphviz_binary_non_tty_handling(mocker: MockerFixture, example_d
     # Verify that binary data was written to stdout
     mock_fdopen.assert_called_once_with(1, "wb")
     mock_bytestream.write.assert_called_once_with(output)
+
+
+def test_render_graphviz_with_metadata(
+    mock_pkgs: Callable[[MockGraph], Iterator[Mock]],
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph: MockGraph = {("a", "1.0"): [("b", [(">=", "1.0")])], ("b", "1.0"): []}
+    dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
+    monkeypatch.setattr(Package, "licenses", lambda _: "(MIT)")
+    ctx = RenderContext(metadata=["license"])
+    render_graphviz(dag, output_format="dot", reverse=False, context=ctx)
+    output = capsys.readouterr().out
+    assert "MIT License" in output
+
+
+def test_render_graphviz_reversed_with_metadata(
+    mock_pkgs: Callable[[MockGraph], Iterator[Mock]],
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph: MockGraph = {("a", "1.0"): [("b", [(">=", "1.0")])], ("b", "1.0"): []}
+    dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
+    monkeypatch.setattr(Package, "licenses", lambda _: "(MIT)")
+    ctx = RenderContext(metadata=["license"])
+    render_graphviz(dag.reverse(), output_format="dot", reverse=True, context=ctx)
+    output = capsys.readouterr().out
+    assert "MIT License" in output

--- a/tests/render/test_json.py
+++ b/tests/render/test_json.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from textwrap import dedent
 from typing import TYPE_CHECKING
 
+from pipdeptree._cli import RenderContext
+from pipdeptree._computed import ComputedValues
 from pipdeptree._models.dag import PackageDAG
+from pipdeptree._models.package import Package
 from pipdeptree._render.json import render_json
 
 if TYPE_CHECKING:
@@ -11,6 +14,7 @@ if TYPE_CHECKING:
     from unittest.mock import Mock
 
     import pytest
+    from pytest_mock import MockerFixture
 
     from tests.conftest import MockDistMaker
     from tests.our_types import MockGraph
@@ -66,3 +70,32 @@ def test_render_json_with_extras(capsys: pytest.CaptureFixture[str], make_mock_d
     render_json(dag)
     output = capsys.readouterr().out
     assert '"extra": "dev"' in output
+
+
+def test_render_json_with_metadata(
+    mock_pkgs: Callable[[MockGraph], Iterator[Mock]],
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph: MockGraph = {("a", "1.0"): []}
+    dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
+    monkeypatch.setattr(Package, "get_metadata_dict", lambda _, fields: dict.fromkeys(fields, "test"))
+    render_json(dag, context=RenderContext(metadata=["license"]))
+    output = capsys.readouterr().out
+    assert '"metadata"' in output
+    assert '"license": "test"' in output
+
+
+def test_render_json_with_computed(
+    mock_pkgs: Callable[[MockGraph], Iterator[Mock]],
+    capsys: pytest.CaptureFixture[str],
+    mocker: MockerFixture,
+) -> None:
+    graph: MockGraph = {("a", "1.0"): []}
+    dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
+    mocker.patch("pipdeptree._computed.distribution")
+    mocker.patch.object(ComputedValues, "_file_size", return_value=100)
+    render_json(dag, context=RenderContext(computed=["size"]))
+    output = capsys.readouterr().out
+    assert '"computed"' in output
+    assert '"size"' in output

--- a/tests/render/test_json_tree.py
+++ b/tests/render/test_json_tree.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
 
 import pytest
 
+from pipdeptree._cli import RenderContext
 from pipdeptree._models.dag import PackageDAG
+from pipdeptree._models.package import Package
 from pipdeptree._render.json_tree import render_json_tree
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
     from unittest.mock import Mock
+
+    from pytest_mock import MockerFixture
 
     from tests.our_types import MockGraph
 
@@ -37,3 +42,31 @@ def test_json_tree_given_req_package_with_version_spec(
 
     captured = capsys.readouterr()
     assert captured.out.find(expected_version_spec) != -1
+
+
+def test_json_tree_with_metadata(
+    mock_pkgs: Callable[[MockGraph], Iterator[Mock]],
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph: MockGraph = {("a", "1.0"): []}
+    dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
+    monkeypatch.setattr(Package, "get_metadata_dict", lambda _, fields: dict.fromkeys(fields, "test"))
+    render_json_tree(dag, context=RenderContext(metadata=["license"]))
+    output = capsys.readouterr().out
+    assert '"metadata"' in output
+    assert '"license": "test"' in output
+
+
+def test_json_tree_with_computed(
+    mock_pkgs: Callable[[MockGraph], Iterator[Mock]],
+    capsys: pytest.CaptureFixture[str],
+    mocker: MockerFixture,
+) -> None:
+    graph: MockGraph = {("a", "1.0"): []}
+    dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
+    mocker.patch("pipdeptree._computed.distribution", return_value=MagicMock(files=None))
+    render_json_tree(dag, context=RenderContext(computed=["size"]))
+    output = capsys.readouterr().out
+    assert '"computed"' in output
+    assert '"size": "0 B"' in output

--- a/tests/render/test_mermaid.py
+++ b/tests/render/test_mermaid.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from textwrap import dedent, indent
 from typing import TYPE_CHECKING
 
+from pipdeptree._cli import RenderContext
 from pipdeptree._models import PackageDAG
+from pipdeptree._models.package import Package
 from pipdeptree._render.mermaid import render_mermaid
 
 if TYPE_CHECKING:
@@ -104,3 +106,31 @@ def test_mermaid_reserved_ids(
         """,
         ).rstrip()
     )
+
+
+def test_mermaid_with_metadata(
+    mock_pkgs: Callable[[MockGraph], Iterator[Mock]],
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph: MockGraph = {("a", "1.0"): [("b", [(">=", "1.0")])], ("b", "1.0"): []}
+    dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
+    monkeypatch.setattr(Package, "licenses", lambda _: "(MIT)")
+    ctx = RenderContext(metadata=["license"])
+    render_mermaid(dag, context=ctx)
+    output = capsys.readouterr().out
+    assert "MIT License" in output
+
+
+def test_mermaid_reversed_with_metadata(
+    mock_pkgs: Callable[[MockGraph], Iterator[Mock]],
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph: MockGraph = {("a", "1.0"): [("b", [(">=", "1.0")])], ("b", "1.0"): []}
+    dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
+    monkeypatch.setattr(Package, "licenses", lambda _: "(MIT)")
+    ctx = RenderContext(metadata=["license"])
+    render_mermaid(dag.reverse(), context=ctx)
+    output = capsys.readouterr().out
+    assert "MIT License" in output

--- a/tests/render/test_render.py
+++ b/tests/render/test_render.py
@@ -12,53 +12,68 @@ from pipdeptree._cli import RenderContext
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
-_EMPTY_CONTEXT = RenderContext()
 
-
-@pytest.mark.parametrize("option", [["--json"], ["--output", "json"]])
+@pytest.mark.parametrize(
+    "option", [pytest.param(["--json"], id="flag"), pytest.param(["--output", "json"], id="output")]
+)
 def test_json_routing(option: list[str], mocker: MockerFixture) -> None:
     render = mocker.patch("pipdeptree._render.render_json")
     main(option)
-    render.assert_called_once_with(ANY, context=_EMPTY_CONTEXT)
+    render.assert_called_once_with(ANY, context=RenderContext())
 
 
-@pytest.mark.parametrize("option", [["--json-tree"], ["--output", "json-tree"]])
+@pytest.mark.parametrize(
+    "option",
+    [pytest.param(["--json-tree"], id="flag"), pytest.param(["--output", "json-tree"], id="output")],
+)
 def test_json_tree_routing(option: list[str], mocker: MockerFixture) -> None:
     render = mocker.patch("pipdeptree._render.render_json_tree")
     main(option)
-    render.assert_called_once_with(ANY, context=_EMPTY_CONTEXT)
+    render.assert_called_once_with(ANY, context=RenderContext())
 
 
-@pytest.mark.parametrize("option", [["--mermaid"], ["--output", "mermaid"]])
+@pytest.mark.parametrize(
+    "option",
+    [pytest.param(["--mermaid"], id="flag"), pytest.param(["--output", "mermaid"], id="output")],
+)
 def test_mermaid_routing(option: list[str], mocker: MockerFixture) -> None:
     render = mocker.patch("pipdeptree._render.render_mermaid")
     main(option)
-    render.assert_called_once_with(ANY, context=_EMPTY_CONTEXT)
+    render.assert_called_once_with(ANY, context=RenderContext())
 
 
-@pytest.mark.parametrize("option", [["--graph-output", "dot"], ["--output", "graphviz-dot"]])
+@pytest.mark.parametrize(
+    "option",
+    [pytest.param(["--graph-output", "dot"], id="flag"), pytest.param(["--output", "graphviz-dot"], id="output")],
+)
 def test_grahpviz_routing(option: list[str], mocker: MockerFixture) -> None:
     render = mocker.patch("pipdeptree._render.render_graphviz")
     main(option)
-    render.assert_called_once_with(ANY, output_format="dot", reverse=False, max_depth=inf, context=_EMPTY_CONTEXT)
+    render.assert_called_once_with(ANY, output_format="dot", reverse=False, max_depth=inf, context=RenderContext())
 
 
-@pytest.mark.parametrize("option", [[], ["--output", "text"]])
+@pytest.mark.parametrize(
+    "option",
+    [pytest.param([], id="default"), pytest.param(["--output", "text"], id="output")],
+)
 def test_text_routing(option: list[str], mocker: MockerFixture) -> None:
     render = mocker.patch("pipdeptree._render.render_text")
     main(option)
-    render.assert_called_once_with(ANY, encoding="utf-8", max_depth=inf, list_all=False, context=_EMPTY_CONTEXT)
+    render.assert_called_once_with(ANY, encoding="utf-8", max_depth=inf, list_all=False, context=RenderContext())
 
 
-@pytest.mark.parametrize("option", [["--freeze"], ["--output", "freeze"]])
+@pytest.mark.parametrize(
+    "option",
+    [pytest.param(["--freeze"], id="flag"), pytest.param(["--output", "freeze"], id="output")],
+)
 def test_freeze_routing(option: list[str], mocker: MockerFixture) -> None:
     render = mocker.patch("pipdeptree._render.render_freeze")
     main(option)
     render.assert_called_once_with(ANY, max_depth=inf, list_all=False)
 
 
-@pytest.mark.parametrize("option", [["--output", "rich"]])
+@pytest.mark.parametrize("option", [pytest.param(["--output", "rich"], id="output")])
 def test_rich_routing(option: list[str], mocker: MockerFixture) -> None:
     render = mocker.patch("pipdeptree._render.render_rich_text")
     main(option)
-    render.assert_called_once_with(ANY, max_depth=inf, list_all=False, context=_EMPTY_CONTEXT)
+    render.assert_called_once_with(ANY, max_depth=inf, list_all=False, context=RenderContext())

--- a/tests/render/test_render.py
+++ b/tests/render/test_render.py
@@ -7,44 +7,47 @@ from unittest.mock import ANY
 import pytest
 
 from pipdeptree.__main__ import main
+from pipdeptree._cli import RenderContext
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
+
+_EMPTY_CONTEXT = RenderContext()
 
 
 @pytest.mark.parametrize("option", [["--json"], ["--output", "json"]])
 def test_json_routing(option: list[str], mocker: MockerFixture) -> None:
     render = mocker.patch("pipdeptree._render.render_json")
     main(option)
-    render.assert_called_once_with(ANY)
+    render.assert_called_once_with(ANY, context=_EMPTY_CONTEXT)
 
 
 @pytest.mark.parametrize("option", [["--json-tree"], ["--output", "json-tree"]])
 def test_json_tree_routing(option: list[str], mocker: MockerFixture) -> None:
     render = mocker.patch("pipdeptree._render.render_json_tree")
     main(option)
-    render.assert_called_once_with(ANY)
+    render.assert_called_once_with(ANY, context=_EMPTY_CONTEXT)
 
 
 @pytest.mark.parametrize("option", [["--mermaid"], ["--output", "mermaid"]])
 def test_mermaid_routing(option: list[str], mocker: MockerFixture) -> None:
     render = mocker.patch("pipdeptree._render.render_mermaid")
     main(option)
-    render.assert_called_once_with(ANY)
+    render.assert_called_once_with(ANY, context=_EMPTY_CONTEXT)
 
 
 @pytest.mark.parametrize("option", [["--graph-output", "dot"], ["--output", "graphviz-dot"]])
 def test_grahpviz_routing(option: list[str], mocker: MockerFixture) -> None:
     render = mocker.patch("pipdeptree._render.render_graphviz")
     main(option)
-    render.assert_called_once_with(ANY, output_format="dot", reverse=False, max_depth=inf)
+    render.assert_called_once_with(ANY, output_format="dot", reverse=False, max_depth=inf, context=_EMPTY_CONTEXT)
 
 
 @pytest.mark.parametrize("option", [[], ["--output", "text"]])
 def test_text_routing(option: list[str], mocker: MockerFixture) -> None:
     render = mocker.patch("pipdeptree._render.render_text")
     main(option)
-    render.assert_called_once_with(ANY, encoding="utf-8", max_depth=inf, list_all=False, include_license=False)
+    render.assert_called_once_with(ANY, encoding="utf-8", max_depth=inf, list_all=False, context=_EMPTY_CONTEXT)
 
 
 @pytest.mark.parametrize("option", [["--freeze"], ["--output", "freeze"]])
@@ -58,4 +61,4 @@ def test_freeze_routing(option: list[str], mocker: MockerFixture) -> None:
 def test_rich_routing(option: list[str], mocker: MockerFixture) -> None:
     render = mocker.patch("pipdeptree._render.render_rich_text")
     main(option)
-    render.assert_called_once_with(ANY, max_depth=inf, list_all=False, include_license=False)
+    render.assert_called_once_with(ANY, max_depth=inf, list_all=False, context=_EMPTY_CONTEXT)

--- a/tests/render/test_rich_text.py
+++ b/tests/render/test_rich_text.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from pipdeptree._cli import RenderContext
 from pipdeptree._models import PackageDAG
 from pipdeptree._models.package import Package
 from pipdeptree._render.rich_text import render_rich_text
@@ -73,10 +74,10 @@ def test_render_rich_text_with_license_info(
     dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
     monkeypatch.setattr(Package, "licenses", lambda _: "(TEST)")
 
-    render_rich_text(dag, max_depth=float("inf"), include_license=True)
+    render_rich_text(dag, max_depth=float("inf"), context=RenderContext(metadata=["license"]))
     output = capsys.readouterr().out
     assert "a==3.4.0" in output
-    assert "(TEST)" in output
+    assert "[TEST]" in output
 
 
 def test_render_rich_text_with_extras(capsys: pytest.CaptureFixture[str], make_mock_dist: MockDistMaker) -> None:

--- a/tests/render/test_rich_text.py
+++ b/tests/render/test_rich_text.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import sys
+from email.message import Message
 from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -172,3 +174,58 @@ def test_render_rich_text_dependency_status(
     output = capsys.readouterr().out
     for item in expected:
         assert item in output
+
+
+def test_render_rich_text_multi_value_metadata(
+    mock_pkgs: Callable[[MockGraph], Iterator[Mock]],
+    capsys: pytest.CaptureFixture[str],
+    mocker: MockerFixture,
+) -> None:
+    pytest.importorskip("rich")
+    graph: MockGraph = {("a", "1.0.0"): []}
+    dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
+    msg = Message()
+    msg["Classifier"] = "Development Status :: 5 - Production/Stable"
+    msg["Classifier"] = "License :: OSI Approved :: MIT License"
+    mocker.patch("pipdeptree._models.package.metadata", return_value=msg)
+
+    render_rich_text(dag, max_depth=float("inf"), context=RenderContext(metadata=["Classifier"]))
+    output = capsys.readouterr().out
+    assert "Classifier" in output
+    assert "Development Status :: 5 - Production/Stable" in output
+    assert "License :: OSI Approved :: MIT License" in output
+
+
+def test_render_rich_text_multiline_metadata(
+    mock_pkgs: Callable[[MockGraph], Iterator[Mock]],
+    capsys: pytest.CaptureFixture[str],
+    mocker: MockerFixture,
+) -> None:
+    pytest.importorskip("rich")
+    graph: MockGraph = {("a", "1.0.0"): []}
+    dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
+    msg = Message()
+    msg["Description"] = "Line one\nLine two\nLine three"
+    mocker.patch("pipdeptree._models.package.metadata", return_value=msg)
+
+    render_rich_text(dag, max_depth=float("inf"), context=RenderContext(metadata=["Description"]))
+    output = capsys.readouterr().out
+    assert "Description" in output
+    assert "Line one" in output
+    assert "Line two" in output
+
+
+def test_render_rich_text_unique_dep_icon(
+    mock_pkgs: Callable[[MockGraph], Iterator[Mock]],
+    capsys: pytest.CaptureFixture[str],
+    mocker: MockerFixture,
+) -> None:
+    pytest.importorskip("rich")
+    # b is only used by a, so it's a unique dep
+    graph: MockGraph = {("a", "1.0.0"): [("b", [(">=", "1.0")])], ("b", "1.0.0"): []}
+    dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
+    mocker.patch("pipdeptree._computed.distribution", return_value=MagicMock(files=None))
+    ctx = RenderContext(computed=["unique-deps-count"])
+    render_rich_text(dag, max_depth=float("inf"), context=ctx)
+    output = capsys.readouterr().out
+    assert "⭐" in output

--- a/tests/render/test_rich_text.py
+++ b/tests/render/test_rich_text.py
@@ -30,7 +30,7 @@ def test_render_rich_text_missing_import(mocker: MockerFixture, example_dag: Pac
 @pytest.mark.parametrize(
     ("list_all", "expected"),
     [
-        pytest.param(True, ["a==3.4.0", "b==2.3.1", "c==5.10.0", "✓", "required:", "installed:"], id="list-all"),
+        pytest.param(True, ["a==3.4.0", "b==2.3.1", "c==5.10.0", "required:", "installed:"], id="list-all"),
         pytest.param(False, ["a==3.4.0", "g==6.8.3rc1"], id="not-list-all"),
     ],
 )
@@ -77,7 +77,7 @@ def test_render_rich_text_with_license_info(
     render_rich_text(dag, max_depth=float("inf"), context=RenderContext(metadata=["license"]))
     output = capsys.readouterr().out
     assert "a==3.4.0" in output
-    assert "[TEST]" in output
+    assert "(TEST License)" in output
 
 
 def test_render_rich_text_with_extras(capsys: pytest.CaptureFixture[str], make_mock_dist: MockDistMaker) -> None:
@@ -129,7 +129,7 @@ def test_render_rich_text_with_circular_deps(
     dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
     render_rich_text(dag, max_depth=float("inf"))
     output = capsys.readouterr().out
-    expected = ["a==1.0.0", "b==1.0.0", "✓"]
+    expected = ["a==1.0.0", "b==1.0.0"]
     for item in expected:
         assert item in output
 
@@ -155,7 +155,7 @@ def test_render_rich_text_with_circular_deps(
                 ("a", "1.0.0"): [("b", [(">=", "1.0.0"), ("<", "2.0.0")])],
                 ("b", "1.5.0"): [],
             },
-            ["✓", "b", ">=1.0.0,<2.0.0", "1.5.0"],
+            ["b", ">=1.0.0,<2.0.0", "1.5.0"],
             id="satisfied",
         ),
     ],

--- a/tests/render/test_text.py
+++ b/tests/render/test_text.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from pipdeptree._cli import RenderContext
 from pipdeptree._models import PackageDAG
 from pipdeptree._models.package import Package
 from pipdeptree._render.text import render_text
@@ -478,19 +479,19 @@ def test_render_text_list_all_and_packages_options_used(
         (
             "utf-8",
             [
-                "a==3.4.0 (TEST)",
-                "└── c [required: ==1.0.0, installed: 1.0.0]",
-                "b==2.3.1 (TEST)",
-                "c==1.0.0 (TEST)",
+                "a==3.4.0 [TEST]",
+                "└── c [required: ==1.0.0, installed: 1.0.0] [TEST]",
+                "b==2.3.1 [TEST]",
+                "c==1.0.0 [TEST]",
             ],
         ),
         (
             "ascii",
             [
-                "a==3.4.0 (TEST)",
-                "  - c [required: ==1.0.0, installed: 1.0.0]",
-                "b==2.3.1 (TEST)",
-                "c==1.0.0 (TEST)",
+                "a==3.4.0 [TEST]",
+                "  - c [required: ==1.0.0, installed: 1.0.0] [TEST]",
+                "b==2.3.1 [TEST]",
+                "c==1.0.0 [TEST]",
             ],
         ),
     ],
@@ -510,7 +511,7 @@ def test_render_text_with_license_info(
     dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
     monkeypatch.setattr(Package, "licenses", lambda _: "(TEST)")
 
-    render_text(dag, max_depth=float("inf"), encoding=encoding, include_license=True)
+    render_text(dag, max_depth=float("inf"), encoding=encoding, context=RenderContext(metadata=["license"]))
     captured = capsys.readouterr()
     assert "\n".join(expected_output).strip() == captured.out.strip()
 
@@ -521,25 +522,25 @@ def test_render_text_with_license_info(
         (
             "utf-8",
             [
-                "a==3.4.0 (TEST)",
-                "b==2.3.1 (TEST)",
-                "└── a==3.4.0 [requires: b==2.3.1]",
-                "c==1.0.0 (TEST)",
-                "├── a==3.4.0 [requires: c==1.0.0]",
-                "└── b==2.3.1 [requires: c==1.0.0]",
-                "    └── a==3.4.0 [requires: b==2.3.1]",
+                "a==3.4.0 [TEST]",
+                "b==2.3.1 [TEST]",
+                "└── a==3.4.0 [requires: b==2.3.1] [TEST]",
+                "c==1.0.0 [TEST]",
+                "├── a==3.4.0 [requires: c==1.0.0] [TEST]",
+                "└── b==2.3.1 [requires: c==1.0.0] [TEST]",
+                "    └── a==3.4.0 [requires: b==2.3.1] [TEST]",
             ],
         ),
         (
             "ascii",
             [
-                "a==3.4.0 (TEST)",
-                "b==2.3.1 (TEST)",
-                "  - a==3.4.0 [requires: b==2.3.1]",
-                "c==1.0.0 (TEST)",
-                "  - a==3.4.0 [requires: c==1.0.0]",
-                "  - b==2.3.1 [requires: c==1.0.0]",
-                "    - a==3.4.0 [requires: b==2.3.1]",
+                "a==3.4.0 [TEST]",
+                "b==2.3.1 [TEST]",
+                "  - a==3.4.0 [requires: b==2.3.1] [TEST]",
+                "c==1.0.0 [TEST]",
+                "  - a==3.4.0 [requires: c==1.0.0] [TEST]",
+                "  - b==2.3.1 [requires: c==1.0.0] [TEST]",
+                "    - a==3.4.0 [requires: b==2.3.1] [TEST]",
             ],
         ),
     ],
@@ -560,7 +561,7 @@ def test_render_text_with_license_info_and_reversed_tree(
     dag = dag.reverse()
     monkeypatch.setattr(Package, "licenses", lambda _: "(TEST)")
 
-    render_text(dag, max_depth=float("inf"), encoding=encoding, include_license=True)
+    render_text(dag, max_depth=float("inf"), encoding=encoding, context=RenderContext(metadata=["license"]))
     captured = capsys.readouterr()
     assert "\n".join(expected_output).strip() == captured.out.strip()
 

--- a/tests/render/test_text.py
+++ b/tests/render/test_text.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -12,6 +13,8 @@ from pipdeptree._render.text import render_text
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
     from unittest.mock import Mock
+
+    from pytest_mock import MockerFixture
 
     from tests.conftest import MockDistMaker
     from tests.our_types import MockGraph
@@ -479,19 +482,19 @@ def test_render_text_list_all_and_packages_options_used(
         (
             "utf-8",
             [
-                "a==3.4.0 [TEST]",
-                "└── c [required: ==1.0.0, installed: 1.0.0] [TEST]",
-                "b==2.3.1 [TEST]",
-                "c==1.0.0 [TEST]",
+                "a==3.4.0 (TEST License)",
+                "└── c [required: ==1.0.0, installed: 1.0.0] (TEST License)",
+                "b==2.3.1 (TEST License)",
+                "c==1.0.0 (TEST License)",
             ],
         ),
         (
             "ascii",
             [
-                "a==3.4.0 [TEST]",
-                "  - c [required: ==1.0.0, installed: 1.0.0] [TEST]",
-                "b==2.3.1 [TEST]",
-                "c==1.0.0 [TEST]",
+                "a==3.4.0 (TEST License)",
+                "  - c [required: ==1.0.0, installed: 1.0.0] (TEST License)",
+                "b==2.3.1 (TEST License)",
+                "c==1.0.0 (TEST License)",
             ],
         ),
     ],
@@ -509,7 +512,7 @@ def test_render_text_with_license_info(
         ("c", "1.0.0"): [],
     }
     dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
-    monkeypatch.setattr(Package, "licenses", lambda _: "(TEST)")
+    monkeypatch.setattr(Package, "licenses", lambda _: "(TEST License)")
 
     render_text(dag, max_depth=float("inf"), encoding=encoding, context=RenderContext(metadata=["license"]))
     captured = capsys.readouterr()
@@ -522,25 +525,25 @@ def test_render_text_with_license_info(
         (
             "utf-8",
             [
-                "a==3.4.0 [TEST]",
-                "b==2.3.1 [TEST]",
-                "└── a==3.4.0 [requires: b==2.3.1] [TEST]",
-                "c==1.0.0 [TEST]",
-                "├── a==3.4.0 [requires: c==1.0.0] [TEST]",
-                "└── b==2.3.1 [requires: c==1.0.0] [TEST]",
-                "    └── a==3.4.0 [requires: b==2.3.1] [TEST]",
+                "a==3.4.0 (TEST License)",
+                "b==2.3.1 (TEST License)",
+                "└── a==3.4.0 [requires: b==2.3.1] (TEST License)",
+                "c==1.0.0 (TEST License)",
+                "├── a==3.4.0 [requires: c==1.0.0] (TEST License)",
+                "└── b==2.3.1 [requires: c==1.0.0] (TEST License)",
+                "    └── a==3.4.0 [requires: b==2.3.1] (TEST License)",
             ],
         ),
         (
             "ascii",
             [
-                "a==3.4.0 [TEST]",
-                "b==2.3.1 [TEST]",
-                "  - a==3.4.0 [requires: b==2.3.1] [TEST]",
-                "c==1.0.0 [TEST]",
-                "  - a==3.4.0 [requires: c==1.0.0] [TEST]",
-                "  - b==2.3.1 [requires: c==1.0.0] [TEST]",
-                "    - a==3.4.0 [requires: b==2.3.1] [TEST]",
+                "a==3.4.0 (TEST License)",
+                "b==2.3.1 (TEST License)",
+                "  - a==3.4.0 [requires: b==2.3.1] (TEST License)",
+                "c==1.0.0 (TEST License)",
+                "  - a==3.4.0 [requires: c==1.0.0] (TEST License)",
+                "  - b==2.3.1 [requires: c==1.0.0] (TEST License)",
+                "    - a==3.4.0 [requires: b==2.3.1] (TEST License)",
             ],
         ),
     ],
@@ -559,11 +562,29 @@ def test_render_text_with_license_info_and_reversed_tree(
     }
     dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
     dag = dag.reverse()
-    monkeypatch.setattr(Package, "licenses", lambda _: "(TEST)")
+    monkeypatch.setattr(Package, "licenses", lambda _: "(TEST License)")
 
     render_text(dag, max_depth=float("inf"), encoding=encoding, context=RenderContext(metadata=["license"]))
     captured = capsys.readouterr()
     assert "\n".join(expected_output).strip() == captured.out.strip()
+
+
+def test_render_text_with_computed(
+    mock_pkgs: Callable[[MockGraph], Iterator[Mock]],
+    capsys: pytest.CaptureFixture[str],
+    mocker: MockerFixture,
+) -> None:
+    graph: MockGraph = {
+        ("a", "1.0"): [("b", [(">=", "1.0")])],
+        ("b", "1.0"): [],
+    }
+    dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
+    mocker.patch("pipdeptree._computed.distribution", return_value=MagicMock(files=None))
+    render_text(
+        dag, max_depth=float("inf"), encoding="utf-8", context=RenderContext(computed=["size", "unique-deps-count"])
+    )
+    output = capsys.readouterr().out
+    assert "(0 B, 1 unique deps)" in output
 
 
 @pytest.mark.parametrize("encoding", [pytest.param("utf-8", id="unicode"), pytest.param("ascii", id="simple")])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -56,13 +56,39 @@ def test_get_options_output_format_that_does_not_exist(capsys: pytest.CaptureFix
     assert 'i-dont-exist" is not a known output format.' in err
 
 
-def test_get_options_license_and_freeze_together_not_supported(capsys: pytest.CaptureFixture[str]) -> None:
-    with pytest.raises(SystemExit, match="2"):
-        get_options(["--license", "--freeze"])
+def test_get_options_license_deprecated() -> None:
+    with pytest.warns(DeprecationWarning, match="--license is deprecated"):
+        options = get_options(["--license"])
+    assert options.metadata == ["license"]
+    assert options.context.metadata == ["license"]
 
+
+def test_get_options_license_and_metadata_license_conflict(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit, match="2"):
+        get_options(["--license", "--metadata", "license"])
     out, err = capsys.readouterr()
     assert not out
-    assert "cannot use --license with --freeze" in err
+    assert "cannot use --license with --metadata license" in err
+
+
+def test_get_options_metadata() -> None:
+    options = get_options(["--metadata", "license,summary"])
+    assert options.metadata == ["license", "summary"]
+    assert options.context.metadata == ["license", "summary"]
+
+
+def test_get_options_computed() -> None:
+    options = get_options(["--computed", "size,unique-deps-count"])
+    assert options.computed == ["size", "unique-deps-count"]
+    assert options.context.computed == ["size", "unique-deps-count"]
+
+
+def test_get_options_invalid_computed(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit, match="2"):
+        get_options(["--computed", "invalid-field"])
+    out, err = capsys.readouterr()
+    assert not out
+    assert "invalid --computed values: invalid-field" in err
 
 
 @pytest.mark.parametrize(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -77,6 +77,12 @@ def test_get_options_metadata() -> None:
     assert options.context.metadata == ["license", "summary"]
 
 
+def test_get_options_metadata_dedup() -> None:
+    options = get_options(["--metadata", "name,name"])
+    assert options.metadata == ["name"]
+    assert options.context.metadata == ["name"]
+
+
 def test_get_options_computed() -> None:
     options = get_options(["--computed", "size,unique-deps-count"])
     assert options.computed == ["size", "unique-deps-count"]

--- a/tests/test_computed.py
+++ b/tests/test_computed.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pipdeptree._computed import (
+    _format_size,
+    compute_installed_size_bytes,
+    compute_unique_deps,
+    format_computed_display,
+    get_computed_values,
+)
+from pipdeptree._models import PackageDAG
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+    from pathlib import Path
+    from unittest.mock import Mock
+
+    from tests.our_types import MockGraph
+
+
+@pytest.mark.parametrize(
+    ("size_bytes", "expected"),
+    [
+        pytest.param(0, "0 B", id="zero"),
+        pytest.param(512, "512 B", id="bytes"),
+        pytest.param(1024, "1.0 KB", id="kilobytes"),
+        pytest.param(1536, "1.5 KB", id="fractional-kb"),
+        pytest.param(1048576, "1.0 MB", id="megabytes"),
+        pytest.param(1073741824, "1.0 GB", id="gigabytes"),
+    ],
+)
+def test_format_size(size_bytes: int, expected: str) -> None:
+    assert _format_size(size_bytes) == expected
+
+
+def test_compute_installed_size_bytes_no_files() -> None:
+    mock_dist = MagicMock()
+    mock_dist.files = None
+    with patch("pipdeptree._computed.distribution", return_value=mock_dist):
+        assert compute_installed_size_bytes("some-pkg") is None
+
+
+def test_compute_installed_size_bytes_with_files(tmp_path: Path) -> None:
+    (tmp_path / "file1.py").write_text("x" * 100)
+    (tmp_path / "file2.py").write_text("y" * 200)
+
+    mock_dist = MagicMock()
+    mock_dist.files = ["file1.py", "file2.py"]
+    mock_dist.locate_file = lambda f: tmp_path / f
+    with patch("pipdeptree._computed.distribution", return_value=mock_dist):
+        assert compute_installed_size_bytes("some-pkg") == 300
+
+
+def test_compute_unique_deps(mock_pkgs: Callable[[MockGraph], Iterator[Mock]]) -> None:
+    graph: MockGraph = {
+        ("a", "1.0"): [("c", [(">=", "1.0")])],
+        ("b", "1.0"): [("d", [(">=", "1.0")])],
+        ("c", "1.0"): [],
+        ("d", "1.0"): [],
+    }
+    if dag := PackageDAG.from_pkgs(list(mock_pkgs(graph))):
+        assert compute_unique_deps("a", dag) == {"c"}
+        assert compute_unique_deps("b", dag) == {"d"}
+
+
+def test_compute_unique_deps_shared(mock_pkgs: Callable[[MockGraph], Iterator[Mock]]) -> None:
+    graph: MockGraph = {
+        ("a", "1.0"): [("c", [(">=", "1.0")])],
+        ("b", "1.0"): [("c", [(">=", "1.0")])],
+        ("c", "1.0"): [],
+    }
+    if dag := PackageDAG.from_pkgs(list(mock_pkgs(graph))):
+        assert compute_unique_deps("a", dag) == set()
+        assert compute_unique_deps("b", dag) == set()
+
+
+def test_get_computed_values_size_and_unique_deps(mock_pkgs: Callable[[MockGraph], Iterator[Mock]]) -> None:
+    graph: MockGraph = {
+        ("a", "1.0"): [("b", [(">=", "1.0")])],
+        ("b", "1.0"): [],
+    }
+    dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
+    with patch("pipdeptree._computed.compute_installed_size_bytes", return_value=100):
+        result = get_computed_values("a", ["size", "unique-deps-count", "unique-deps-names"], dag)
+    assert result == {"size": "100 B", "unique_deps_count": 1, "unique_deps_names": ["b"]}
+
+
+def test_get_computed_values_size_raw(mock_pkgs: Callable[[MockGraph], Iterator[Mock]]) -> None:
+    dag = PackageDAG.from_pkgs(list(mock_pkgs({("a", "1.0"): []})))
+    with patch("pipdeptree._computed.compute_installed_size_bytes", return_value=123456):
+        assert get_computed_values("a", ["size-raw"], dag) == {"size_raw": 123456}
+
+
+def test_get_computed_values_size_and_size_raw_computes_once(mock_pkgs: Callable[[MockGraph], Iterator[Mock]]) -> None:
+    dag = PackageDAG.from_pkgs(list(mock_pkgs({("a", "1.0"): []})))
+    with patch("pipdeptree._computed.compute_installed_size_bytes", return_value=2048) as mock_size:
+        result = get_computed_values("a", ["size", "size-raw"], dag)
+        mock_size.assert_called_once_with("a")
+    assert result == {"size": "2.0 KB", "size_raw": 2048}
+
+
+def test_get_computed_values_unique_deps_computes_once(mock_pkgs: Callable[[MockGraph], Iterator[Mock]]) -> None:
+    graph: MockGraph = {
+        ("a", "1.0"): [("b", [(">=", "1.0")])],
+        ("b", "1.0"): [],
+    }
+    dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
+    with patch("pipdeptree._computed.compute_unique_deps", return_value={"b"}) as mock_unique:
+        result = get_computed_values("a", ["unique-deps-count", "unique-deps-names"], dag)
+        mock_unique.assert_called_once_with("a", dag)
+    assert result == {"unique_deps_count": 1, "unique_deps_names": ["b"]}
+
+
+def test_format_computed_display_count_and_names(mock_pkgs: Callable[[MockGraph], Iterator[Mock]]) -> None:
+    graph: MockGraph = {
+        ("a", "1.0"): [("b", [(">=", "1.0")])],
+        ("b", "1.0"): [],
+    }
+    dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
+    with patch("pipdeptree._computed.compute_installed_size_bytes", return_value=100):
+        result = format_computed_display("a", ["size", "unique-deps-count", "unique-deps-names"], dag)
+    assert result == ["100 B", "1 unique deps", "unique: b"]
+
+
+def test_format_computed_display_hides_zero_unique_deps(mock_pkgs: Callable[[MockGraph], Iterator[Mock]]) -> None:
+    dag = PackageDAG.from_pkgs(list(mock_pkgs({("a", "1.0"): []})))
+    assert format_computed_display("a", ["unique-deps-count", "unique-deps-names"], dag) == []
+
+
+def test_format_computed_display_size_raw(mock_pkgs: Callable[[MockGraph], Iterator[Mock]]) -> None:
+    dag = PackageDAG.from_pkgs(list(mock_pkgs({("a", "1.0"): []})))
+    with patch("pipdeptree._computed.compute_installed_size_bytes", return_value=5000):
+        assert format_computed_display("a", ["size-raw"], dag) == ["5000"]

--- a/tests/test_computed.py
+++ b/tests/test_computed.py
@@ -1,17 +1,12 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
-from pipdeptree._computed import (
-    _format_size,
-    compute_installed_size_bytes,
-    compute_unique_deps,
-    format_computed_display,
-    get_computed_values,
-)
+from pipdeptree._cli import RenderContext
+from pipdeptree._computed import ComputedValues
 from pipdeptree._models import PackageDAG
 
 if TYPE_CHECKING:
@@ -19,11 +14,13 @@ if TYPE_CHECKING:
     from pathlib import Path
     from unittest.mock import Mock
 
+    from pytest_mock import MockerFixture
+
     from tests.our_types import MockGraph
 
 
 @pytest.mark.parametrize(
-    ("size_bytes", "expected"),
+    ("total_bytes", "expected"),
     [
         pytest.param(0, "0 B", id="zero"),
         pytest.param(512, "512 B", id="bytes"),
@@ -33,29 +30,46 @@ if TYPE_CHECKING:
         pytest.param(1073741824, "1.0 GB", id="gigabytes"),
     ],
 )
-def test_format_size(size_bytes: int, expected: str) -> None:
-    assert _format_size(size_bytes) == expected
+def test_size_formatting(total_bytes: int, expected: str, mocker: MockerFixture) -> None:
+    dag = MagicMock(spec=PackageDAG)
+    mocker.patch(
+        "pipdeptree._computed.distribution",
+        return_value=MagicMock(files=["f"], locate_file=lambda _: "/dev/null"),
+    )
+    mocker.patch.object(ComputedValues, "_file_size", return_value=total_bytes)
+    assert ComputedValues("pkg", dag).size == expected
 
 
-def test_compute_installed_size_bytes_no_files() -> None:
-    mock_dist = MagicMock()
-    mock_dist.files = None
-    with patch("pipdeptree._computed.distribution", return_value=mock_dist):
-        assert compute_installed_size_bytes("some-pkg") is None
+def test_size_bytes_no_files(mocker: MockerFixture) -> None:
+    dag = MagicMock(spec=PackageDAG)
+    mocker.patch("pipdeptree._computed.distribution", return_value=MagicMock(files=None))
+    assert ComputedValues("some-pkg", dag).size_bytes is None
 
 
-def test_compute_installed_size_bytes_with_files(tmp_path: Path) -> None:
+def test_size_bytes_with_files(tmp_path: Path, mocker: MockerFixture) -> None:
     (tmp_path / "file1.py").write_text("x" * 100)
     (tmp_path / "file2.py").write_text("y" * 200)
+    mocker.patch(
+        "pipdeptree._computed.distribution",
+        return_value=MagicMock(files=["file1.py", "file2.py"], locate_file=lambda f: tmp_path / f),
+    )
+    dag = MagicMock(spec=PackageDAG)
+    cv = ComputedValues("some-pkg", dag)
+    assert cv.size_bytes == 300
+    assert cv.size == "300 B"
+    assert cv.size_raw == 300
 
-    mock_dist = MagicMock()
-    mock_dist.files = ["file1.py", "file2.py"]
-    mock_dist.locate_file = lambda f: tmp_path / f
-    with patch("pipdeptree._computed.distribution", return_value=mock_dist):
-        assert compute_installed_size_bytes("some-pkg") == 300
+
+def test_size_bytes_missing_file_on_disk(mocker: MockerFixture) -> None:
+    dag = MagicMock(spec=PackageDAG)
+    mocker.patch(
+        "pipdeptree._computed.distribution",
+        return_value=MagicMock(files=["missing.py"], locate_file=lambda _: "/nonexistent/path"),
+    )
+    assert ComputedValues("pkg", dag).size_bytes == 0
 
 
-def test_compute_unique_deps(mock_pkgs: Callable[[MockGraph], Iterator[Mock]]) -> None:
+def test_unique_deps(mock_pkgs: Callable[[MockGraph], Iterator[Mock]]) -> None:
     graph: MockGraph = {
         ("a", "1.0"): [("c", [(">=", "1.0")])],
         ("b", "1.0"): [("d", [(">=", "1.0")])],
@@ -63,75 +77,170 @@ def test_compute_unique_deps(mock_pkgs: Callable[[MockGraph], Iterator[Mock]]) -
         ("d", "1.0"): [],
     }
     if dag := PackageDAG.from_pkgs(list(mock_pkgs(graph))):
-        assert compute_unique_deps("a", dag) == {"c"}
-        assert compute_unique_deps("b", dag) == {"d"}
+        assert ComputedValues("a", dag).unique_deps == {"c"}
+        assert ComputedValues("b", dag).unique_deps == {"d"}
 
 
-def test_compute_unique_deps_shared(mock_pkgs: Callable[[MockGraph], Iterator[Mock]]) -> None:
+def test_unique_deps_shared(mock_pkgs: Callable[[MockGraph], Iterator[Mock]]) -> None:
     graph: MockGraph = {
         ("a", "1.0"): [("c", [(">=", "1.0")])],
         ("b", "1.0"): [("c", [(">=", "1.0")])],
         ("c", "1.0"): [],
     }
     if dag := PackageDAG.from_pkgs(list(mock_pkgs(graph))):
-        assert compute_unique_deps("a", dag) == set()
-        assert compute_unique_deps("b", dag) == set()
+        assert ComputedValues("a", dag).unique_deps == set()
+        assert ComputedValues("b", dag).unique_deps == set()
 
 
-def test_get_computed_values_size_and_unique_deps(mock_pkgs: Callable[[MockGraph], Iterator[Mock]]) -> None:
+def test_unique_deps_size(mock_pkgs: Callable[[MockGraph], Iterator[Mock]], mocker: MockerFixture) -> None:
     graph: MockGraph = {
         ("a", "1.0"): [("b", [(">=", "1.0")])],
         ("b", "1.0"): [],
     }
     dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
-    with patch("pipdeptree._computed.compute_installed_size_bytes", return_value=100):
-        result = get_computed_values("a", ["size", "unique-deps-count", "unique-deps-names"], dag)
-    assert result == {"size": "100 B", "unique_deps_count": 1, "unique_deps_names": ["b"]}
+    mocker.patch(
+        "pipdeptree._computed.distribution",
+        return_value=MagicMock(files=["f"], locate_file=lambda _: "/dev/null"),
+    )
+    mocker.patch.object(ComputedValues, "_file_size", return_value=2048)
+    assert ComputedValues("a", dag).unique_deps_size == "2.0 KB"
 
 
-def test_get_computed_values_size_raw(mock_pkgs: Callable[[MockGraph], Iterator[Mock]]) -> None:
-    dag = PackageDAG.from_pkgs(list(mock_pkgs({("a", "1.0"): []})))
-    with patch("pipdeptree._computed.compute_installed_size_bytes", return_value=123456):
-        assert get_computed_values("a", ["size-raw"], dag) == {"size_raw": 123456}
+def test_unique_deps_count_matches_names(mock_pkgs: Callable[[MockGraph], Iterator[Mock]]) -> None:
+    dag = PackageDAG.from_pkgs(list(mock_pkgs({("a", "1.0"): [("b", [(">=", "1.0")])], ("b", "1.0"): []})))
+    cv = ComputedValues("a", dag)
+    assert cv.unique_deps_count == 1
+    assert cv.unique_deps_names == ["b"]
 
 
-def test_get_computed_values_size_and_size_raw_computes_once(mock_pkgs: Callable[[MockGraph], Iterator[Mock]]) -> None:
-    dag = PackageDAG.from_pkgs(list(mock_pkgs({("a", "1.0"): []})))
-    with patch("pipdeptree._computed.compute_installed_size_bytes", return_value=2048) as mock_size:
-        result = get_computed_values("a", ["size", "size-raw"], dag)
-        mock_size.assert_called_once_with("a")
-    assert result == {"size": "2.0 KB", "size_raw": 2048}
-
-
-def test_get_computed_values_unique_deps_computes_once(mock_pkgs: Callable[[MockGraph], Iterator[Mock]]) -> None:
+def test_as_dict(mock_pkgs: Callable[[MockGraph], Iterator[Mock]], mocker: MockerFixture) -> None:
     graph: MockGraph = {
         ("a", "1.0"): [("b", [(">=", "1.0")])],
         ("b", "1.0"): [],
     }
     dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
-    with patch("pipdeptree._computed.compute_unique_deps", return_value={"b"}) as mock_unique:
-        result = get_computed_values("a", ["unique-deps-count", "unique-deps-names"], dag)
-        mock_unique.assert_called_once_with("a", dag)
-    assert result == {"unique_deps_count": 1, "unique_deps_names": ["b"]}
+    mocker.patch("pipdeptree._computed.distribution", return_value=MagicMock(files=None))
+    assert ComputedValues("a", dag).as_dict(["size", "unique-deps-count", "unique-deps-names"]) == {
+        "size": "0 B",
+        "unique_deps_count": 1,
+        "unique_deps_names": ["b"],
+    }
 
 
-def test_format_computed_display_count_and_names(mock_pkgs: Callable[[MockGraph], Iterator[Mock]]) -> None:
+def test_as_dict_size_raw(mock_pkgs: Callable[[MockGraph], Iterator[Mock]], mocker: MockerFixture) -> None:
+    dag = PackageDAG.from_pkgs(list(mock_pkgs({("a", "1.0"): []})))
+    mocker.patch(
+        "pipdeptree._computed.distribution",
+        return_value=MagicMock(files=["f"], locate_file=lambda _: "/dev/null"),
+    )
+    mocker.patch.object(ComputedValues, "_file_size", return_value=123456)
+    assert ComputedValues("a", dag).as_dict(["size-raw"]) == {"size_raw": 123456}
+
+
+def test_as_dict_unknown_field(mock_pkgs: Callable[[MockGraph], Iterator[Mock]]) -> None:
+    dag = PackageDAG.from_pkgs(list(mock_pkgs({("a", "1.0"): []})))
+    assert ComputedValues("a", dag).as_dict(["nonexistent"]) == {}
+
+
+def test_size_computed_once(mocker: MockerFixture) -> None:
+    dag = MagicMock(spec=PackageDAG)
+    mock_dist = mocker.patch("pipdeptree._computed.distribution", return_value=MagicMock(files=None))
+    cv = ComputedValues("a", dag)
+    assert cv.size_bytes is None
+    assert cv.size == "0 B"
+    assert cv.size_raw == 0
+    mock_dist.assert_called_once()
+
+
+def test_format_display(mock_pkgs: Callable[[MockGraph], Iterator[Mock]], mocker: MockerFixture) -> None:
     graph: MockGraph = {
         ("a", "1.0"): [("b", [(">=", "1.0")])],
         ("b", "1.0"): [],
     }
     dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
-    with patch("pipdeptree._computed.compute_installed_size_bytes", return_value=100):
-        result = format_computed_display("a", ["size", "unique-deps-count", "unique-deps-names"], dag)
-    assert result == ["100 B", "1 unique deps", "unique: b"]
+    mocker.patch(
+        "pipdeptree._computed.distribution",
+        return_value=MagicMock(files=["f"], locate_file=lambda _: "/dev/null"),
+    )
+    mocker.patch.object(ComputedValues, "_file_size", return_value=100)
+    assert ComputedValues("a", dag).format_display(["size", "unique-deps-count", "unique-deps-names"]) == [
+        "100 B",
+        "1 unique deps",
+        "unique: b",
+    ]
 
 
-def test_format_computed_display_hides_zero_unique_deps(mock_pkgs: Callable[[MockGraph], Iterator[Mock]]) -> None:
+def test_format_display_unique_deps_size(
+    mock_pkgs: Callable[[MockGraph], Iterator[Mock]], mocker: MockerFixture
+) -> None:
+    graph: MockGraph = {
+        ("a", "1.0"): [("b", [(">=", "1.0")])],
+        ("b", "1.0"): [],
+    }
+    dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
+    mocker.patch(
+        "pipdeptree._computed.distribution",
+        return_value=MagicMock(files=["f"], locate_file=lambda _: "/dev/null"),
+    )
+    mocker.patch.object(ComputedValues, "_file_size", return_value=1024)
+    assert ComputedValues("a", dag).format_display(["unique-deps-size"]) == ["unique size: 1.0 KB"]
+
+
+def test_format_display_hides_zero_unique_deps(mock_pkgs: Callable[[MockGraph], Iterator[Mock]]) -> None:
     dag = PackageDAG.from_pkgs(list(mock_pkgs({("a", "1.0"): []})))
-    assert format_computed_display("a", ["unique-deps-count", "unique-deps-names"], dag) == []
+    assert ComputedValues("a", dag).format_display(["unique-deps-count", "unique-deps-names", "unique-deps-size"]) == []
 
 
-def test_format_computed_display_size_raw(mock_pkgs: Callable[[MockGraph], Iterator[Mock]]) -> None:
+def test_format_display_size_raw(mock_pkgs: Callable[[MockGraph], Iterator[Mock]], mocker: MockerFixture) -> None:
     dag = PackageDAG.from_pkgs(list(mock_pkgs({("a", "1.0"): []})))
-    with patch("pipdeptree._computed.compute_installed_size_bytes", return_value=5000):
-        assert format_computed_display("a", ["size-raw"], dag) == ["5000"]
+    mocker.patch(
+        "pipdeptree._computed.distribution",
+        return_value=MagicMock(files=["f"], locate_file=lambda _: "/dev/null"),
+    )
+    mocker.patch.object(ComputedValues, "_file_size", return_value=5000)
+    assert ComputedValues("a", dag).format_display(["size-raw"]) == ["5000"]
+
+
+def test_build_node_extra_label_inactive() -> None:
+    dag = MagicMock(spec=PackageDAG)
+    assert not RenderContext().build_node_extra_label("a", dag, ", ")
+
+
+def test_build_node_extra_label_metadata(
+    mock_pkgs: Callable[[MockGraph], Iterator[Mock]], mocker: MockerFixture
+) -> None:
+    graph: MockGraph = {("a", "1.0"): []}
+    dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
+    mocker.patch("pipdeptree._models.package.Package.get_metadata_values", return_value=["A package"])
+    ctx = RenderContext(metadata=["Summary"])
+    assert ctx.build_node_extra_label("a", dag, ", ") == "A package"
+
+
+def test_build_node_extra_label_computed(
+    mock_pkgs: Callable[[MockGraph], Iterator[Mock]], mocker: MockerFixture
+) -> None:
+    graph: MockGraph = {("a", "1.0"): [("b", [(">=", "1.0")])], ("b", "1.0"): []}
+    dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
+    mocker.patch("pipdeptree._computed.distribution", return_value=MagicMock(files=None))
+    ctx = RenderContext(computed=["size"])
+    assert ctx.build_node_extra_label("a", dag, ", ") == "size: 0 B"
+
+
+def test_build_node_extra_label_license(
+    mock_pkgs: Callable[[MockGraph], Iterator[Mock]], mocker: MockerFixture
+) -> None:
+    graph: MockGraph = {("a", "1.0"): []}
+    dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
+    mocker.patch("pipdeptree._models.package.Package.licenses", return_value="(MIT)")
+    ctx = RenderContext(metadata=["license"])
+    assert ctx.build_node_extra_label("a", dag, ", ") == "MIT License"
+
+
+def test_build_node_extra_label_missing_metadata_field(
+    mock_pkgs: Callable[[MockGraph], Iterator[Mock]], mocker: MockerFixture
+) -> None:
+    graph: MockGraph = {("a", "1.0"): []}
+    dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
+    mocker.patch("pipdeptree._models.package.Package.get_metadata_values", return_value=[])
+    ctx = RenderContext(metadata=["Author"])
+    assert not ctx.build_node_extra_label("a", dag, ", ")

--- a/tests/test_computed.py
+++ b/tests/test_computed.py
@@ -201,6 +201,16 @@ def test_format_display_size_raw(mock_pkgs: Callable[[MockGraph], Iterator[Mock]
     assert ComputedValues("a", dag).format_display(["size-raw"]) == ["5000"]
 
 
+def test_format_display_with_exclude(mock_pkgs: Callable[[MockGraph], Iterator[Mock]], mocker: MockerFixture) -> None:
+    dag = PackageDAG.from_pkgs(list(mock_pkgs({("a", "1.0"): []})))
+    mocker.patch(
+        "pipdeptree._computed.distribution",
+        return_value=MagicMock(files=["f"], locate_file=lambda _: "/dev/null"),
+    )
+    mocker.patch.object(ComputedValues, "_file_size", return_value=100)
+    assert ComputedValues("a", dag).format_display(["size"], exclude=frozenset({"size"})) == []
+
+
 def test_build_node_extra_label_inactive() -> None:
     dag = MagicMock(spec=PackageDAG)
     assert not RenderContext().build_node_extra_label("a", dag, ", ")
@@ -244,3 +254,12 @@ def test_build_node_extra_label_missing_metadata_field(
     mocker.patch("pipdeptree._models.package.Package.get_metadata_values", return_value=[])
     ctx = RenderContext(metadata=["Author"])
     assert not ctx.build_node_extra_label("a", dag, ", ")
+
+
+def test_build_node_extra_label_key_not_in_tree(
+    mock_pkgs: Callable[[MockGraph], Iterator[Mock]],
+) -> None:
+    graph: MockGraph = {("a", "1.0"): []}
+    dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
+    ctx = RenderContext(metadata=["Summary"])
+    assert not ctx.build_node_extra_label("nonexistent", dag, ", ")

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -6,13 +6,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
+import pytest
 import virtualenv
 
 from pipdeptree.__main__ import main
-from pipdeptree._discovery import get_installed_distributions
+from pipdeptree._discovery import get_installed_distributions, has_valid_metadata
 
 if TYPE_CHECKING:
-    import pytest
     from pytest_mock import MockerFixture
 
 
@@ -181,6 +181,13 @@ def test_paths(fake_dist: Path) -> None:
     dists = get_installed_distributions(supplied_paths=mocked_path)
     assert len(dists) == 1
     assert dists[0].metadata["Name"] == "bar"
+
+
+@pytest.mark.parametrize("exc", [TypeError, FileNotFoundError])
+def test_has_valid_metadata_broken(exc: type[Exception]) -> None:
+    dist = Mock()
+    type(dist).metadata = property(lambda _: (_ for _ in ()).throw(exc))
+    assert has_valid_metadata(dist) is False
 
 
 def test_paths_when_in_virtual_env(tmp_path: Path, fake_dist: Path) -> None:


### PR DESCRIPTION
The `--license` flag was a one-off that couldn't scale as users requested more package information (#391 dependency sizes, #386 unique dependency counts). Each new piece of data would have required yet another boolean flag.

✨ Two new flags generalize `--license`:

`--metadata` / `-m` accepts comma-separated field names from the package `METADATA` file (`license`, `summary`, `author`, `home-page`, `requires-python`, or any arbitrary field). `--computed` / `-c` accepts calculated fields: `size` (human-readable installed size), `size-raw` (raw byte count as native int for JSON), `unique-deps-count` (number of exclusive transitive dependencies), `unique-deps-names` (their names), and `unique-deps-size` (their total installed size). Both flags work together across all output formats and display on every node in the tree.

A `RenderContext` dataclass bundles field lists and carries a reference to the full unfiltered tree so that `--packages` filtering doesn't break unique-deps calculations. Unique deps are computed transitively: if removing a package orphans a dependency, and that orphan would in turn orphan its own dependencies, all are counted. Size is computed once when both `size` and `size-raw` are requested, and unique deps are computed once when any `unique-deps-*` field is requested. JSON output uses native types (`int` for `size_raw` and `unique_deps_count`, `list[str]` for `unique_deps_names`) with underscore keys matching the existing `package_name`/`installed_version` convention. In text/rich display, `unique-deps-count`, `unique-deps-names`, and `unique-deps-size` are hidden when zero/empty.

`--license` is preserved for backwards compatibility as a deprecated alias mapping to `--metadata license`, emitting a `DeprecationWarning` when used.

Closes #419, closes #391, closes #386.