### PR TITLE
Fix metadata lookup to use distribution object

### DIFF
--- a/src/pipdeptree/_models/package.py
+++ b/src/pipdeptree/_models/package.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from importlib import import_module
-from importlib.metadata import Distribution, PackageNotFoundError, metadata, version
+from importlib.metadata import Distribution, PackageMetadata, PackageNotFoundError, metadata, version
 from inspect import ismodule
 from typing import TYPE_CHECKING
 
@@ -27,45 +27,43 @@ class InvalidRequirementError(ValueError):
 class Package(ABC):
     """Abstract class for wrappers around objects that pip returns."""
 
-    UNKNOWN_LICENSE_STR = "(Unknown license)"
+    NA = "N/A"
+    UNKNOWN_LICENSE_STR = f"({NA})"
 
     def __init__(self, project_name: str) -> None:
         self.project_name = project_name
         self.key = canonicalize_name(project_name)
 
-    def licenses(self) -> str:
+    def _get_dist_metadata(self) -> PackageMetadata | None:
         try:
-            dist_metadata = metadata(self.key)
+            return metadata(self.key)
         except PackageNotFoundError:
+            return None
+
+    def licenses(self) -> str:
+        if (dist_metadata := self._get_dist_metadata()) is None:
             return self.UNKNOWN_LICENSE_STR
 
-        if license_str := dist_metadata[("License-Expression")]:
+        if license_str := dist_metadata["License-Expression"]:
             return f"({license_str})"
 
         license_strs: list[str] = []
-        classifiers = dist_metadata.get_all("Classifier", [])
-        for classifier in classifiers:
+        for classifier in dist_metadata.get_all("Classifier", []):
             line = str(classifier)
             if line.startswith("License"):
-                license_str = line.rsplit(":: ", 1)[-1]
-                license_strs.append(license_str)
+                license_strs.append(line.rsplit(":: ", 1)[-1])
 
-        if not license_strs:
-            return self.UNKNOWN_LICENSE_STR
-
-        return f"({', '.join(license_strs)})"
+        return f"({', '.join(license_strs)})" if license_strs else self.UNKNOWN_LICENSE_STR
 
     def get_metadata(self, field: str) -> str | list[str]:
         if field == "license":
             raw = self.licenses().strip("()")
             return raw if "license" in raw.lower() else f"{raw} License"
-        try:
-            dist_metadata = metadata(self.key)
-        except PackageNotFoundError:
-            return "Unknown"
+        if (dist_metadata := self._get_dist_metadata()) is None:
+            return self.NA
         values = dist_metadata.get_all(field)
         if not values:
-            return "Unknown"
+            return self.NA
         if len(values) == 1:
             return str(values[0])
         return [str(v) for v in values]
@@ -129,6 +127,9 @@ class DistPackage(Package):
         super().__init__(obj.metadata["Name"])
         self._obj = obj
         self.req = req
+
+    def _get_dist_metadata(self) -> PackageMetadata:
+        return self._obj.metadata
 
     def requires(self) -> Iterator[Requirement]:
         """

--- a/tests/_models/test_package.py
+++ b/tests/_models/test_package.py
@@ -106,73 +106,54 @@ def test_dist_package_as_dict() -> None:
     assert expected == result
 
 
+def _license_msg(*classifiers: str, license_expression: str | None = None) -> Message:
+    msg = Message()
+    msg["Name"] = "a"
+    if license_expression:
+        msg["License-Expression"] = license_expression
+    for c in classifiers:
+        msg["Classifier"] = c
+    return msg
+
+
 @pytest.mark.parametrize(
-    ("mocked_metadata", "expected_output"),
+    ("dist_metadata", "expected_output"),
     [
+        pytest.param(_license_msg(), Package.UNKNOWN_LICENSE_STR, id="no-license"),
         pytest.param(
-            Mock(__getitem__=Mock(return_value=None), get_all=Mock(return_value=[])),
-            Package.UNKNOWN_LICENSE_STR,
-            id="no-license",
-        ),
-        pytest.param(
-            Mock(
-                __getitem__=Mock(return_value=None),
-                get_all=Mock(
-                    return_value=[
-                        "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
-                        "Operating System :: OS Independent",
-                    ]
-                ),
+            _license_msg(
+                "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
+                "Operating System :: OS Independent",
             ),
             "(GNU General Public License v2 (GPLv2))",
             id="one-license-with-one-non-license",
         ),
         pytest.param(
-            Mock(
-                __getitem__=Mock(return_value=None),
-                get_all=Mock(
-                    return_value=[
-                        "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
-                        "License :: OSI Approved :: Apache Software License",
-                    ]
-                ),
+            _license_msg(
+                "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
+                "License :: OSI Approved :: Apache Software License",
             ),
             "(GNU General Public License v2 (GPLv2), Apache Software License)",
             id="more-than-one-license",
         ),
+        pytest.param(_license_msg(license_expression="MIT"), "(MIT)", id="license-expression"),
         pytest.param(
-            Mock(__getitem__=Mock(return_value="MIT"), get_all=Mock(return_value=[])),
-            "(MIT)",
-            id="license-expression",
-        ),
-        pytest.param(
-            Mock(
-                __getitem__=Mock(return_value="MIT"),
-                get_all=Mock(
-                    return_value=[
-                        "License :: OSI Approved :: MIT License",
-                    ]
-                ),
-            ),
+            _license_msg("License :: OSI Approved :: MIT License", license_expression="MIT"),
             "(MIT)",
             id="license-expression-with-license-classifier",
         ),
     ],
 )
-def test_dist_package_licenses(mocked_metadata: Mock, expected_output: str, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("pipdeptree._models.package.metadata", Mock(return_value=mocked_metadata))
-    dist = DistPackage(Mock(metadata={"Name": "a"}))
-    licenses_str = dist.licenses()
-
-    assert licenses_str == expected_output
+def test_dist_package_licenses(dist_metadata: Message, expected_output: str) -> None:
+    dist = DistPackage(Mock(metadata=dist_metadata))
+    assert dist.licenses() == expected_output
 
 
-def test_dist_package_licenses_importlib_cant_find_package(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("pipdeptree._models.package.metadata", Mock(side_effect=PackageNotFoundError()))
-    dist = DistPackage(Mock(metadata={"Name": "a"}))
-    licenses_str = dist.licenses()
-
-    assert licenses_str == Package.UNKNOWN_LICENSE_STR
+def test_licenses_importlib_cant_find_package(mocker: MockerFixture) -> None:
+    mocker.patch("pipdeptree._models.package.metadata", side_effect=PackageNotFoundError())
+    req = MagicMock()
+    req.name = "nonexistent"
+    assert ReqPackage(req).licenses() == Package.UNKNOWN_LICENSE_STR
 
 
 def test_dist_package_key_pep503_normalized() -> None:
@@ -381,49 +362,51 @@ def test_get_metadata_license(mocker: MockerFixture) -> None:
     assert DistPackage(dist).get_metadata("license") == "MIT License"
 
 
-def test_get_metadata_arbitrary_field(mocker: MockerFixture) -> None:
-
+def _make_dist_msg(**fields: str | list[str]) -> MagicMock:
     msg = Message()
-    msg["Summary"] = "A package"
-    mocker.patch("pipdeptree._models.package.metadata", return_value=msg)
-    dist = MagicMock(metadata={"Name": "foo"}, version="1.0")
+    msg["Name"] = "foo"
+    for key, val in fields.items():
+        if isinstance(val, list):
+            for v in val:
+                msg[key] = v
+        else:
+            msg[key] = val
+    return MagicMock(metadata=msg, version="1.0")
+
+
+def test_get_metadata_arbitrary_field() -> None:
+    dist = _make_dist_msg(Summary="A package")
     assert DistPackage(dist).get_metadata("Summary") == "A package"
 
 
-def test_get_metadata_missing_field(mocker: MockerFixture) -> None:
-
-    mocker.patch("pipdeptree._models.package.metadata", return_value=Message())
-    dist = MagicMock(metadata={"Name": "foo"}, version="1.0")
-    assert DistPackage(dist).get_metadata("Nonexistent") == "Unknown"
+def test_get_metadata_missing_field() -> None:
+    dist = _make_dist_msg()
+    assert DistPackage(dist).get_metadata("Nonexistent") == "N/A"
 
 
 def test_get_metadata_unknown_package(mocker: MockerFixture) -> None:
     mocker.patch("pipdeptree._models.package.metadata", side_effect=PackageNotFoundError("x"))
-    dist = MagicMock(metadata={"Name": "foo"}, version="1.0")
-    assert DistPackage(dist).get_metadata("Summary") == "Unknown"
+    req = MagicMock()
+    req.name = "nonexistent"
+    assert ReqPackage(req).get_metadata("Summary") == "N/A"
 
 
 def test_get_metadata_dict(mocker: MockerFixture) -> None:
-
     mocker.patch.object(Package, "licenses", return_value="(MIT)")
-    msg = Message()
-    msg["Summary"] = "A package"
-    mocker.patch("pipdeptree._models.package.metadata", return_value=msg)
-    dist = MagicMock(metadata={"Name": "foo"}, version="1.0")
+    dist = _make_dist_msg(Summary="A package")
     result = DistPackage(dist).get_metadata_dict(["license", "Summary"])
     assert result == {"license": "MIT License", "Summary": "A package"}
 
 
-def test_get_metadata_multi_value(mocker: MockerFixture) -> None:
-
-    msg = Message()
-    msg["Classifier"] = "Development Status :: 5 - Production/Stable"
-    msg["Classifier"] = "License :: OSI Approved :: MIT License"
-    msg["Classifier"] = "Programming Language :: Python :: 3"
-    mocker.patch("pipdeptree._models.package.metadata", return_value=msg)
-    dist = MagicMock(metadata={"Name": "foo"}, version="1.0")
-    result = DistPackage(dist).get_metadata("Classifier")
-    assert result == [
+def test_get_metadata_multi_value() -> None:
+    dist = _make_dist_msg(
+        Classifier=[
+            "Development Status :: 5 - Production/Stable",
+            "License :: OSI Approved :: MIT License",
+            "Programming Language :: Python :: 3",
+        ],
+    )
+    assert DistPackage(dist).get_metadata("Classifier") == [
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
@@ -431,30 +414,22 @@ def test_get_metadata_multi_value(mocker: MockerFixture) -> None:
 
 
 def test_get_metadata_values_with_multi_value(mocker: MockerFixture) -> None:
-
-    msg = Message()
-    msg["Classifier"] = "Development Status :: 5 - Production/Stable"
-    msg["Classifier"] = "License :: OSI Approved :: MIT License"
-    mocker.patch("pipdeptree._models.package.metadata", return_value=msg)
     mocker.patch.object(Package, "licenses", return_value="(MIT)")
-    dist = MagicMock(metadata={"Name": "foo"}, version="1.0")
-    result = DistPackage(dist).get_metadata_values(["license", "Classifier"])
-    assert result == [
+    dist = _make_dist_msg(
+        Classifier=["Development Status :: 5 - Production/Stable", "License :: OSI Approved :: MIT License"],
+    )
+    assert DistPackage(dist).get_metadata_values(["license", "Classifier"]) == [
         "MIT License",
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: MIT License",
     ]
 
 
-def test_get_metadata_dict_with_multi_value(mocker: MockerFixture) -> None:
-
-    msg = Message()
-    msg["Classifier"] = "Development Status :: 5 - Production/Stable"
-    msg["Classifier"] = "License :: OSI Approved :: MIT License"
-    mocker.patch("pipdeptree._models.package.metadata", return_value=msg)
-    dist = MagicMock(metadata={"Name": "foo"}, version="1.0")
-    result = DistPackage(dist).get_metadata_dict(["Classifier"])
-    assert result == {
+def test_get_metadata_dict_with_multi_value() -> None:
+    dist = _make_dist_msg(
+        Classifier=["Development Status :: 5 - Production/Stable", "License :: OSI Approved :: MIT License"],
+    )
+    assert DistPackage(dist).get_metadata_dict(["Classifier"]) == {
         "Classifier": [
             "Development Status :: 5 - Production/Stable",
             "License :: OSI Approved :: MIT License",
@@ -464,21 +439,35 @@ def test_get_metadata_dict_with_multi_value(mocker: MockerFixture) -> None:
 
 def test_get_metadata_values(mocker: MockerFixture) -> None:
     mocker.patch.object(Package, "licenses", return_value="(MIT)")
-    dist = MagicMock(metadata={"Name": "foo"}, version="1.0")
+    dist = _make_dist_msg()
     assert DistPackage(dist).get_metadata_values(["license"]) == ["MIT License"]
 
 
-def test_get_metadata_values_escapes_newlines(mocker: MockerFixture) -> None:
-    msg = Message()
-    msg["Description"] = "A long\nmulti-line\ndescription"
-    mocker.patch("pipdeptree._models.package.metadata", return_value=msg)
-    dist = MagicMock(metadata={"Name": "foo"}, version="1.0")
+def test_get_metadata_values_escapes_newlines() -> None:
+    dist = _make_dist_msg(Description="A long\nmulti-line\ndescription")
     assert DistPackage(dist).get_metadata_values(["Description"]) == [r"A long\nmulti-line\ndescription"]
 
 
-def test_get_metadata_dict_preserves_newlines(mocker: MockerFixture) -> None:
-    msg = Message()
-    msg["Description"] = "A long\nmulti-line\ndescription"
-    mocker.patch("pipdeptree._models.package.metadata", return_value=msg)
-    dist = MagicMock(metadata={"Name": "foo"}, version="1.0")
+def test_get_metadata_dict_preserves_newlines() -> None:
+    dist = _make_dist_msg(Description="A long\nmulti-line\ndescription")
     assert DistPackage(dist).get_metadata_dict(["Description"]) == {"Description": "A long\nmulti-line\ndescription"}
+
+
+def test_get_metadata_uses_dist_not_global_lookup(mocker: MockerFixture) -> None:
+    msg = Message()
+    msg["Name"] = "foo"
+    msg["Summary"] = "From dist"
+    dist = MagicMock(metadata=msg, version="1.0")
+    global_metadata = mocker.patch("pipdeptree._models.package.metadata", side_effect=PackageNotFoundError("x"))
+    assert DistPackage(dist).get_metadata("Summary") == "From dist"
+    global_metadata.assert_not_called()
+
+
+def test_licenses_uses_dist_not_global_lookup(mocker: MockerFixture) -> None:
+    msg = Message()
+    msg["Name"] = "foo"
+    msg["License-Expression"] = "MIT"
+    dist = MagicMock(metadata=msg, version="1.0")
+    global_metadata = mocker.patch("pipdeptree._models.package.metadata", side_effect=PackageNotFoundError("x"))
+    assert DistPackage(dist).licenses() == "(MIT)"
+    global_metadata.assert_not_called()

--- a/tests/render/test_rich_text.py
+++ b/tests/render/test_rich_text.py
@@ -9,7 +9,7 @@ import pytest
 
 from pipdeptree._cli import RenderContext
 from pipdeptree._models import PackageDAG
-from pipdeptree._models.package import Package
+from pipdeptree._models.package import DistPackage, Package
 from pipdeptree._render.rich_text import render_rich_text
 
 if TYPE_CHECKING:
@@ -187,7 +187,7 @@ def test_render_rich_text_multi_value_metadata(
     msg = Message()
     msg["Classifier"] = "Development Status :: 5 - Production/Stable"
     msg["Classifier"] = "License :: OSI Approved :: MIT License"
-    mocker.patch("pipdeptree._models.package.metadata", return_value=msg)
+    mocker.patch.object(DistPackage, "_get_dist_metadata", return_value=msg)
 
     render_rich_text(dag, max_depth=float("inf"), context=RenderContext(metadata=["Classifier"]))
     output = capsys.readouterr().out
@@ -206,7 +206,7 @@ def test_render_rich_text_multiline_metadata(
     dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
     msg = Message()
     msg["Description"] = "Line one\nLine two\nLine three"
-    mocker.patch("pipdeptree._models.package.metadata", return_value=msg)
+    mocker.patch.object(DistPackage, "_get_dist_metadata", return_value=msg)
 
     render_rich_text(dag, max_depth=float("inf"), context=RenderContext(metadata=["Description"]))
     output = capsys.readouterr().out


### PR DESCRIPTION
## Summary

- `get_metadata()` and `licenses()` called the global `importlib.metadata.metadata()` which queries the current interpreter's packages. When using `--python` to inspect another environment, this returned wrong results (always "Unknown"). Now `DistPackage` uses `self._obj.metadata` directly from the distribution object, which is already resolved from the correct environment.
- Changes "Unknown" to "N/A" for missing metadata fields.

## Test plan

- [x] Added test that patches global `metadata()` to raise `PackageNotFoundError` and verifies `DistPackage.get_metadata()` still returns correct values from its own distribution
- [x] Same for `licenses()`
- [x] Existing tests updated to use `Message` objects on dist mocks instead of patching global `metadata()`
- [x] `tox run -e 3.14` passes with 100% diff-coverage