### PR TITLE
🐛 fix(types): resolve ty 0.0.30 check failures

### DIFF
--- a/src/pipdeptree/_models/dag.py
+++ b/src/pipdeptree/_models/dag.py
@@ -58,7 +58,7 @@ class PackageDAG(Mapping[DistPackage, list[ReqPackage]]):
     ) -> PackageDAG:
         warning_printer = get_warning_printer()
         dist_pkgs = [DistPackage(p) for p in pkgs]
-        idx = {p.key: p for p in dist_pkgs}
+        idx: dict[str, DistPackage] = {p.key: p for p in dist_pkgs}
         pkg_deps: dict[DistPackage, list[ReqPackage]] = {}
         dist_name_to_invalid_reqs_dict: dict[str, list[str]] = {}
         for pkg in dist_pkgs:

--- a/src/pipdeptree/_models/package.py
+++ b/src/pipdeptree/_models/package.py
@@ -254,7 +254,7 @@ class ReqPackage(Package):
 
     @property
     def version_spec(self) -> str | None:
-        specs = sorted(map(str, self._obj.specifier), reverse=True)  # ty: ignore[invalid-argument-type]  # `reverse` makes '>' prior to '<'
+        specs = sorted(map(str, self._obj.specifier), reverse=True)  # `reverse` makes '>' prior to '<'
         return ",".join(specs) if specs else None
 
     @property

--- a/src/pipdeptree/_render/mermaid.py
+++ b/src/pipdeptree/_render/mermaid.py
@@ -78,7 +78,7 @@ def _build_reversed_mermaid(
             package.project_name,
             "(missing)" if package.is_missing else package.installed_version,
         ]
-        if extra := context and context.build_node_extra_label(package.key, tree, "<br/>"):
+        if context and (extra := context.build_node_extra_label(package.key, tree, "<br/>")):
             label_parts.append(extra)
         package_key = _mermaid_id(package.key, node_ids_map)
         nodes.add(f'{package_key}["{"<br/>".join(label_parts)}"]')
@@ -97,7 +97,7 @@ def _build_forward_mermaid(
 ) -> None:
     for package, dependencies in tree.items():
         label_parts = [package.project_name, package.version]
-        if extra := context and context.build_node_extra_label(package.key, tree, "<br/>"):
+        if context and (extra := context.build_node_extra_label(package.key, tree, "<br/>")):
             label_parts.append(extra)
         package_key = _mermaid_id(package.key, node_ids_map)
         nodes.add(f'{package_key}["{"<br/>".join(label_parts)}"]')


### PR DESCRIPTION
The scheduled `check` workflow on `main` started failing after `ty` 0.0.30 shifted its diagnostics on three unrelated call sites, blocking the green-main signal the project relies on. 🐛 None of the underlying code was buggy at runtime, but the type-check job treats any warning as fatal, so the job needs to be cleaned up before new work can merge cleanly.

The dict feeding `_resolve_extras` in `PackageDAG.from_pkgs` now gets an explicit `dict[str, DistPackage]` annotation; without it `ty` infers `dict[NormalizedName, DistPackage]` from `canonicalize_name` and dict-key invariance turns the call into a type error, matching how `PackageDAG._index` is already annotated a few lines down. In the mermaid renderer, the `extra := context and context.build_node_extra_label(...)` pattern let `extra` widen to `RenderContext | str`; moving the walrus inside the right-hand side of the `and` narrows it back to `str` and mirrors the shape already used by the graphviz renderer. The `ty: ignore[invalid-argument-type]` directive on `sorted(map(str, specifier), ...)` no longer corresponds to a real diagnostic in 0.0.30 and was being flagged as unused, so it is dropped while keeping the adjacent comment that explains the `reverse=True` argument.

No runtime behaviour changes. ✅