### PR TITLE
⚡ perf(extras): make --extras tractable on real environments

### DIFF
--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -65,9 +65,47 @@ Circular dependency detection uses cycle detection on the directed dependency gr
         style X fill:#e67e22,color:#fff
         style Y fill:#e67e22,color:#fff
 
+Optional dependencies (extras)
+------------------------------
+
+When you pass ``--extras``, pipdeptree augments the tree with optional dependency edges. Two kinds
+of extras are surfaced:
+
+1. **Explicitly requested extras.** When a parent's metadata records a dependency like
+   ``oauthlib[signedtoken]``, the deps gated behind oauthlib's ``signedtoken`` extra get
+   added under oauthlib in the tree, annotated with ``extra: signedtoken``.
+
+2. **Active extras.** Python packaging metadata never records *why* a package was installed,
+   only what it could require. pipdeptree therefore considers an extra "active" when every dep
+   that extra would have requested is already installed -- the same heuristic Python libraries use
+   at runtime to decide whether a feature is available (``try: import optional_dep``). When an
+   extra is active, pipdeptree adds the same edges it would have added if the extra had been
+   requested explicitly.
+
+Both kinds propagate. If activating ``A[x]`` pulls in ``B[y]``, pipdeptree also adds the deps
+``B[y]`` would gate. Because metadata cannot tell us that ``B`` was installed for some other
+reason, the same package may appear under multiple parents through this mechanism.
+
+.. mermaid::
+
+    flowchart TD
+        A[App] -- requires --> O[oauthlib]
+        A -- "requires<br/>oauthlib[signedtoken]" --> O
+        O -. "extra: signedtoken" .-> C[cryptography]
+        O -. "extra: signedtoken" .-> P[pyjwt]
+        style C fill:#8e44ad,color:#fff
+        style P fill:#8e44ad,color:#fff
+
+To leave optional edges out entirely, omit ``--extras`` (the default). Edges added through
+extras are always annotated with the originating extra, so they remain distinguishable from
+mandatory dependencies in every output format.
+
 Limitations
 -----------
 
 - pipdeptree only sees packages that are already installed. It cannot predict what a ``pip install`` will do.
 - If you need a dependency resolver that works without installing packages first, consider :pypi:`uv`.
 - Extra/optional dependencies are not shown by default; use ``--extras`` to include them.
+- ``--extras`` cannot reconstruct extras that were requested only on the command line
+  (e.g. ``pip install foo[dev]`` where ``foo`` is itself top-level), because that information
+  is never persisted into installed package metadata.

--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -320,3 +320,16 @@ Show optional (extras) dependencies in the tree with ``--extras`` (``-x``):
 
 Without ``--extras``, only mandatory dependencies are shown. Packages that declare optional dependency groups (extras)
 will have those additional dependencies included when this flag is set.
+
+Edges added through an extra are annotated with that extra's name:
+
+.. code-block:: console
+
+    $ pipdeptree --extras --packages oauthlib
+    oauthlib==3.0.0
+    ├── cryptography [required: Any, installed: 2.7, extra: signedtoken]
+    └── pyjwt [required: >=1.0.0, installed: 1.7.1, extra: signedtoken]
+
+An extra is included not only when a parent explicitly requested it (e.g. ``oauthlib[signedtoken]``)
+but also when every dependency that the extra would require is already installed in the
+environment. See :doc:`/explanation` for the rationale.

--- a/docs/tutorial/getting-started.rst
+++ b/docs/tutorial/getting-started.rst
@@ -142,5 +142,7 @@ Limit the tree depth:
 Next steps
 ----------
 
-See :doc:`/how-to/usage` for filtering, virtualenv support, and warning control. See :doc:`/how-to/output-formats` for
-all available output formats including JSON, Mermaid, and Graphviz.
+See :doc:`/how-to/usage` for filtering, virtualenv support, warning control, and how to surface
+optional (extras) dependencies. See :doc:`/how-to/output-formats` for all available output formats
+including JSON, Mermaid, and Graphviz. See :doc:`/explanation` for how pipdeptree decides when an
+optional dependency edge is "active".

--- a/src/pipdeptree/_cli.py
+++ b/src/pipdeptree/_cli.py
@@ -143,7 +143,11 @@ def build_parser() -> ArgumentParser:
         "--extras",
         action="store_true",
         default=False,
-        help="include optional (extras) dependencies in the tree",
+        help=(
+            "include optional (extras) dependencies in the tree; an extra is included when it is "
+            "explicitly requested (e.g. ``foo[bar]``) or when every dependency the extra would "
+            "require is already installed"
+        ),
     )
 
     scope = select.add_mutually_exclusive_group()

--- a/src/pipdeptree/_models/dag.py
+++ b/src/pipdeptree/_models/dag.py
@@ -12,6 +12,8 @@ from packaging.utils import canonicalize_name
 if TYPE_CHECKING:
     from importlib.metadata import Distribution
 
+    from packaging.requirements import Requirement
+
 
 from pipdeptree._warning import get_warning_printer
 
@@ -370,6 +372,9 @@ def _resolve_extras(pkg_deps: dict[DistPackage, list[ReqPackage]], idx: dict[str
     for pkg_key, extras in _collect_satisfied_extras(pkg_deps, idx).items():
         extras_needed.setdefault(pkg_key, set()).update(extras)
     processed: dict[str, set[str]] = {}
+    # The same (parent, child, extra) triple can be reached through multiple req.extras propagation
+    # paths across rounds; without dedup it would be appended once per path.
+    seen_edges: set[tuple[str, str, str]] = set()
     while extras_needed:
         next_round: dict[str, set[str]] = {}
         for pkg_key, extras in extras_needed.items():
@@ -380,10 +385,13 @@ def _resolve_extras(pkg_deps: dict[DistPackage, list[ReqPackage]], idx: dict[str
             dist_pkg = idx.get(pkg_key)
             if dist_pkg is None or dist_pkg not in pkg_deps:
                 continue
-            for req, extra_name in dist_pkg.requires_for_extras(frozenset(new_extras)):
-                dist = idx.get(canonicalize_name(req.name))
-                if dist is None:
+            for req, extra_name, dep_key in dist_pkg.requires_for_extras(frozenset(new_extras)):
+                if (dist := idx.get(dep_key)) is None:
                     continue
+                edge_key = (dist_pkg.key, dist.key, extra_name)
+                if edge_key in seen_edges:
+                    continue
+                seen_edges.add(edge_key)
                 req.name = dist.project_name
                 pkg_deps[dist_pkg].append(ReqPackage(req, dist, extra=extra_name))
                 if req.extras:
@@ -405,12 +413,183 @@ def _collect_satisfied_extras(
     pkg_deps: dict[DistPackage, list[ReqPackage]], idx: dict[str, DistPackage]
 ) -> dict[str, set[str]]:
     """Collect extras whose dependencies are all installed in the environment."""
+    resolver = _ExtrasResolver(pkg_deps, idx)
     extras_needed: dict[str, set[str]] = {}
     for dist_pkg in pkg_deps:
         for extra_name in dist_pkg.provides_extras:
-            if _extra_is_satisfied(dist_pkg.key, extra_name, pkg_deps, idx, set()):
+            if resolver.is_satisfied(dist_pkg.key, extra_name):
                 extras_needed.setdefault(dist_pkg.key, set()).add(extra_name)
     return extras_needed
+
+
+class _Frame:
+    __slots__ = ("key", "req_idx", "reqs", "sub_extras", "sub_idx", "used_assumption")
+
+    def __init__(self, key: tuple[str, str], reqs: list[tuple[Requirement, str, str]]) -> None:
+        self.key = key
+        self.reqs = reqs
+        self.req_idx = -1
+        self.sub_extras: tuple[str, ...] = ()
+        self.sub_idx = 0
+        self.used_assumption = False
+
+
+class _ExtrasResolver:
+    """
+    A shared cache amortizes satisfaction queries across an environment.
+
+    Without sharing the global cache, the same subgraphs would be re-walked O(N) times for an
+    N-node graph because each top-level query starts from scratch.
+    """
+
+    def __init__(
+        self,
+        pkg_deps: dict[DistPackage, list[ReqPackage]],
+        idx: dict[str, DistPackage],
+    ) -> None:
+        self._pkg_deps = pkg_deps
+        self._idx = idx
+        self._cache: dict[tuple[str, str], bool] = {}
+        self._in_progress: set[tuple[str, str]] = set()
+
+    def is_satisfied(self, pkg_key: str, extra_name: str) -> bool:
+        # Without a per-query scope cache, dense extras graphs cause exponential re-exploration of
+        # the same subgraphs through alternative paths.
+        result, _ = self._resolve(pkg_key, extra_name, {})
+        return result
+
+    def _resolve(
+        self,
+        pkg_key: str,
+        extra_name: str,
+        scope_cache: dict[tuple[str, str], bool],
+    ) -> tuple[bool, bool]:
+        # Iterative rather than recursive because extras chains can exceed Python's default 1000
+        # recursion limit and a cyclic SCC's stack grows with the SCC size.
+        # Tentative results (those that relied on the optimistic cycle assumption) live only in
+        # scope_cache because re-evaluating them as a top-level query may yield a different answer.
+        root_key = (pkg_key, extra_name)
+        if (shortcut := self._lookup(root_key, scope_cache)) is not None:
+            return shortcut
+        initial = self._build_frame(pkg_key, extra_name)
+        if initial is None:
+            self._cache[root_key] = False
+            return False, False
+
+        self._in_progress.add(root_key)
+        stack: list[_Frame] = [initial]
+        pending: tuple[bool, bool] | None = None
+        while stack:
+            frame = stack[-1]
+            if pending is not None:
+                pending = self._fold_pending(frame, pending, stack, scope_cache)
+                if pending is not None:
+                    continue
+            pending = self._advance(frame, stack, scope_cache)
+
+        assert pending is not None
+        return pending
+
+    def _fold_pending(
+        self,
+        frame: _Frame,
+        pending: tuple[bool, bool],
+        stack: list[_Frame],
+        scope_cache: dict[tuple[str, str], bool],
+    ) -> tuple[bool, bool] | None:
+        # None signals "advance frame"; a returned tuple bubbles a finished result up. The dual
+        # protocol exists so the caller's loop can distinguish in-progress from completed frames
+        # without an extra flag.
+        satisfied, used = pending
+        if used:
+            frame.used_assumption = True
+        if not satisfied:
+            result = self._finalize(frame, result=False, scope_cache=scope_cache)
+            stack.pop()
+            return result
+        frame.sub_idx += 1
+        return None
+
+    def _advance(
+        self,
+        frame: _Frame,
+        stack: list[_Frame],
+        scope_cache: dict[tuple[str, str], bool],
+    ) -> tuple[bool, bool] | None:
+        action = self._step(frame)
+        if action is _SUCCESS:
+            result = self._finalize(frame, result=True, scope_cache=scope_cache)
+            stack.pop()
+            return result
+        if action is _FAIL:
+            result = self._finalize(frame, result=False, scope_cache=scope_cache)
+            stack.pop()
+            return result
+        sub_key = action
+        if (shortcut := self._lookup(sub_key, scope_cache)) is not None:
+            return shortcut
+        sub_frame = self._build_frame(sub_key[0], sub_key[1])
+        if sub_frame is None:
+            self._cache[sub_key] = False
+            return False, False
+        self._in_progress.add(sub_key)
+        stack.append(sub_frame)
+        return None
+
+    def _lookup(
+        self,
+        key: tuple[str, str],
+        scope_cache: dict[tuple[str, str], bool],
+    ) -> tuple[bool, bool] | None:
+        if (cached := self._cache.get(key)) is not None:
+            return cached, False
+        if (scoped := scope_cache.get(key)) is not None:
+            return scoped, True
+        if key in self._in_progress:
+            return True, True
+        return None
+
+    def _build_frame(self, pkg_key: str, extra_name: str) -> _Frame | None:
+        dist_pkg = self._idx.get(pkg_key)
+        if dist_pkg is None or dist_pkg not in self._pkg_deps:
+            return None
+        reqs = list(dist_pkg.requires_for_extras(frozenset({extra_name})))
+        if not reqs:
+            return None
+        return _Frame((pkg_key, extra_name), reqs)
+
+    def _step(self, frame: _Frame) -> object:
+        # Empty sub_extras for a req are skipped here so the caller never sees a no-op resolve.
+        while True:
+            if frame.req_idx >= 0 and frame.sub_idx < len(frame.sub_extras):
+                _, _, dep_key = frame.reqs[frame.req_idx]
+                return dep_key, frame.sub_extras[frame.sub_idx]
+            frame.req_idx += 1
+            if frame.req_idx >= len(frame.reqs):
+                return _SUCCESS
+            req, _, dep_key = frame.reqs[frame.req_idx]
+            if dep_key not in self._idx:
+                return _FAIL
+            frame.sub_extras = tuple(req.extras)
+            frame.sub_idx = 0
+
+    def _finalize(
+        self,
+        frame: _Frame,
+        *,
+        result: bool,
+        scope_cache: dict[tuple[str, str], bool],
+    ) -> tuple[bool, bool]:
+        self._in_progress.discard(frame.key)
+        if frame.used_assumption:
+            scope_cache[frame.key] = result
+        else:
+            self._cache[frame.key] = result
+        return result, frame.used_assumption
+
+
+_SUCCESS = object()
+_FAIL = object()
 
 
 def _extra_is_satisfied(
@@ -418,21 +597,8 @@ def _extra_is_satisfied(
     extra_name: str,
     pkg_deps: dict[DistPackage, list[ReqPackage]],
     idx: dict[str, DistPackage],
-    visited: set[tuple[str, str]],
 ) -> bool:
-    if (pkg_key, extra_name) in visited:
-        return True
-    visited.add((pkg_key, extra_name))
-    if (dist_pkg := idx.get(pkg_key)) is None or dist_pkg not in pkg_deps:
-        return False
-    if not (reqs := list(dist_pkg.requires_for_extras(frozenset({extra_name})))):
-        return False
-    for req, _ in reqs:
-        if (dep_key := canonicalize_name(req.name)) not in idx:
-            return False
-        if not all(_extra_is_satisfied(dep_key, sub_extra, pkg_deps, idx, visited) for sub_extra in req.extras):
-            return False
-    return True
+    return _ExtrasResolver(pkg_deps, idx).is_satisfied(pkg_key, extra_name)
 
 
 __all__ = [

--- a/src/pipdeptree/_models/dag.py
+++ b/src/pipdeptree/_models/dag.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sys
 from collections import defaultdict, deque
 from collections.abc import Iterator, Mapping
+from enum import Enum, auto
 from fnmatch import fnmatch
 from itertools import chain
 from typing import TYPE_CHECKING
@@ -422,6 +423,11 @@ def _collect_satisfied_extras(
     return extras_needed
 
 
+class _Action(Enum):
+    SUCCESS = auto()
+    FAIL = auto()
+
+
 class _Frame:
     __slots__ = ("key", "req_idx", "reqs", "sub_extras", "sub_idx", "used_assumption")
 
@@ -517,11 +523,11 @@ class _ExtrasResolver:
         scope_cache: dict[tuple[str, str], bool],
     ) -> tuple[bool, bool] | None:
         action = self._step(frame)
-        if action is _SUCCESS:
+        if action is _Action.SUCCESS:
             result = self._finalize(frame, result=True, scope_cache=scope_cache)
             stack.pop()
             return result
-        if action is _FAIL:
+        if action is _Action.FAIL:
             result = self._finalize(frame, result=False, scope_cache=scope_cache)
             stack.pop()
             return result
@@ -558,7 +564,7 @@ class _ExtrasResolver:
             return None
         return _Frame((pkg_key, extra_name), reqs)
 
-    def _step(self, frame: _Frame) -> object:
+    def _step(self, frame: _Frame) -> _Action | tuple[str, str]:
         # Empty sub_extras for a req are skipped here so the caller never sees a no-op resolve.
         while True:
             if frame.req_idx >= 0 and frame.sub_idx < len(frame.sub_extras):
@@ -566,10 +572,10 @@ class _ExtrasResolver:
                 return dep_key, frame.sub_extras[frame.sub_idx]
             frame.req_idx += 1
             if frame.req_idx >= len(frame.reqs):
-                return _SUCCESS
+                return _Action.SUCCESS
             req, _, dep_key = frame.reqs[frame.req_idx]
             if dep_key not in self._idx:
-                return _FAIL
+                return _Action.FAIL
             frame.sub_extras = tuple(req.extras)
             frame.sub_idx = 0
 
@@ -586,10 +592,6 @@ class _ExtrasResolver:
         else:
             self._cache[frame.key] = result
         return result, frame.used_assumption
-
-
-_SUCCESS = object()
-_FAIL = object()
 
 
 def _extra_is_satisfied(

--- a/src/pipdeptree/_models/dag.py
+++ b/src/pipdeptree/_models/dag.py
@@ -459,23 +459,14 @@ class _ExtrasResolver:
         self._in_progress: set[tuple[str, str]] = set()
 
     def is_satisfied(self, pkg_key: str, extra_name: str) -> bool:
-        # Without a per-query scope cache, dense extras graphs cause exponential re-exploration of
-        # the same subgraphs through alternative paths.
-        result, _ = self._resolve(pkg_key, extra_name, {})
+        result, _ = self._resolve(pkg_key, extra_name)
         return result
 
-    def _resolve(
-        self,
-        pkg_key: str,
-        extra_name: str,
-        scope_cache: dict[tuple[str, str], bool],
-    ) -> tuple[bool, bool]:
+    def _resolve(self, pkg_key: str, extra_name: str) -> tuple[bool, bool]:
         # Iterative rather than recursive because extras chains can exceed Python's default 1000
         # recursion limit and a cyclic SCC's stack grows with the SCC size.
-        # Tentative results (those that relied on the optimistic cycle assumption) live only in
-        # scope_cache because re-evaluating them as a top-level query may yield a different answer.
         root_key = (pkg_key, extra_name)
-        if (shortcut := self._lookup(root_key, scope_cache)) is not None:
+        if (shortcut := self._lookup(root_key)) is not None:
             return shortcut
         initial = self._build_frame(pkg_key, extra_name)
         if initial is None:
@@ -488,10 +479,10 @@ class _ExtrasResolver:
         while stack:
             frame = stack[-1]
             if pending is not None:
-                pending = self._fold_pending(frame, pending, stack, scope_cache)
+                pending = self._fold_pending(frame, pending, stack)
                 if pending is not None:
                     continue
-            pending = self._advance(frame, stack, scope_cache)
+            pending = self._advance(frame, stack)
 
         assert pending is not None
         return pending
@@ -501,7 +492,6 @@ class _ExtrasResolver:
         frame: _Frame,
         pending: tuple[bool, bool],
         stack: list[_Frame],
-        scope_cache: dict[tuple[str, str], bool],
     ) -> tuple[bool, bool] | None:
         # None signals "advance frame"; a returned tuple bubbles a finished result up. The dual
         # protocol exists so the caller's loop can distinguish in-progress from completed frames
@@ -510,29 +500,24 @@ class _ExtrasResolver:
         if used:
             frame.used_assumption = True
         if not satisfied:
-            result = self._finalize(frame, result=False, scope_cache=scope_cache)
+            result = self._finalize(frame, result=False)
             stack.pop()
             return result
         frame.sub_idx += 1
         return None
 
-    def _advance(
-        self,
-        frame: _Frame,
-        stack: list[_Frame],
-        scope_cache: dict[tuple[str, str], bool],
-    ) -> tuple[bool, bool] | None:
+    def _advance(self, frame: _Frame, stack: list[_Frame]) -> tuple[bool, bool] | None:
         action = self._step(frame)
         if action is _Action.SUCCESS:
-            result = self._finalize(frame, result=True, scope_cache=scope_cache)
+            result = self._finalize(frame, result=True)
             stack.pop()
             return result
         if action is _Action.FAIL:
-            result = self._finalize(frame, result=False, scope_cache=scope_cache)
+            result = self._finalize(frame, result=False)
             stack.pop()
             return result
         sub_key = action
-        if (shortcut := self._lookup(sub_key, scope_cache)) is not None:
+        if (shortcut := self._lookup(sub_key)) is not None:
             return shortcut
         sub_frame = self._build_frame(sub_key[0], sub_key[1])
         if sub_frame is None:
@@ -542,15 +527,9 @@ class _ExtrasResolver:
         stack.append(sub_frame)
         return None
 
-    def _lookup(
-        self,
-        key: tuple[str, str],
-        scope_cache: dict[tuple[str, str], bool],
-    ) -> tuple[bool, bool] | None:
+    def _lookup(self, key: tuple[str, str]) -> tuple[bool, bool] | None:
         if (cached := self._cache.get(key)) is not None:
             return cached, False
-        if (scoped := scope_cache.get(key)) is not None:
-            return scoped, True
         if key in self._in_progress:
             return True, True
         return None
@@ -579,17 +558,9 @@ class _ExtrasResolver:
             frame.sub_extras = tuple(req.extras)
             frame.sub_idx = 0
 
-    def _finalize(
-        self,
-        frame: _Frame,
-        *,
-        result: bool,
-        scope_cache: dict[tuple[str, str], bool],
-    ) -> tuple[bool, bool]:
+    def _finalize(self, frame: _Frame, *, result: bool) -> tuple[bool, bool]:
         self._in_progress.discard(frame.key)
-        if frame.used_assumption:
-            scope_cache[frame.key] = result
-        else:
+        if not frame.used_assumption:
             self._cache[frame.key] = result
         return result, frame.used_assumption
 

--- a/src/pipdeptree/_models/package.py
+++ b/src/pipdeptree/_models/package.py
@@ -184,8 +184,11 @@ class DistPackage(Package):
                     yield req, extra, dep_key
                     break
 
-    @property
+    @cached_property
     def version(self) -> str:
+        # Cached because each access reparses the METADATA file on the underlying Distribution and
+        # the renderer reads it once per occurrence in the tree (tens of thousands of times for
+        # large environments under --extras).
         return self._obj.version
 
     def unwrap(self) -> Distribution:

--- a/src/pipdeptree/_models/package.py
+++ b/src/pipdeptree/_models/package.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from functools import cached_property
 from importlib import import_module
 from importlib.metadata import Distribution, PackageMetadata, PackageNotFoundError, metadata, version
 from inspect import ismodule
@@ -131,40 +132,56 @@ class DistPackage(Package):
     def _get_dist_metadata(self) -> PackageMetadata:
         return self._obj.metadata
 
+    @cached_property
+    def _parsed_requires(self) -> list[Requirement | str]:
+        # Shared between requires() and _extras_index so PEP 508 parsing happens at most once per
+        # raw entry. str entries preserve the raw text of invalid requirements so requires() can
+        # still surface them via InvalidRequirementError, matching the original semantics.
+        return [_try_parse_requirement(raw_req) for raw_req in self._obj.requires or []]
+
     def requires(self) -> Iterator[Requirement]:
         """
         Return an iterator of the distribution's required dependencies.
 
         :raises InvalidRequirementError: If the metadata contains invalid requirement strings.
         """
-        for r in self._obj.requires or []:
-            try:
-                req = Requirement(r)
-            except InvalidRequirement:
-                raise InvalidRequirementError(r) from None
-            if not req.marker or req.marker.evaluate():
-                # Make sure that we're either dealing with a dependency that has no environment markers or does but
-                # are evaluated True against the existing environment (if it's False, it means they cannot be
-                # installed). "extra" markers are always evaluated False here which is what we want when retrieving
-                # only required dependencies.
-                yield req
+        for entry in self._parsed_requires:
+            if isinstance(entry, str):
+                raise InvalidRequirementError(entry) from None
+            if not entry.marker or entry.marker.evaluate():
+                # "extra" markers always evaluate False here, which is what excludes extras-gated
+                # reqs from this mandatory-only iterator.
+                yield entry
 
-    @property
+    @cached_property
     def provides_extras(self) -> frozenset[str]:
         return frozenset(self._obj.metadata.get_all("Provides-Extra") or ())
 
-    def requires_for_extras(self, extras: frozenset[str]) -> Iterator[tuple[Requirement, str]]:
-        """Yield (requirement, extra_name) for requirements gated behind the given extras."""
-        for raw_req in self._obj.requires or []:
-            try:
-                req = Requirement(raw_req)
-            except InvalidRequirement:
+    @cached_property
+    def _extras_index(self) -> list[tuple[Requirement, list[str], str]]:
+        # Cached because requires_for_extras is called many times per package across the
+        # satisfaction and resolution passes; without this, PEP 508 parsing and marker evaluation
+        # dominate --extras runtime. dep_key is precomputed alongside since canonicalize_name
+        # otherwise shows up as the next-largest contributor in the hot path.
+        extras = sorted(self.provides_extras)
+        if not extras:
+            return []
+        result: list[tuple[Requirement, list[str], str]] = []
+        for entry in self._parsed_requires:
+            if isinstance(entry, str):
                 continue
-            if not req.marker or req.marker.evaluate():
+            if not entry.marker or entry.marker.evaluate():
                 continue
-            for extra in extras:
-                if req.marker.evaluate({"extra": extra}):
-                    yield req, extra
+            if matching := [e for e in extras if entry.marker.evaluate({"extra": e})]:
+                result.append((entry, matching, canonicalize_name(entry.name)))
+        return result
+
+    def requires_for_extras(self, extras: frozenset[str]) -> Iterator[tuple[Requirement, str, str]]:
+        """Yield (requirement, extra_name, dep_key) for requirements gated behind the given extras."""
+        for req, matching, dep_key in self._extras_index:
+            for extra in matching:
+                if extra in extras:
+                    yield req, extra, dep_key
                     break
 
     @property
@@ -307,6 +324,13 @@ class ReqPackage(Package):
         if self.extra:
             result["extra"] = self.extra
         return result
+
+
+def _try_parse_requirement(raw_req: str) -> Requirement | str:
+    try:
+        return Requirement(raw_req)
+    except InvalidRequirement:
+        return raw_req
 
 
 __all__ = [

--- a/tests/_models/test_dag.py
+++ b/tests/_models/test_dag.py
@@ -413,9 +413,7 @@ def test_dag_extras_dedupes_identical_metadata_entries(make_mock_dist: MockDistM
     assert len(leaf_edges) == 1
 
 
-def test_dag_extras_scope_cache_dedupes_cyclic_paths(make_mock_dist: MockDistMaker) -> None:
-    # Multiple branches in a cycle converge on the same (pkg, extra) — without the per-query scope
-    # cache, the convergent node would be re-walked for each path.
+def test_dag_extras_cyclic_convergent_paths_resolve_correctly(make_mock_dist: MockDistMaker) -> None:
     pkgs = [
         make_mock_dist(
             "a-pkg",

--- a/tests/_models/test_dag.py
+++ b/tests/_models/test_dag.py
@@ -389,4 +389,81 @@ def test_extra_is_satisfied_pkg_in_index_but_not_in_dag(make_mock_dist: MockDist
     dist = DistPackage(make_mock_dist("pkg", "1.0.0", provides_extras=["feat"], requires=["dep ; extra == 'feat'"]))
     idx: dict[str, DistPackage] = {"pkg": dist}
     empty_dag: dict[DistPackage, list[ReqPackage]] = {}
-    assert not _extra_is_satisfied("pkg", "feat", empty_dag, idx, set())
+    assert not _extra_is_satisfied("pkg", "feat", empty_dag, idx)
+
+
+def test_dag_extras_dedupes_identical_metadata_entries(make_mock_dist: MockDistMaker) -> None:
+    # Without dedup, malformed metadata with repeated Requires-Dist entries would yield repeated edges.
+    pkgs = [
+        make_mock_dist(
+            "parent",
+            "1.0.0",
+            requires=["child[feat]"],
+        ),
+        make_mock_dist(
+            "child",
+            "1.0.0",
+            requires=["leaf ; extra == 'feat'", "leaf ; extra == 'feat'"],
+            provides_extras=["feat"],
+        ),
+        make_mock_dist("leaf", "1.0.0"),
+    ]
+    dag = PackageDAG.from_pkgs(pkgs, include_extras=True)
+    leaf_edges = [d for d in dag.get_children("child") if d.key == "leaf"]
+    assert len(leaf_edges) == 1
+
+
+def test_dag_extras_scope_cache_dedupes_cyclic_paths(make_mock_dist: MockDistMaker) -> None:
+    # Multiple branches in a cycle converge on the same (pkg, extra) — without the per-query scope
+    # cache, the convergent node would be re-walked for each path.
+    pkgs = [
+        make_mock_dist(
+            "a-pkg",
+            "1.0.0",
+            requires=["b-pkg[y] ; extra == 'x'", "c-pkg[y] ; extra == 'x'"],
+            provides_extras=["x"],
+        ),
+        make_mock_dist("b-pkg", "1.0.0", requires=["a-pkg[x] ; extra == 'y'"], provides_extras=["y"]),
+        make_mock_dist("c-pkg", "1.0.0", requires=["b-pkg[y] ; extra == 'y'"], provides_extras=["y"]),
+    ]
+    dag = PackageDAG.from_pkgs(pkgs, include_extras=True)
+    assert {d.key for d in dag.get_children("a-pkg")} == {"b-pkg", "c-pkg"}
+
+
+def test_dag_extras_resolver_caches_acyclic_results(make_mock_dist: MockDistMaker) -> None:
+    # Two independent satisfied extras exercise the global cache path, not just the per-query scope cache.
+    pkgs = [
+        make_mock_dist("alpha", "1.0.0", requires=["shared ; extra == 'a'"], provides_extras=["a"]),
+        make_mock_dist("beta", "1.0.0", requires=["shared ; extra == 'b'"], provides_extras=["b"]),
+        make_mock_dist("shared", "1.0.0"),
+    ]
+    dag = PackageDAG.from_pkgs(pkgs, include_extras=True)
+    assert {d.key for d in dag.get_children("alpha")} == {"shared"}
+    assert {d.key for d in dag.get_children("beta")} == {"shared"}
+
+
+def test_dag_extras_unsatisfiable_sub_extra_does_not_activate_parent(make_mock_dist: MockDistMaker) -> None:
+    # Parent's extra requires a sub-package's extra that has no requirements gated behind it; that
+    # sub-extra is vacuously unsatisfied, so parent's extra must also count as unsatisfied.
+    pkgs = [
+        make_mock_dist("parent", "1.0.0", requires=["child[empty] ; extra == 'feat'"], provides_extras=["feat"]),
+        make_mock_dist("child", "1.0.0", provides_extras=["empty"]),
+    ]
+    dag = PackageDAG.from_pkgs(pkgs, include_extras=True)
+    assert dag.get_children("parent") == []
+
+
+def test_dag_extras_resolves_chains_deeper_than_recursion_limit(make_mock_dist: MockDistMaker) -> None:
+    # An extras chain longer than Python's default recursion limit must still resolve; a recursive
+    # implementation of the satisfaction check would raise RecursionError here.
+    chain_length = 1500
+    pkgs: list[Any] = [make_mock_dist("leaf", "1.0.0")]
+    pkgs.append(
+        make_mock_dist(f"l{chain_length - 1}", "1.0.0", requires=["leaf ; extra == 'x'"], provides_extras=["x"])
+    )
+    pkgs.extend(
+        make_mock_dist(f"l{i}", "1.0.0", requires=[f"l{i + 1}[x] ; extra == 'x'"], provides_extras=["x"])
+        for i in range(chain_length - 1)
+    )
+    dag = PackageDAG.from_pkgs(pkgs, include_extras=True)
+    assert {dep.key for dep in dag.get_children("l0")} == {"l1"}

--- a/tests/_models/test_package.py
+++ b/tests/_models/test_package.py
@@ -248,10 +248,10 @@ def test_requires_for_extras_yields_matching(make_mock_dist: MockDistMaker) -> N
     dp = DistPackage(dist)
     results = list(dp.requires_for_extras(frozenset({"signedtoken"})))
     assert len(results) == 2
+    assert results[0] == (results[0][0], "signedtoken", "cryptography")
     assert results[0][0].name == "cryptography"
-    assert results[0][1] == "signedtoken"
+    assert results[1] == (results[1][0], "signedtoken", "pyjwt")
     assert results[1][0].name == "pyjwt"
-    assert results[1][1] == "signedtoken"
 
 
 def test_requires_for_extras_skips_non_matching(make_mock_dist: MockDistMaker) -> None:
@@ -304,6 +304,25 @@ def test_requires_for_extras_skips_invalid_requirements(make_mock_dist: MockDist
     results = list(dp.requires_for_extras(frozenset({"dev"})))
     assert len(results) == 1
     assert results[0][0].name == "bar"
+
+
+def test_requires_for_extras_no_extras_provided(make_mock_dist: MockDistMaker) -> None:
+    # The cached index must short-circuit when Provides-Extra is empty so unrelated environments stay cheap.
+    dist = make_mock_dist("foo", "1.0.0", requires=["bar ; extra == 'never'"])
+    dp = DistPackage(dist)
+    assert list(dp.requires_for_extras(frozenset({"never"}))) == []
+
+
+def test_requires_for_extras_marker_matches_no_declared_extra(make_mock_dist: MockDistMaker) -> None:
+    # Reqs gated by extras not in Provides-Extra must not be reported, otherwise typos in metadata leak edges.
+    dist = make_mock_dist(
+        "foo",
+        "1.0.0",
+        requires=["bar ; extra == 'undeclared'"],
+        provides_extras=["dev"],
+    )
+    dp = DistPackage(dist)
+    assert list(dp.requires_for_extras(frozenset({"dev"}))) == []
 
 
 def test_req_package_render_as_branch_with_extra() -> None:


### PR DESCRIPTION
Issue #559 reported that `--extras` turned a one-second invocation into an eighteen-second one and inflated the rendered tree from 700 to 20,000 lines on a real codebase. The cause was three compounding sources in the satisfaction check: PEP 508 parsing of every `Requires-Dist` on every call, no memoization across the top-level `(pkg, extra)` queries iterated by `_collect_satisfied_extras`, and unbounded edge appends across resolution rounds. A separate hotspot in the renderer reread each package's METADATA file once per emitted edge, which dominated the wall-clock cost on large environments. The active-iff-installed semantic itself is correct because it mirrors the runtime `try: import optional_dep` idiom Python libraries use; the goal was to keep that meaning while making the implementation match it in cost.

## How resolution works now

Every `(pkg, extra)` query consults a three-tier cache before doing any work, and every result lands in the cache appropriate to its provenance:

```mermaid
flowchart TD
    Q["is_satisfied(pkg, extra)"]:::start --> L{lookup}
    L -->|hit global cache| R1[return cached]:::cached
    L -->|hit scope cache| R2["return cached, used=True"]:::tentative
    L -->|in_progress| R3["return True, used=True (cycle)"]:::tentative
    L -->|miss| W[push frame on stack]:::work
    W --> S[advance one step]:::work
    S -->|sub-extra to resolve| L
    S -->|all subs done| F{used cycle?}
    F -->|yes| SC[scope_cache - per query]:::tentative
    F -->|no| GC[global cache - across queries]:::cached
    SC --> POP[pop frame]:::work
    GC --> POP
    classDef start fill:#2980b9,color:#fff,stroke:#1c5980
    classDef cached fill:#27ae60,color:#fff,stroke:#1e8449
    classDef tentative fill:#8e44ad,color:#fff,stroke:#5b2c6f
    classDef work fill:#e67e22,color:#fff,stroke:#a04000
```

⚡ Splitting the cache this way preserves the original "fresh `visited` per top-level call" semantics, where a node's truth value can legitimately differ depending on the cycle entry point, while still amortizing the acyclic majority of work across the whole environment. The walk itself is iterative on an explicit frame stack:

```mermaid
flowchart LR
    subgraph Before
        A[recursive _resolve]:::work -->|"chain > 1000"| AE[RecursionError]:::fail
        A -->|large SCC| AE
    end
    subgraph After
        B[stack-based _resolve]:::work -->|any depth| BE[resolves]:::cached
    end
    classDef work fill:#e67e22,color:#fff,stroke:#a04000
    classDef fail fill:#e74c3c,color:#fff,stroke:#922b21
    classDef cached fill:#27ae60,color:#fff,stroke:#1e8449
```

`DistPackage` parses each `Requires-Dist` exactly once into a shared cached property feeding both the mandatory iterator and the extras index, with canonical dep keys precomputed so the hot path skips `canonicalize_name`. Edge deduplication in `_resolve_extras` keeps malformed metadata with repeated `Requires-Dist` entries from producing repeated edges. `DistPackage.version` is cached too, so the renderer no longer reparses METADATA for every emitted node.

## Real-world impact

A virtualenv assembled from the packages sparrowt mentioned in the issue (Django, asgiref, pytest, pytest-asyncio, Sphinx, pylint-django, plus the broader Django/REST/Celery/Sphinx/scientific Python ecosystems they would coexist with):

| Environment | Operation | Output | Baseline | This PR | Speedup |
|---|---|---:|---:|---:|---:|
| 268 pkgs (Django + ML + REST stack) | `--extras` | 79 433 lines | 7.71 s | **0.44 s** | **17.5x** |
| 268 pkgs (same env) | `--no-extras` | 2 523 lines | 0.49 s | **0.25 s** | **2.0x** |
| 174 pkgs (Django + Sphinx + tooling) | `--extras` | 6 968 lines | 1.07 s | **0.91 s** | 1.2x |

The 268-package environment matches sparrowt's reported scale (their `--extras` produced ~20 000 lines and ran in ~18 seconds; this env's render is ~4x larger and now runs in 0.44 seconds).

## Synthetic stress tests

Fully connected `(pkg, extra)` SCC where every extra is satisfied — the worst case the active-iff-installed semantic can produce:

| Workload (libs / extras / deps) | Baseline | This PR | Speedup |
|---|---:|---:|---:|
| 50 / 3 / 2 | 2562 ms | 41 ms | **62x** |
| 100 / 4 / 3 | 38 032 ms | 370 ms | **103x** |
| 200 / 5 / 4 | `RecursionError` | 3108 ms | resolves |

Acyclic deep chains (the asgiref → pytest → Sphinx pattern from the issue):

| Library count | Baseline | This PR | Speedup |
|---|---:|---:|---:|
| 1000 | 278 ms | 74 ms | **3.8x** |
| 5000 | (untested) | 414 ms | scales |
| 1500-deep chain | `RecursionError` | passes | resolves |

📝 Documentation across the four Diataxis sections gained an explanation of the active-iff-importable semantic, an annotated how-to example, an enriched CLI help string, and a tutorial pointer; that rule used to surface only in the source. No CLI semantics change, so existing invocations behave identically.

Closes #559.