### PR TITLE
refactor: Remove setuptools check when getting installed version

### DIFF
--- a/src/pipdeptree/_models/package.py
+++ b/src/pipdeptree/_models/package.py
@@ -291,9 +291,6 @@ class ReqPackage(Package):
                 return version(self.key)
             except PackageNotFoundError:
                 pass
-            # Avoid AssertionError with setuptools, see https://github.com/tox-dev/pipdeptree/issues/162
-            if self.key == "setuptools":
-                return self.UNKNOWN_VERSION
             try:
                 m = import_module(self.key)
             except ImportError:

--- a/tests/_models/test_package.py
+++ b/tests/_models/test_package.py
@@ -21,14 +21,6 @@ def sort_map_values(m: dict[str, Any]) -> dict[str, Any]:
     return {k: sorted(v) for k, v in m.items()}
 
 
-def test_guess_version_setuptools(mocker: MockerFixture) -> None:
-    mocker.patch("pipdeptree._models.package.version", side_effect=PackageNotFoundError)
-    r = MagicMock()
-    r.name = "setuptools"
-    result = ReqPackage(r).installed_version
-    assert result == "?"
-
-
 def test_package_as_frozen_repr(mocker: MockerFixture) -> None:
     foo = Mock(metadata={"Name": "foo"}, version="1.2.3")
     dp = DistPackage(foo)


### PR DESCRIPTION
`ReqPackage.installed_version` provided a check to see if `setuptools` was installed and if so it would return with the`UNKNOWN_VERSION` string. Put simply this was done because because when `pip` was imported and then `setuptools` was imported (imported in order to find the version) it would cause an `AssertionError`.

With private pip API being completely removed with our implementation of freeze requirements, this problem should no longer occur.