### PR TITLE
✨ feat(extras): default --extras to explicit, add active/none modes

### DIFF
--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -68,23 +68,23 @@ Circular dependency detection uses cycle detection on the directed dependency gr
 Optional dependencies (extras)
 ------------------------------
 
-When you pass ``--extras``, pipdeptree augments the tree with optional dependency edges. Two kinds
-of extras are surfaced:
+The ``--extras`` option controls which optional dependency edges appear in the tree. It takes one
+of three values:
 
-1. **Explicitly requested extras.** When a parent's metadata records a dependency like
-   ``oauthlib[signedtoken]``, the deps gated behind oauthlib's ``signedtoken`` extra get
-   added under oauthlib in the tree, annotated with ``extra: signedtoken``.
+``explicit`` (the default)
+    Show an extra only when a parent's metadata requests it via ``name[extra]``, such as
+    ``oauthlib[signedtoken]``. The deps gated behind that extra are added under the parent,
+    annotated with ``extra: signedtoken``. This propagates: if ``A[x]`` pulls in ``B[y]``, the
+    deps ``B[y]`` gates are added too.
 
-2. **Active extras.** Python packaging metadata never records *why* a package was installed,
-   only what it could require. pipdeptree therefore considers an extra "active" when every dep
-   that extra would have requested is already installed -- the same heuristic Python libraries use
-   at runtime to decide whether a feature is available (``try: import optional_dep``). When an
-   extra is active, pipdeptree adds the same edges it would have added if the extra had been
-   requested explicitly.
+``active``
+    Everything ``explicit`` shows, plus extras that nothing requested but whose dependencies are
+    all installed. Packaging metadata never records why a package was installed, so this treats a
+    satisfiable extra as if it had been requested. The same package can then appear under several
+    parents, and the tree grows accordingly.
 
-Both kinds propagate. If activating ``A[x]`` pulls in ``B[y]``, pipdeptree also adds the deps
-``B[y]`` would gate. Because metadata cannot tell us that ``B`` was installed for some other
-reason, the same package may appear under multiple parents through this mechanism.
+``none``
+    Omit optional edges entirely.
 
 .. mermaid::
 
@@ -96,16 +96,16 @@ reason, the same package may appear under multiple parents through this mechanis
         style C fill:#8e44ad,color:#fff
         style P fill:#8e44ad,color:#fff
 
-To leave optional edges out entirely, omit ``--extras`` (the default). Edges added through
-extras are always annotated with the originating extra, so they remain distinguishable from
-mandatory dependencies in every output format.
+Edges added through an extra are always annotated with the originating extra, so they stay
+distinguishable from mandatory dependencies in every output format.
 
 Limitations
 -----------
 
 - pipdeptree only sees packages that are already installed. It cannot predict what a ``pip install`` will do.
 - If you need a dependency resolver that works without installing packages first, consider :pypi:`uv`.
-- Extra/optional dependencies are not shown by default; use ``--extras`` to include them.
+- Optional dependencies show by default (``--extras=explicit``); use ``--extras=none`` to omit them,
+  or ``--extras=active`` to also include extras that are merely satisfiable.
 - ``--extras`` cannot reconstruct extras that were requested only on the command line
   (e.g. ``pip install foo[dev]`` where ``foo`` is itself top-level), because that information
   is never persisted into installed package metadata.

--- a/src/pipdeptree/__main__.py
+++ b/src/pipdeptree/__main__.py
@@ -44,7 +44,7 @@ def main(args: Sequence[str] | None = None) -> int | None:
         print(f"Failed to query custom interpreter: {e}", file=sys.stderr)  # noqa: T201
         return 1
 
-    tree = PackageDAG.from_pkgs(pkgs, include_extras=options.extras)
+    tree = PackageDAG.from_pkgs(pkgs, extras=options.extras)
 
     validate(tree)
 

--- a/src/pipdeptree/_cli.py
+++ b/src/pipdeptree/_cli.py
@@ -4,9 +4,10 @@ import sys
 import warnings
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, ArgumentTypeError, Namespace
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, cast, get_args
 
 from pipdeptree._computed import ComputedValues
+from pipdeptree._models.dag import ExtrasMode
 
 from .version import __version__
 
@@ -33,7 +34,7 @@ class Options(Namespace):
     mermaid: bool
     graphviz_format: str | None
     output_format: str
-    extras: bool
+    extras: ExtrasMode
     depth: float
     encoding: str
     license: bool
@@ -141,12 +142,14 @@ def build_parser() -> ArgumentParser:
     select.add_argument(
         "-x",
         "--extras",
-        action="store_true",
-        default=False,
+        nargs="?",
+        const="explicit",
+        choices=get_args(ExtrasMode),
+        default="explicit",
         help=(
-            "include optional (extras) dependencies in the tree; an extra is included when it is "
-            "explicitly requested (e.g. ``foo[bar]``) or when every dependency the extra would "
-            "require is already installed"
+            "which optional (extras) dependencies to include: 'explicit' (default) shows extras requested via "
+            "name[extra], including transitively; 'active' also shows extras whose dependencies are all "
+            "installed; 'none' shows none. Bare --extras means 'explicit'"
         ),
     )
 

--- a/src/pipdeptree/_models/dag.py
+++ b/src/pipdeptree/_models/dag.py
@@ -6,7 +6,7 @@ from collections.abc import Iterator, Mapping
 from enum import Enum, auto
 from fnmatch import fnmatch
 from itertools import chain
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from packaging.utils import canonicalize_name
 
@@ -19,6 +19,8 @@ if TYPE_CHECKING:
 from pipdeptree._warning import get_warning_printer
 
 from .package import DistPackage, InvalidRequirementError, ReqPackage
+
+ExtrasMode = Literal["none", "explicit", "active"]
 
 
 class IncludeExcludeOverlapError(Exception):
@@ -57,7 +59,7 @@ class PackageDAG(Mapping[DistPackage, list[ReqPackage]]):
         cls,
         pkgs: list[Distribution],
         *,
-        include_extras: bool = False,
+        extras: ExtrasMode = "none",
     ) -> PackageDAG:
         warning_printer = get_warning_printer()
         dist_pkgs = [DistPackage(p) for p in pkgs]
@@ -91,8 +93,8 @@ class PackageDAG(Mapping[DistPackage, list[ReqPackage]]):
                 lambda: render_invalid_reqs_text(dist_name_to_invalid_reqs_dict),
             )
 
-        if include_extras:
-            _resolve_extras(pkg_deps, idx)
+        if extras != "none":
+            _resolve_extras(pkg_deps, idx, extras)
 
         return cls(pkg_deps)
 
@@ -367,19 +369,19 @@ class ReversedPackageDAG(PackageDAG):
         return PackageDAG(dict(forward_dag))
 
 
-def _resolve_extras(pkg_deps: dict[DistPackage, list[ReqPackage]], idx: dict[str, DistPackage]) -> None:
+def _resolve_extras(
+    pkg_deps: dict[DistPackage, list[ReqPackage]], idx: dict[str, DistPackage], extras: ExtrasMode
+) -> None:
     """Add extra/optional dependencies to the DAG in-place."""
-    extras_needed = _collect_explicit_extras(pkg_deps)
-    for pkg_key, extras in _collect_satisfied_extras(pkg_deps, idx).items():
-        extras_needed.setdefault(pkg_key, set()).update(extras)
+    extras_needed = _seed_extras(pkg_deps, idx, extras)
     processed: dict[str, set[str]] = {}
     # The same (parent, child, extra) triple can be reached through multiple req.extras propagation
     # paths across rounds; without dedup it would be appended once per path.
     seen_edges: set[tuple[str, str, str]] = set()
     while extras_needed:
         next_round: dict[str, set[str]] = {}
-        for pkg_key, extras in extras_needed.items():
-            new_extras = extras - processed.get(pkg_key, set())
+        for pkg_key, wanted in extras_needed.items():
+            new_extras = wanted - processed.get(pkg_key, set())
             if not new_extras:
                 continue
             processed.setdefault(pkg_key, set()).update(new_extras)
@@ -398,6 +400,17 @@ def _resolve_extras(pkg_deps: dict[DistPackage, list[ReqPackage]], idx: dict[str
                 if req.extras:
                     next_round.setdefault(dist.key, set()).update(req.extras)
         extras_needed = next_round
+
+
+def _seed_extras(
+    pkg_deps: dict[DistPackage, list[ReqPackage]], idx: dict[str, DistPackage], extras: ExtrasMode
+) -> dict[str, set[str]]:
+    """Collect the extras to resolve: requested extras, plus satisfiable ones in active mode."""
+    extras_needed = _collect_explicit_extras(pkg_deps)
+    if extras == "active":
+        for pkg_key, satisfied in _collect_satisfied_extras(pkg_deps, idx).items():
+            extras_needed.setdefault(pkg_key, set()).update(satisfied)
+    return extras_needed
 
 
 def _collect_explicit_extras(pkg_deps: dict[DistPackage, list[ReqPackage]]) -> dict[str, set[str]]:
@@ -575,6 +588,7 @@ def _extra_is_satisfied(
 
 
 __all__ = [
+    "ExtrasMode",
     "PackageDAG",
     "ReversedPackageDAG",
 ]

--- a/src/pipdeptree/_models/package.py
+++ b/src/pipdeptree/_models/package.py
@@ -14,7 +14,6 @@ from pipdeptree._parser import distribution_to_specifier
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
-    from importlib.metadata import Distribution
 
 
 class InvalidRequirementError(ValueError):

--- a/tests/_models/test_dag.py
+++ b/tests/_models/test_dag.py
@@ -10,8 +10,10 @@ from pipdeptree._models.dag import IncludeExcludeOverlapError, IncludePatternNot
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
+    from importlib.metadata import Distribution
     from unittest.mock import Mock
 
+    from pipdeptree._models.dag import ExtrasMode
     from tests.conftest import MockDistMaker
     from tests.our_types import MockGraph
 
@@ -266,7 +268,7 @@ def test_package_from_pkgs_given_invalid_requirements(
     )
 
 
-def _build_extras_dag(make_mock_dist: MockDistMaker, *, include_extras: bool = True) -> PackageDAG:
+def _build_extras_dag(make_mock_dist: MockDistMaker, *, extras: ExtrasMode = "active") -> PackageDAG:
     pkgs = [
         make_mock_dist("jira", "2.0.0", requires=["oauthlib[signedtoken]>=1.0.0", "requests>=2.10.0"]),
         make_mock_dist(
@@ -279,28 +281,29 @@ def _build_extras_dag(make_mock_dist: MockDistMaker, *, include_extras: bool = T
         make_mock_dist("cryptography", "2.7"),
         make_mock_dist("pyjwt", "1.7.1"),
     ]
-    return PackageDAG.from_pkgs(pkgs, include_extras=include_extras)
+    return PackageDAG.from_pkgs(pkgs, extras=extras)
 
 
-def test_dag_extras_includes_extra_deps(make_mock_dist: MockDistMaker) -> None:
-    dag = _build_extras_dag(make_mock_dist, include_extras=True)
+@pytest.mark.parametrize(
+    ("extras", "shown"),
+    [
+        pytest.param("active", True, id="active"),
+        pytest.param("explicit", True, id="explicit"),
+        pytest.param("none", False, id="none"),
+    ],
+)
+def test_dag_extras_requested_deps_by_mode(make_mock_dist: MockDistMaker, extras: ExtrasMode, shown: bool) -> None:
+    dag = _build_extras_dag(make_mock_dist, extras=extras)
     dep_keys = {dep.key for dep in dag.get_children("oauthlib")}
-    assert "cryptography" in dep_keys
-    assert "pyjwt" in dep_keys
+    assert ("cryptography" in dep_keys) is shown
+    assert ("pyjwt" in dep_keys) is shown
 
 
 def test_dag_extras_annotates_extra_name(make_mock_dist: MockDistMaker) -> None:
-    dag = _build_extras_dag(make_mock_dist, include_extras=True)
+    dag = _build_extras_dag(make_mock_dist, extras="active")
     extra_deps = [dep for dep in dag.get_children("oauthlib") if dep.extra is not None]
     assert len(extra_deps) == 2
     assert all(dep.extra == "signedtoken" for dep in extra_deps)
-
-
-def test_dag_without_extras_excludes_extra_deps(make_mock_dist: MockDistMaker) -> None:
-    dag = _build_extras_dag(make_mock_dist, include_extras=False)
-    dep_keys = {dep.key for dep in dag.get_children("oauthlib")}
-    assert "cryptography" not in dep_keys
-    assert "pyjwt" not in dep_keys
 
 
 def test_dag_extras_skips_missing_deps(make_mock_dist: MockDistMaker) -> None:
@@ -308,21 +311,35 @@ def test_dag_extras_skips_missing_deps(make_mock_dist: MockDistMaker) -> None:
         make_mock_dist("parent", "1.0.0", requires=["child[feat]"]),
         make_mock_dist("child", "1.0.0", requires=["ghost ; extra == 'feat'"], provides_extras=["feat"]),
     ]
-    dag = PackageDAG.from_pkgs(pkgs, include_extras=True)
+    dag = PackageDAG.from_pkgs(pkgs, extras="active")
     assert len(dag.get_children("child")) == 0
 
 
-def test_dag_extras_includes_satisfied_extras(make_mock_dist: MockDistMaker) -> None:
-    pkgs = [
+@pytest.fixture
+def satisfied_only_pkgs(make_mock_dist: MockDistMaker) -> list[Distribution]:
+    return [
         make_mock_dist(
             "myapp", "1.0.0", requires=["requests>=2.0", "pytest ; extra == 'test'"], provides_extras=["test"]
         ),
         make_mock_dist("requests", "2.22.0"),
         make_mock_dist("pytest", "7.0.0"),
     ]
-    dag = PackageDAG.from_pkgs(pkgs, include_extras=True)
+
+
+@pytest.mark.parametrize(
+    ("extras", "pytest_shown"),
+    [
+        pytest.param("active", True, id="active-infers-satisfied"),
+        pytest.param("explicit", False, id="explicit-skips-satisfied"),
+    ],
+)
+def test_dag_extras_satisfied_only_depends_on_mode(
+    satisfied_only_pkgs: list[Distribution], extras: ExtrasMode, pytest_shown: bool
+) -> None:
+    # pytest is installed but never requested as myapp[test]; only active mode infers it.
+    dag = PackageDAG.from_pkgs(satisfied_only_pkgs, extras=extras)
     dep_keys = {dep.key for dep in dag.get_children("myapp")}
-    assert "pytest" in dep_keys
+    assert ("pytest" in dep_keys) is pytest_shown
     assert "requests" in dep_keys
 
 
@@ -330,7 +347,7 @@ def test_dag_extras_skips_unsatisfied_extras(make_mock_dist: MockDistMaker) -> N
     pkgs = [
         make_mock_dist("myapp", "1.0.0", requires=["missing-dep ; extra == 'feat'"], provides_extras=["feat"]),
     ]
-    dag = PackageDAG.from_pkgs(pkgs, include_extras=True)
+    dag = PackageDAG.from_pkgs(pkgs, extras="active")
     assert len(dag.get_children("myapp")) == 0
 
 
@@ -340,7 +357,7 @@ def test_dag_extras_satisfied_on_transitive_package(make_mock_dist: MockDistMake
         make_mock_dist("middle", "1.0.0", requires=["bottom ; extra == 'feat'"], provides_extras=["feat"]),
         make_mock_dist("bottom", "1.0.0"),
     ]
-    dag = PackageDAG.from_pkgs(pkgs, include_extras=True)
+    dag = PackageDAG.from_pkgs(pkgs, extras="active")
     dep_keys = {dep.key for dep in dag.get_children("middle")}
     assert "bottom" in dep_keys
 
@@ -350,7 +367,7 @@ def test_dag_extras_satisfied_checks_sub_extras(make_mock_dist: MockDistMaker) -
         make_mock_dist("outer", "1.0.0", requires=["inner[feat] ; extra == 'feat'"], provides_extras=["feat"]),
         make_mock_dist("inner", "1.0.0", requires=["leaf ; extra == 'feat'"], provides_extras=["feat"]),
     ]
-    dag = PackageDAG.from_pkgs(pkgs, include_extras=True)
+    dag = PackageDAG.from_pkgs(pkgs, extras="active")
     assert len(dag.get_children("outer")) == 0
 
 
@@ -361,7 +378,7 @@ def test_dag_extras_transitive(make_mock_dist: MockDistMaker) -> None:
         make_mock_dist("c-pkg", "1.0.0", requires=["d-pkg ; extra == 'y'"], provides_extras=["y"]),
         make_mock_dist("d-pkg", "1.0.0"),
     ]
-    dag = PackageDAG.from_pkgs(pkgs, include_extras=True)
+    dag = PackageDAG.from_pkgs(pkgs, extras="active")
     dep_keys = {dep.key for dep in dag.get_children("c-pkg")}
     assert "d-pkg" in dep_keys
 
@@ -372,14 +389,14 @@ def test_dag_extras_cyclic_terminates(make_mock_dist: MockDistMaker) -> None:
         make_mock_dist("b-pkg", "1.0.0", requires=["c-pkg[y] ; extra == 'x'"], provides_extras=["x"]),
         make_mock_dist("c-pkg", "1.0.0", requires=["b-pkg[x] ; extra == 'y'"], provides_extras=["y"]),
     ]
-    dag = PackageDAG.from_pkgs(pkgs, include_extras=True)
+    dag = PackageDAG.from_pkgs(pkgs, extras="active")
     dep_keys = {dep.key for dep in dag.get_children("b-pkg")}
     assert "c-pkg" in dep_keys
 
 
 def test_dag_extras_skips_unresolved_extras_package(make_mock_dist: MockDistMaker) -> None:
     pkgs = [make_mock_dist("parent", "1.0.0", requires=["nonexistent[feat]"])]
-    dag = PackageDAG.from_pkgs(pkgs, include_extras=True)
+    dag = PackageDAG.from_pkgs(pkgs, extras="active")
     deps = dag.get_children("parent")
     assert len(deps) == 1
     assert deps[0].dist is None
@@ -408,7 +425,7 @@ def test_dag_extras_dedupes_identical_metadata_entries(make_mock_dist: MockDistM
         ),
         make_mock_dist("leaf", "1.0.0"),
     ]
-    dag = PackageDAG.from_pkgs(pkgs, include_extras=True)
+    dag = PackageDAG.from_pkgs(pkgs, extras="active")
     leaf_edges = [d for d in dag.get_children("child") if d.key == "leaf"]
     assert len(leaf_edges) == 1
 
@@ -424,7 +441,7 @@ def test_dag_extras_cyclic_convergent_paths_resolve_correctly(make_mock_dist: Mo
         make_mock_dist("b-pkg", "1.0.0", requires=["a-pkg[x] ; extra == 'y'"], provides_extras=["y"]),
         make_mock_dist("c-pkg", "1.0.0", requires=["b-pkg[y] ; extra == 'y'"], provides_extras=["y"]),
     ]
-    dag = PackageDAG.from_pkgs(pkgs, include_extras=True)
+    dag = PackageDAG.from_pkgs(pkgs, extras="active")
     assert {d.key for d in dag.get_children("a-pkg")} == {"b-pkg", "c-pkg"}
 
 
@@ -435,7 +452,7 @@ def test_dag_extras_resolver_caches_acyclic_results(make_mock_dist: MockDistMake
         make_mock_dist("beta", "1.0.0", requires=["shared ; extra == 'b'"], provides_extras=["b"]),
         make_mock_dist("shared", "1.0.0"),
     ]
-    dag = PackageDAG.from_pkgs(pkgs, include_extras=True)
+    dag = PackageDAG.from_pkgs(pkgs, extras="active")
     assert {d.key for d in dag.get_children("alpha")} == {"shared"}
     assert {d.key for d in dag.get_children("beta")} == {"shared"}
 
@@ -447,7 +464,7 @@ def test_dag_extras_unsatisfiable_sub_extra_does_not_activate_parent(make_mock_d
         make_mock_dist("parent", "1.0.0", requires=["child[empty] ; extra == 'feat'"], provides_extras=["feat"]),
         make_mock_dist("child", "1.0.0", provides_extras=["empty"]),
     ]
-    dag = PackageDAG.from_pkgs(pkgs, include_extras=True)
+    dag = PackageDAG.from_pkgs(pkgs, extras="active")
     assert dag.get_children("parent") == []
 
 
@@ -463,5 +480,5 @@ def test_dag_extras_resolves_chains_deeper_than_recursion_limit(make_mock_dist: 
         make_mock_dist(f"l{i}", "1.0.0", requires=[f"l{i + 1}[x] ; extra == 'x'"], provides_extras=["x"])
         for i in range(chain_length - 1)
     )
-    dag = PackageDAG.from_pkgs(pkgs, include_extras=True)
+    dag = PackageDAG.from_pkgs(pkgs, extras="active")
     assert {dep.key for dep in dag.get_children("l0")} == {"l1"}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import locale
+from importlib.metadata import Distribution, PackageMetadata
 from pathlib import Path
 from random import shuffle
 from typing import TYPE_CHECKING, Protocol
-from unittest.mock import MagicMock, Mock
+from unittest.mock import Mock
 
 import pytest
 
@@ -12,7 +13,8 @@ from pipdeptree._models import PackageDAG
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
-    from importlib.metadata import Distribution
+
+    from pytest_mock import MockerFixture
 
     from tests.our_types import MockGraph
 
@@ -82,21 +84,24 @@ class MockDistMaker(Protocol):
     ) -> Distribution: ...
 
 
-def _make_mock_dist(
-    name: str,
-    version: str,
-    requires: list[str] | None = None,
-    provides_extras: list[str] | None = None,
-) -> Distribution:
-    metadata = MagicMock()
-    metadata.__getitem__ = lambda _, key: {"Name": name}.get(key)
-    metadata.get_all = lambda key: provides_extras if key == "Provides-Extra" else None
-    return Mock(metadata=metadata, version=version, requires=requires)
+@pytest.fixture
+def make_mock_dist(mocker: MockerFixture) -> MockDistMaker:
+    def func(
+        name: str,
+        version: str,
+        requires: list[str] | None = None,
+        provides_extras: list[str] | None = None,
+    ) -> Distribution:
+        metadata = mocker.create_autospec(PackageMetadata, instance=True)
+        metadata.__getitem__.side_effect = {"Name": name}.get
+        metadata.get_all.side_effect = lambda key, failobj=None: provides_extras if key == "Provides-Extra" else failobj
+        dist = mocker.create_autospec(Distribution, instance=True)
+        dist.metadata = metadata
+        dist.version = version
+        dist.requires = requires
+        return dist
 
-
-@pytest.fixture(scope="session")
-def make_mock_dist() -> MockDistMaker:
-    return _make_mock_dist
+    return func
 
 
 @pytest.fixture

--- a/tests/render/test_json.py
+++ b/tests/render/test_json.py
@@ -66,7 +66,7 @@ def test_render_json_with_extras(capsys: pytest.CaptureFixture[str], make_mock_d
         make_mock_dist("foo", "1.0.0", requires=["bar ; extra == 'dev'"], provides_extras=["dev"]),
         make_mock_dist("bar", "2.0.0"),
     ]
-    dag = PackageDAG.from_pkgs(pkgs, include_extras=True)
+    dag = PackageDAG.from_pkgs(pkgs, extras="active")
     render_json(dag)
     output = capsys.readouterr().out
     assert '"extra": "dev"' in output

--- a/tests/render/test_rich_text.py
+++ b/tests/render/test_rich_text.py
@@ -94,7 +94,7 @@ def test_render_rich_text_with_extras(capsys: pytest.CaptureFixture[str], make_m
         ),
         make_mock_dist("cryptography", "2.7"),
     ]
-    dag = PackageDAG.from_pkgs(pkgs, include_extras=True)
+    dag = PackageDAG.from_pkgs(pkgs, extras="active")
     render_rich_text(dag, max_depth=float("inf"))
     output = capsys.readouterr().out
     expected = ["jira==2.0.0", "oauthlib==3.0.0", "[extra: signedtoken]", "cryptography==2.7"]

--- a/tests/render/test_text.py
+++ b/tests/render/test_text.py
@@ -601,7 +601,7 @@ def test_render_text_with_extras(
         ),
         make_mock_dist("cryptography", "2.7"),
     ]
-    dag = PackageDAG.from_pkgs(pkgs, include_extras=True)
+    dag = PackageDAG.from_pkgs(pkgs, extras="active")
     render_text(dag, max_depth=float("inf"), encoding=encoding)
     output = capsys.readouterr().out
     assert "extra: signedtoken" in output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -166,12 +166,29 @@ def test_parse_warn_option_invalid() -> None:
         get_options(["--warn", "non-existent-warning-type"])
 
 
-@pytest.mark.parametrize("flag", ["-x", "--extras"])
-def test_get_options_extras(flag: str) -> None:
-    options = get_options([flag])
-    assert options.extras is True
+@pytest.mark.parametrize(
+    ("args", "expected"),
+    [
+        (["-x"], "explicit"),
+        (["--extras"], "explicit"),
+        (["--extras", "explicit"], "explicit"),
+        (["--extras", "active"], "active"),
+        (["--extras", "none"], "none"),
+    ],
+)
+def test_get_options_extras(args: list[str], expected: str) -> None:
+    options = get_options(args)
+    assert options.extras == expected
 
 
 def test_get_options_extras_default() -> None:
     options = get_options([])
-    assert options.extras is False
+    assert options.extras == "explicit"
+
+
+def test_get_options_extras_invalid(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit, match="2"):
+        get_options(["--extras", "bogus"])
+    out, err = capsys.readouterr()
+    assert not out
+    assert "invalid choice: 'bogus'" in err

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -181,7 +181,7 @@ def test_render_cycles_text_annotates_extras(capsys: pytest.CaptureFixture[str],
         make_mock_dist("a", "1.0.0", requires=["b[x]>=1.0"]),
         make_mock_dist("b", "1.0.0", requires=["a>=1.0 ; extra == 'x'"], provides_extras=["x"]),
     ]
-    tree = PackageDAG.from_pkgs(pkgs, include_extras=True)
+    tree = PackageDAG.from_pkgs(pkgs, extras="active")
     cycles = cyclic_deps(tree)
     assert len(cycles) > 0
     render_cycles_text(cycles)


### PR DESCRIPTION
Closes #559.

The opt-in `--extras` flag treated an extra as present whenever every dependency it could pull in happened to be installed. On real environments that heuristic exploded the tree (a user reported 20k lines versus 700) because a package installed for any reason was taken as proof that an extra gating it was active, so it resurfaced under every parent that could have requested it. 🌳 The thread on #559 converged on showing only the extras a project actually asks for.

`--extras` now takes a mode and defaults on. `explicit`, the default, shows an extra only when a parent requests it via `name[extra]`, and follows that transitively, which answers the common "why is this package here" question without the noise. `active` keeps the previous satisfiable-deps heuristic for anyone who wants to discover which extras could be in use. `none` restores extra-free output. The flag still accepts a bare `--extras` (it maps to `explicit`), and the accepted values derive from the `ExtrasMode` literal through `typing.get_args`, so the type and the argparse choices cannot drift apart.

This changes default output, so it is a breaking change: invocations that relied on extras being hidden need `--extras=none`. ⚠️ The rendering of extra edges is unchanged; each one still carries its originating `extra:` annotation in every format.