### PR TITLE
✨ feat(cli): auto-detect active virtualenv by default

### DIFF
--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -4,7 +4,15 @@ Usage patterns
 Running in virtualenvs
 ----------------------
 
-If pipdeptree is installed globally but you want to inspect a virtualenv, use ``--python``:
+By default pipdeptree auto-detects your active virtual environment (venv, virtualenv, conda, or poetry) and inspects
+it. When no virtual environment is active, it falls back to the interpreter running pipdeptree, so a globally
+installed pipdeptree keeps inspecting the global packages:
+
+.. code-block:: console
+
+    $ pipdeptree
+
+To inspect a specific interpreter regardless of what is active, pass its path to ``--python``:
 
 .. code-block:: console
 
@@ -13,7 +21,8 @@ If pipdeptree is installed globally but you want to inspect a virtualenv, use ``
     └── coverage [required: >=6.0.2, installed: 7.13.5]
     ...
 
-As of version 2.21.0, you can use ``--python auto`` to auto-detect the active virtualenv:
+Use ``--python auto`` to force auto-detection of the active virtualenv and fail if none can be found (unlike the
+default, which silently falls back to the running interpreter):
 
 .. code-block:: console
 

--- a/src/pipdeptree/__main__.py
+++ b/src/pipdeptree/__main__.py
@@ -6,7 +6,7 @@ import sys
 from typing import TYPE_CHECKING
 
 from pipdeptree._cli import Options, get_options
-from pipdeptree._detect_env import detect_active_interpreter
+from pipdeptree._detect_env import detect_active_interpreter, find_active_interpreter
 from pipdeptree._discovery import InterpreterQueryError, get_installed_distributions
 from pipdeptree._models import PackageDAG
 from pipdeptree._models.dag import IncludeExcludeOverlapError, IncludePatternNotFoundError
@@ -28,10 +28,7 @@ def main(args: Sequence[str] | None = None) -> int | None:
     warning_printer = get_warning_printer()
     warning_printer.warning_type = WarningType.from_str(options.warn)
 
-    if options.python == "auto":
-        resolved_path = detect_active_interpreter()
-        options.python = resolved_path
-        print(f"(resolved python: {resolved_path})", file=sys.stderr)  # noqa: T201
+    options.python = _resolve_python(options.python)
 
     try:
         pkgs = get_installed_distributions(
@@ -72,6 +69,21 @@ def main(args: Sequence[str] | None = None) -> int | None:
     render(options, tree)
 
     return _determine_return_code(warning_printer)
+
+
+def _resolve_python(python: str | None) -> str:
+    # Default (None): auto-detect the active virtual environment, silently falling back to the running interpreter so
+    # users outside a virtual environment keep the historical behavior. "auto" stays strict and fails if none is found.
+    if python is None:
+        if resolved_path := find_active_interpreter():
+            print(f"(resolved python: {resolved_path})", file=sys.stderr)  # noqa: T201
+            return resolved_path
+        return sys.executable
+    if python == "auto":
+        resolved_path = detect_active_interpreter()
+        print(f"(resolved python: {resolved_path})", file=sys.stderr)  # noqa: T201
+        return resolved_path
+    return python
 
 
 def _is_text_output(options: Options) -> bool:

--- a/src/pipdeptree/_cli.py
+++ b/src/pipdeptree/_cli.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 class Options(Namespace):
     freeze: bool
-    python: str
+    python: str | None
     path: list[str]
     all: bool
     local_only: bool
@@ -109,10 +109,11 @@ def build_parser() -> ArgumentParser:
     select = parser.add_argument_group(title="select", description="choose what to render")
     select.add_argument(
         "--python",
-        default=sys.executable,
+        default=None,
         help=(
-            'Python interpreter to inspect. With "auto", it attempts to detect your virtual environment and fails if'
-            " it can't."
+            "Python interpreter to inspect. By default it auto-detects your active virtual environment (venv, "
+            "virtualenv, conda, or poetry), falling back to the interpreter running pipdeptree when none is found. "
+            'With "auto" it detects the active virtual environment and fails if it can\'t.'
         ),
     )
     select.add_argument(

--- a/src/pipdeptree/_detect_env.py
+++ b/src/pipdeptree/_detect_env.py
@@ -17,6 +17,15 @@ def detect_active_interpreter() -> str:
 
     If it fails to find any, it will fail with a message.
     """
+    if path := find_active_interpreter():
+        return path
+
+    print("Unable to detect virtual environment.", file=sys.stderr)  # noqa: T201
+    raise SystemExit(1)
+
+
+def find_active_interpreter() -> str | None:
+    """Attempt to detect a venv, virtualenv, poetry, or conda environment, returning ``None`` if none is found."""
     detection_funcs: list[Callable[[], Path | None]] = [
         detect_venv_or_virtualenv_interpreter,
         detect_conda_env_interpreter,
@@ -30,8 +39,7 @@ def detect_active_interpreter() -> str:
             continue
         return str(path)
 
-    print("Unable to detect virtual environment.", file=sys.stderr)  # noqa: T201
-    raise SystemExit(1)
+    return None
 
 
 def detect_venv_or_virtualenv_interpreter() -> Path | None:
@@ -98,4 +106,7 @@ def determine_interpreter_file_name() -> str | None:
     return name
 
 
-__all__ = ["detect_active_interpreter"]
+__all__ = [
+    "detect_active_interpreter",
+    "find_active_interpreter",
+]

--- a/tests/test_detect_env.py
+++ b/tests/test_detect_env.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from pipdeptree._detect_env import detect_active_interpreter
+from pipdeptree._detect_env import detect_active_interpreter, find_active_interpreter
 
 if TYPE_CHECKING:
     from pytest_mock import MockFixture
@@ -71,3 +71,20 @@ def test_detect_active_interpreter_continue_when_other_detections_fail(tmp_path:
     detected_path = detect_active_interpreter()
 
     assert detected_path == str(fake_python_path)
+
+
+def test_find_active_interpreter_returns_path_when_detected(tmp_path: Path, mocker: MockFixture) -> None:
+    mocker.patch("pipdeptree._detect_env.os.environ", {"VIRTUAL_ENV": str(tmp_path)})
+    mocker.patch("pipdeptree._detect_env.Path.exists", return_value=True)
+
+    detected = find_active_interpreter()
+
+    assert detected is not None
+    assert detected.startswith(str(tmp_path))
+
+
+def test_find_active_interpreter_returns_none_when_nothing_detected(mocker: MockFixture) -> None:
+    mocker.patch("pipdeptree._detect_env.os.environ", {})
+    mocker.patch("pipdeptree._detect_env.subprocess.run", side_effect=FileNotFoundError)
+
+    assert find_active_interpreter() is None

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -32,6 +32,10 @@ def test_local_only(tmp_path: Path, mocker: MockerFixture, capfd: pytest.Capture
     mock_path = sys_path + venv_site_packages
     mocker.patch("pipdeptree._discovery.sys.path", mock_path)
     mocker.patch("pipdeptree._discovery.sys.argv", cmd)
+
+    # The test mocks the running interpreter's environment, so keep the default --python on the running interpreter.
+    mocker.patch("pipdeptree.__main__.find_active_interpreter", return_value=None)
+
     main()
     out, _ = capfd.readouterr()
     found = {i.split("==")[0] for i in out.splitlines()}
@@ -50,6 +54,9 @@ def test_user_only(fake_dist: Path, mocker: MockerFixture, capfd: pytest.Capture
     # Add fake user site directory into a fake sys.path (normal environments will have the user site in sys.path).
     fake_sys_path = [*sys.path, fake_user_site]
     mocker.patch("pipdeptree._discovery.sys.path", fake_sys_path)
+
+    # The test mocks the running interpreter's environment, so keep the default --python on the running interpreter.
+    mocker.patch("pipdeptree.__main__.find_active_interpreter", return_value=None)
 
     cmd = ["", "--user-only"]
     mocker.patch("pipdeptree.__main__.sys.argv", cmd)
@@ -75,6 +82,9 @@ def test_user_only_when_in_virtual_env(
     venv_site_packages = site.getsitepackages([venv_path])
     mocker.patch("pipdeptree._discovery.sys.path", venv_site_packages)
     mocker.patch("pipdeptree._discovery.sys.prefix", venv_path)
+
+    # The test mocks the running interpreter's environment, so keep the default --python on the running interpreter.
+    mocker.patch("pipdeptree.__main__.find_active_interpreter", return_value=None)
 
     cmd = ["", "--user-only"]
     mocker.patch("pipdeptree.__main__.sys.argv", cmd)
@@ -107,6 +117,9 @@ def test_user_only_when_in_virtual_env_and_system_site_pkgs_enabled(
     mock_path = sys.path + venv_site_packages + [fake_user_site]
     mocker.patch("pipdeptree._discovery.sys.path", mock_path)
     mocker.patch("pipdeptree._discovery.sys.prefix", venv_path)
+
+    # The test mocks the running interpreter's environment, so keep the default --python on the running interpreter.
+    mocker.patch("pipdeptree.__main__.find_active_interpreter", return_value=None)
 
     cmd = ["", "--user-only"]
     mocker.patch("pipdeptree.__main__.sys.argv", cmd)

--- a/tests/test_main_python.py
+++ b/tests/test_main_python.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+
+from pipdeptree.__main__ import _resolve_python, main
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest_mock import MockFixture
+
+
+def test_resolve_python_default_uses_detected_env(
+    tmp_path: Path, mocker: MockFixture, capsys: pytest.CaptureFixture[str]
+) -> None:
+    mocker.patch("pipdeptree.__main__.find_active_interpreter", return_value=str(tmp_path))
+
+    assert _resolve_python(None) == str(tmp_path)
+
+    assert capsys.readouterr().err == f"(resolved python: {tmp_path})\n"
+
+
+def test_resolve_python_default_falls_back_silently(mocker: MockFixture, capsys: pytest.CaptureFixture[str]) -> None:
+    mocker.patch("pipdeptree.__main__.find_active_interpreter", return_value=None)
+
+    assert _resolve_python(None) == sys.executable
+
+    captured = capsys.readouterr()
+    assert not captured.out
+    assert not captured.err
+
+
+def test_resolve_python_auto_uses_strict_detection(
+    tmp_path: Path, mocker: MockFixture, capsys: pytest.CaptureFixture[str]
+) -> None:
+    mocker.patch("pipdeptree.__main__.detect_active_interpreter", return_value=str(tmp_path))
+
+    assert _resolve_python("auto") == str(tmp_path)
+
+    assert capsys.readouterr().err == f"(resolved python: {tmp_path})\n"
+
+
+def test_resolve_python_auto_fails_when_none_found(mocker: MockFixture, capsys: pytest.CaptureFixture[str]) -> None:
+    mocker.patch("pipdeptree._detect_env.find_active_interpreter", return_value=None)
+
+    with pytest.raises(SystemExit):
+        _resolve_python("auto")
+
+    assert "Unable to detect virtual environment." in capsys.readouterr().err
+
+
+def test_resolve_python_explicit_path_passthrough(capsys: pytest.CaptureFixture[str]) -> None:
+    assert _resolve_python("/explicit/python") == "/explicit/python"
+
+    captured = capsys.readouterr()
+    assert not captured.out
+    assert not captured.err
+
+
+def test_main_default_falls_back_to_sys_executable(mocker: MockFixture, capsys: pytest.CaptureFixture[str]) -> None:
+    mocker.patch("pipdeptree.__main__.sys.argv", ["pipdeptree"])
+    mocker.patch("pipdeptree.__main__.find_active_interpreter", return_value=None)
+    get_installed = mocker.patch("pipdeptree.__main__.get_installed_distributions", return_value=[])
+
+    assert main() == 0
+
+    assert get_installed.call_args.kwargs["interpreter"] == sys.executable
+    assert "Unable to detect virtual environment." not in capsys.readouterr().err


### PR DESCRIPTION
Closes #438.

Running a globally-installed pipdeptree inside an activated virtualenv used to inspect the environment pipdeptree itself lives in, not the one the user is working in. 🐍 `--python auto` was added as a workaround, but most people expect the active environment to be the default target.

`--python` now defaults to auto-detecting the active venv, virtualenv, conda, or poetry environment, and falls back silently to the interpreter running pipdeptree when none is found, so invocations outside any environment keep working exactly as before. `--python auto` keeps its strict behavior (detect or exit with a clear message), and `--python /path` is unchanged. Detection split into a non-failing `find_active_interpreter()` and the strict `detect_active_interpreter()` so the default and `auto` paths share the probe while differing on the not-found outcome.

This changes default behavior, so it is a breaking change: when an environment is active and differs from pipdeptree's own, the tree now reflects the active one. ⚠️ I left out the `--fail-when-venv-not-found` flag floated in the issue, since `--python auto` already provides that strict semantic; happy to add it as an alias if you prefer.