### PR TITLE
✨ feat(cli): accept extras in --packages filter

### DIFF
--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -99,6 +99,21 @@ Multiple packages can be comma-separated, and wildcards are supported:
         ├── pluggy [required: >=1.5,<2, installed: 1.6.0]
         └── Pygments [required: >=2.7.2, installed: 2.19.2]
 
+A package entry may carry an extras spec such as ``somepackage[extra1,extra2]`` to also include the dependencies
+gated behind those extras (and their subtrees). The extras spec is parsed off before the name is matched, so
+wildcards keep working, for example ``somepackage*[extra1]``. An extra requested this way is always surfaced, even
+with ``--extras none``:
+
+.. code-block:: console
+
+    $ pipdeptree --packages "requests[socks]"
+    requests==2.32.3
+    ├── certifi [required: >=2017.4.17, installed: 2024.8.30]
+    ├── charset-normalizer [required: >=2,<4, installed: 3.4.0]
+    ├── idna [required: >=2.5,<4, installed: 3.10]
+    ├── urllib3 [required: >=1.21.1,<3, installed: 2.2.3]
+    └── PySocks [required: >=1.5.6,!=1.5.7, installed: 1.7.1, extra: socks]
+
 Excluding packages
 ------------------
 
@@ -342,3 +357,7 @@ Edges added through an extra are annotated with that extra's name:
 An extra is included not only when a parent explicitly requested it (e.g. ``oauthlib[signedtoken]``)
 but also when every dependency that the extra would require is already installed in the
 environment. See :doc:`/explanation` for the rationale.
+
+To surface a single package's extra without enabling extras globally, request it through ``--packages`` using
+the ``somepackage[extra]`` syntax shown in the "Filtering packages" section above; that extra is shown even with
+``--extras none``.

--- a/src/pipdeptree/__main__.py
+++ b/src/pipdeptree/__main__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sys
 from typing import TYPE_CHECKING
 
-from pipdeptree._cli import Options, get_options
+from pipdeptree._cli import Options, get_options, parse_packages
 from pipdeptree._detect_env import detect_active_interpreter, find_active_interpreter
 from pipdeptree._discovery import InterpreterQueryError, get_installed_distributions
 from pipdeptree._models import PackageDAG
@@ -41,7 +41,8 @@ def main(args: Sequence[str] | None = None) -> int | None:
         print(f"Failed to query custom interpreter: {e}", file=sys.stderr)  # noqa: T201
         return 1
 
-    tree = PackageDAG.from_pkgs(pkgs, extras=options.extras)
+    include, requested_extras = parse_packages(options.packages)
+    tree = PackageDAG.from_pkgs(pkgs, extras=options.extras, requested_extras=requested_extras)
 
     validate(tree)
 
@@ -52,7 +53,7 @@ def main(args: Sequence[str] | None = None) -> int | None:
     if options.reverse:
         tree = tree.reverse()
 
-    include = options.packages.split(",") if options.packages else None
+    include = include or None
     exclude = set(options.exclude.split(",")) if options.exclude else None
 
     if include is not None or exclude is not None:

--- a/src/pipdeptree/_cli.py
+++ b/src/pipdeptree/_cli.py
@@ -125,7 +125,10 @@ def build_parser() -> ArgumentParser:
     select.add_argument(
         "-p",
         "--packages",
-        help="comma separated list of packages to show - wildcards are supported, like 'somepackage.*'",
+        help=(
+            "comma separated list of packages to show - wildcards are supported, like 'somepackage.*'. append an "
+            "extras spec to also show a package's extra dependencies, like ``somepackage[extra1,extra2]``"
+        ),
         metavar="P",
     )
     select.add_argument(
@@ -316,7 +319,54 @@ def _validate_output_format(value: str) -> str:
     raise ArgumentTypeError(msg)
 
 
+def parse_packages(value: str | None) -> tuple[list[str], dict[str, set[str]]]:
+    """
+    Split a ``--packages`` value into bare name patterns and the extras requested per entry.
+
+    An entry like ``foo[bar,baz]`` yields the name pattern ``foo`` and the extras ``{bar, baz}``; plain entries
+    carry no extras. The extras are matched against installed package names later, so wildcard patterns such as
+    ``foo*[bar]`` apply to every package matching ``foo*``.
+    """
+    if not value:
+        return [], {}
+    names: list[str] = []
+    requested_extras: dict[str, set[str]] = {}
+    for raw in _split_entries(value):
+        if not (entry := raw.strip()):
+            continue
+        name, extras = _split_extras(entry)
+        names.append(name)
+        if extras:
+            requested_extras.setdefault(name, set()).update(extras)
+    return names, requested_extras
+
+
+def _split_entries(value: str) -> list[str]:
+    # Split on commas, but not commas inside an ``[...]`` extras spec, so ``foo[a,b],bar`` yields two entries.
+    entries: list[str] = []
+    depth = 0
+    start = 0
+    for index, char in enumerate(value):
+        if char == "[":
+            depth += 1
+        elif char == "]":
+            depth = max(0, depth - 1)
+        elif char == "," and depth == 0:
+            entries.append(value[start:index])
+            start = index + 1
+    entries.append(value[start:])
+    return entries
+
+
+def _split_extras(entry: str) -> tuple[str, set[str]]:
+    if not entry.endswith("]") or "[" not in entry:
+        return entry, set()
+    name, _, extras_part = entry[:-1].partition("[")
+    return name, {extra.strip() for extra in extras_part.split(",") if extra.strip()}
+
+
 __all__ = [
     "Options",
     "get_options",
+    "parse_packages",
 ]

--- a/src/pipdeptree/_models/dag.py
+++ b/src/pipdeptree/_models/dag.py
@@ -60,6 +60,7 @@ class PackageDAG(Mapping[DistPackage, list[ReqPackage]]):
         pkgs: list[Distribution],
         *,
         extras: ExtrasMode = "none",
+        requested_extras: Mapping[str, set[str]] | None = None,
     ) -> PackageDAG:
         warning_printer = get_warning_printer()
         dist_pkgs = [DistPackage(p) for p in pkgs]
@@ -93,8 +94,11 @@ class PackageDAG(Mapping[DistPackage, list[ReqPackage]]):
                 lambda: render_invalid_reqs_text(dist_name_to_invalid_reqs_dict),
             )
 
-        if extras != "none":
-            _resolve_extras(pkg_deps, idx, extras)
+        # User-requested extras (via ``--packages foo[bar]``) are expanded against the actual package keys and
+        # always honored, even with ``--extras none``, so the requested subtree is surfaced before filtering.
+        user_requested = _expand_requested_extras(idx, requested_extras)
+        if extras != "none" or user_requested:
+            _resolve_extras(pkg_deps, idx, extras, user_requested)
 
         return cls(pkg_deps)
 
@@ -369,11 +373,32 @@ class ReversedPackageDAG(PackageDAG):
         return PackageDAG(dict(forward_dag))
 
 
+def _expand_requested_extras(
+    idx: dict[str, DistPackage], requested_extras: Mapping[str, set[str]] | None
+) -> dict[str, set[str]]:
+    """Map ``--packages`` name patterns to the extras requested for the matching installed packages."""
+    expanded: dict[str, set[str]] = {}
+    if not requested_extras:
+        return expanded
+    for pattern, extras in requested_extras.items():
+        if normalized := {canonicalize_name(extra) for extra in extras}:
+            canonical_pattern = canonicalize_name(pattern)
+            for key in idx:
+                if fnmatch(key, canonical_pattern):
+                    expanded.setdefault(key, set()).update(normalized)
+    return expanded
+
+
 def _resolve_extras(
-    pkg_deps: dict[DistPackage, list[ReqPackage]], idx: dict[str, DistPackage], extras: ExtrasMode
+    pkg_deps: dict[DistPackage, list[ReqPackage]],
+    idx: dict[str, DistPackage],
+    extras: ExtrasMode,
+    requested_extras: dict[str, set[str]] | None = None,
 ) -> None:
     """Add extra/optional dependencies to the DAG in-place."""
     extras_needed = _seed_extras(pkg_deps, idx, extras)
+    for key, wanted in (requested_extras or {}).items():
+        extras_needed.setdefault(key, set()).update(wanted)
     processed: dict[str, set[str]] = {}
     # The same (parent, child, extra) triple can be reached through multiple req.extras propagation
     # paths across rounds; without dedup it would be appended once per path.

--- a/tests/_models/test_dag.py
+++ b/tests/_models/test_dag.py
@@ -306,6 +306,59 @@ def test_dag_extras_annotates_extra_name(make_mock_dist: MockDistMaker) -> None:
     assert all(dep.extra == "signedtoken" for dep in extra_deps)
 
 
+def _build_requested_extras_pkgs(make_mock_dist: MockDistMaker) -> list[Distribution]:
+    return [
+        make_mock_dist(
+            "click",
+            "8.1.0",
+            requires=["colorama ; extra == 'colorama'", "pyamqp>=1.0.0 ; extra == 'amqp'"],
+            provides_extras=["colorama", "amqp"],
+        ),
+        make_mock_dist("colorama", "0.4.6"),
+        make_mock_dist("pyamqp", "1.0.0"),
+    ]
+
+
+def test_dag_requested_extras_added_with_extras_none(make_mock_dist: MockDistMaker) -> None:
+    pkgs = _build_requested_extras_pkgs(make_mock_dist)
+    dag = PackageDAG.from_pkgs(pkgs, extras="none", requested_extras={"click": {"colorama"}})
+    children = {dep.key for dep in dag.get_children("click")}
+    assert "colorama" in children
+    assert "pyamqp" not in children
+
+
+def test_dag_requested_extras_supports_multiple_extras(make_mock_dist: MockDistMaker) -> None:
+    pkgs = _build_requested_extras_pkgs(make_mock_dist)
+    dag = PackageDAG.from_pkgs(pkgs, extras="none", requested_extras={"click": {"colorama", "amqp"}})
+    children = {dep.key for dep in dag.get_children("click")}
+    assert {"colorama", "pyamqp"} <= children
+
+
+def test_dag_requested_extras_unknown_extra_adds_no_edge(make_mock_dist: MockDistMaker) -> None:
+    pkgs = _build_requested_extras_pkgs(make_mock_dist)
+    dag = PackageDAG.from_pkgs(pkgs, extras="none", requested_extras={"click": {"missing"}})
+    assert dag.get_children("click") == []
+
+
+def test_dag_requested_extras_matches_wildcard_pattern(make_mock_dist: MockDistMaker) -> None:
+    pkgs = _build_requested_extras_pkgs(make_mock_dist)
+    dag = PackageDAG.from_pkgs(pkgs, extras="none", requested_extras={"cli*": {"colorama"}})
+    assert "colorama" in {dep.key for dep in dag.get_children("click")}
+
+
+def test_dag_requested_extras_empty_set_is_ignored(make_mock_dist: MockDistMaker) -> None:
+    pkgs = _build_requested_extras_pkgs(make_mock_dist)
+    dag = PackageDAG.from_pkgs(pkgs, extras="none", requested_extras={"click": set()})
+    assert dag.get_children("click") == []
+
+
+def test_dag_requested_extras_merges_with_active_mode(make_mock_dist: MockDistMaker) -> None:
+    pkgs = _build_requested_extras_pkgs(make_mock_dist)
+    dag = PackageDAG.from_pkgs(pkgs, extras="active", requested_extras={"click": {"colorama"}})
+    children = {dep.key for dep in dag.get_children("click")}
+    assert {"colorama", "pyamqp"} <= children
+
+
 def test_dag_extras_skips_missing_deps(make_mock_dist: MockDistMaker) -> None:
     pkgs = [
         make_mock_dist("parent", "1.0.0", requires=["child[feat]"]),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from pipdeptree._cli import build_parser, get_options
+from pipdeptree._cli import build_parser, get_options, parse_packages
 
 
 def test_get_options_default() -> None:
@@ -192,3 +192,22 @@ def test_get_options_extras_invalid(capsys: pytest.CaptureFixture[str]) -> None:
     out, err = capsys.readouterr()
     assert not out
     assert "invalid choice: 'bogus'" in err
+
+
+@pytest.mark.parametrize(
+    ("value", "names", "requested_extras"),
+    [
+        pytest.param("foo", ["foo"], {}, id="plain"),
+        pytest.param("foo[bar]", ["foo"], {"foo": {"bar"}}, id="single-extra"),
+        pytest.param("foo[bar,baz]", ["foo"], {"foo": {"bar", "baz"}}, id="multiple-extras"),
+        pytest.param("foo[bar],qux", ["foo", "qux"], {"foo": {"bar"}}, id="mixed-entries"),
+        pytest.param("foo[]", ["foo"], {}, id="empty-extras"),
+        pytest.param("pytest*[x]", ["pytest*"], {"pytest*": {"x"}}, id="wildcard-extra"),
+        pytest.param("a[b], c , d[e,f]", ["a", "c", "d"], {"a": {"b"}, "d": {"e", "f"}}, id="whitespace"),
+        pytest.param(None, [], {}, id="none"),
+        pytest.param("", [], {}, id="empty"),
+        pytest.param(",,", [], {}, id="only-separators"),
+    ],
+)
+def test_parse_packages(value: str | None, names: list[str], requested_extras: dict[str, set[str]]) -> None:
+    assert parse_packages(value) == (names, requested_extras)


### PR DESCRIPTION
Closes #450.

`--packages` could filter the tree to a package by name, but not to a particular extra's subtree. 🌿 Someone debugging "what does `foo[signedtoken]` actually pull in" had to read the whole `--extras` output and find it by eye.

`--packages "foo[bar]"` now filters to `foo` and surfaces the dependencies gated behind its `bar` extra (annotated `extra: bar`), with multiple extras (`foo[bar,baz]`) and the usual comma-separated package list supported. The `[extras]` part is parsed off in `get_options` into a per-package map, so the existing fnmatch name matching in `filter_nodes` is untouched; the requested extras are then seeded into the existing extras-resolution machinery as another explicit source. A requested extra wins over `--extras=none`, so `-p "foo[bar]" --extras=none` shows `foo`'s `bar` edges while keeping every other extra suppressed.

Two notes for review. This stacks on #587 (it branches off that work for the extras model), so the diff shows those changes until #587 merges. And a wildcard combined with an extra (`foo*[bar]`) filters by the name pattern but resolves the extra per matched key; the original #450 also depended on the now-closed #107, whose need is already met by the #587 extras model.