### PR TITLE
✨ feat(api): add programmatic render() for notebooks

### DIFF
--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -229,6 +229,34 @@ When conflicts exist, the output includes warnings and a non-zero exit code:
     $ echo $?
     1
 
+Use from Python or a notebook
+-----------------------------
+
+When you do not have command-line access -- for example inside a Jupyter or JupyterLite cell -- call
+:func:`pipdeptree.render` to obtain the dependency tree as a string instead of going through ``argv`` and stdout:
+
+.. code-block:: python
+
+    import pipdeptree
+
+    print(pipdeptree.render())                       # text tree of the current env
+    data = pipdeptree.render(output_format="json")   # JSON string, e.g. for json.loads
+    sub = pipdeptree.render(packages="rich", reverse=True)
+
+``output_format`` accepts ``text`` (default), ``json``, ``json-tree``, ``mermaid`` and ``dot`` (Graphviz source).
+Binary Graphviz formats such as ``png`` or ``svg`` cannot be returned as text and raise ``ValueError``; use ``dot`` to
+get the source, or the command-line interface for binary rendering.
+
+The return value is always a ``str``, so ``print``, slicing and comparisons behave as usual. For the default ``text``
+format it is also rich-displayable: in a Jupyter or JupyterLite cell the result renders as a Mermaid dependency
+diagram (natively, with no extra dependency and no Graphviz binary -- which also works in Pyodide/JupyterLite), falling
+back to an HTML ``<pre>`` and then plain text on front-ends that do not render Mermaid. ``str(render())`` and
+``print(render())`` always give the plain text tree. The other formats (``json``, ``json-tree``, ``mermaid``, ``dot``)
+return a plain string with no rich display, so their JSON or source shows verbatim.
+
+Unlike the CLI, warnings are silenced by default (``warn="silence"``) so a notebook cell stays free of stderr noise;
+pass ``warn="suppress"`` or ``warn="fail"`` to opt back in.
+
 Depth limiting
 --------------
 

--- a/src/pipdeptree/__init__.py
+++ b/src/pipdeptree/__init__.py
@@ -1,0 +1,175 @@
+"""
+Programmatic access to pipdeptree.
+
+The :func:`render` function lets you obtain the dependency tree as a string from
+within Python -- e.g. a Jupyter or JupyterLite cell -- without going through the
+command line or capturing stdout yourself::
+
+    import pipdeptree
+
+    print(pipdeptree.render())  # text tree, defaults
+    pipdeptree.render(output_format="json")  # JSON string
+    pipdeptree.render(packages="rich", reverse=True)  # filtered + reversed
+
+In a Jupyter or JupyterLite notebook cell, the default (``text``) render also
+displays as a Mermaid dependency diagram (with an HTML/text fallback) via the
+rich-display protocol, while its string value stays the plain text tree.
+"""
+
+from __future__ import annotations
+
+import io
+from contextlib import redirect_stdout
+from html import escape
+from math import inf
+from typing import TYPE_CHECKING
+
+from pipdeptree import _render
+from pipdeptree.__main__ import _FilterError, build_tree
+from pipdeptree._cli import get_options
+from pipdeptree._warning import WarningType, get_warning_printer
+
+from .version import __version__
+
+if TYPE_CHECKING:
+    from collections.abc import Container
+
+    from pipdeptree._cli import Options
+    from pipdeptree._models import PackageDAG
+
+__all__ = ["__version__", "render"]
+
+_BINARY_GRAPHVIZ_FORMATS = frozenset({"png", "svg", "pdf", "jpeg", "jpg", "gif", "bmp", "ps"})
+_FORMAT_FLAGS: dict[str, list[str]] = {
+    "text": [],
+    "json": ["--json"],
+    "json-tree": ["--json-tree"],
+    "mermaid": ["--mermaid"],
+    "dot": ["--graph-output", "dot"],
+}
+
+
+def render(  # noqa: PLR0913
+    *,
+    packages: str | None = None,
+    exclude: str | None = None,
+    output_format: str = "text",
+    reverse: bool = False,
+    depth: float = inf,
+    extras: bool | str = False,
+    local_only: bool = False,
+    user_only: bool = False,
+    python: str | None = None,
+    encoding: str = "utf-8",
+    warn: str = "silence",
+) -> str:
+    """
+    Render the dependency tree of an environment and return it as a string.
+
+    :param packages: comma separated allow-list of packages to show (wildcards allowed)
+    :param exclude: comma separated deny-list of packages to hide (wildcards allowed)
+    :param output_format: one of ``text``, ``json``, ``json-tree``, ``mermaid`` or ``dot`` (Graphviz source); binary
+        Graphviz formats (png, svg, ...) cannot be returned as text and raise :class:`ValueError`
+    :param reverse: list sub-dependencies with the packages that require them
+    :param depth: limit the depth of the tree (text output only)
+    :param extras: include optional (extras) dependencies in the tree; ``True`` is shorthand for ``"explicit"``
+    :param local_only: only show packages installed in the local virtual environment
+    :param user_only: only show packages installed in the user site
+    :param python: interpreter whose environment to inspect; defaults to the current one
+    :param encoding: encoding used for the text renderer's box-drawing characters
+    :param warn: warning control (``silence``, ``suppress`` or ``fail``); defaults to ``silence`` so notebooks are not
+        polluted with stderr output
+    :raises ValueError: for an unknown ``output_format`` or a binary Graphviz format
+    :return: the rendered dependency tree
+
+    The result is always a :class:`str` whose value is the rendering for the requested ``output_format``, so
+    ``print``, slicing, ``==`` and other string operations behave exactly as before. For the default ``text`` format
+    the result additionally implements Jupyter's rich-display protocol (:meth:`_repr_mimebundle_`), so a notebook cell
+    shows a Mermaid dependency diagram with an HTML ``<pre>`` and plain-text fallback. Other formats (``json``,
+    ``json-tree``, ``mermaid``, ``dot``) return a plain :class:`str` with no rich display, so their source/JSON shows
+    as-is.
+    """
+    argv = ["--warn", warn, "--encoding", encoding, *_format_flags(output_format)]
+    for flag, value in (("--packages", packages), ("--exclude", exclude), ("--python", python)):
+        if value is not None:
+            argv += [flag, value]
+    if depth != inf:
+        argv += ["--depth", str(int(depth))]
+    if extras:
+        # Bare --extras means the "explicit" mode; the boolean keeps the historical call signature working.
+        argv += ["--extras", extras if isinstance(extras, str) else "explicit"]
+    for flag, enabled in (
+        ("--reverse", reverse),
+        ("--local-only", local_only),
+        ("--user-only", user_only),
+    ):
+        if enabled:
+            argv.append(flag)
+    options = get_options(argv)
+
+    # Share the global warning printer so validation warnings honor ``warn`` too and default to silence, keeping
+    # notebooks free of stderr noise.
+    get_warning_printer().warning_type = WarningType.from_str(options.warn)
+
+    try:
+        tree = build_tree(options)
+    except _FilterError:
+        return ""
+
+    text = _render_to_str(options, tree)
+    if output_format != "text":
+        # Non-text formats (JSON, Mermaid source, Graphviz source) are returned as plain strings so they display
+        # verbatim in a notebook instead of being reinterpreted as a diagram.
+        return text
+
+    # Reuse the already-discovered tree to also produce a Mermaid diagram for the rich notebook display.
+    mermaid_options = get_options([*argv, "--mermaid"])
+    mermaid = _render_to_str(mermaid_options, tree)
+    return _RenderResult(text, mermaid=mermaid)
+
+
+def _render_to_str(options: Options, tree: PackageDAG) -> str:
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        _render.render(options, tree)
+    return buffer.getvalue()
+
+
+class _RenderResult(str):  # noqa: FURB189  # Must stay a real ``str`` so isinstance/print/slicing keep working.
+    """A ``str`` whose value is the text tree but that also renders as a Mermaid diagram in a notebook cell."""
+
+    __slots__ = ("_mermaid",)
+
+    _mermaid: str
+
+    def __new__(cls, text: str, *, mermaid: str) -> _RenderResult:  # noqa: PYI034  # str subclass, concrete type is fine.
+        self = super().__new__(cls, text)
+        self._mermaid = mermaid
+        return self
+
+    def _repr_mimebundle_(  # noqa: PLW3201  # Jupyter rich-display protocol method, not a Python dunder.
+        self,
+        include: Container[str] | None = None,
+        exclude: Container[str] | None = None,  # noqa: ARG002
+    ) -> dict[str, str]:
+        bundle = {
+            "text/vnd.mermaid": self._mermaid,
+            "text/html": f"<pre>{escape(str(self))}</pre>",
+            "text/plain": str(self),
+        }
+        if include is not None:
+            bundle = {key: value for key, value in bundle.items() if key in include}
+        return bundle
+
+
+def _format_flags(output_format: str) -> list[str]:
+    if output_format in _FORMAT_FLAGS:
+        return _FORMAT_FLAGS[output_format]
+    if output_format in _BINARY_GRAPHVIZ_FORMATS:
+        msg = (
+            "binary Graphviz formats cannot be returned as a string; use output_format='dot' for the Graphviz source, "
+            "or run the pipdeptree CLI for binary output"
+        )
+        raise ValueError(msg)
+    msg = f"unknown output_format {output_format!r}; expected one of {', '.join(_FORMAT_FLAGS)}"
+    raise ValueError(msg)

--- a/src/pipdeptree/__main__.py
+++ b/src/pipdeptree/__main__.py
@@ -17,6 +17,16 @@ from pipdeptree._warning import WarningPrinter, WarningType, get_warning_printer
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+_OVERLAP_MESSAGE = "Cannot have --packages and --exclude contain the same entries"
+
+
+class _FilterError(Exception):
+    """Raised by build_tree when the include/exclude filter cannot be satisfied."""
+
+    def __init__(self, message: str, *, is_fatal: bool) -> None:
+        super().__init__(message)
+        self.is_fatal = is_fatal
+
 
 def main(args: Sequence[str] | None = None) -> int | None:
     """CLI - The main function called as entry point."""
@@ -28,18 +38,41 @@ def main(args: Sequence[str] | None = None) -> int | None:
     warning_printer = get_warning_printer()
     warning_printer.warning_type = WarningType.from_str(options.warn)
 
-    options.python = _resolve_python(options.python)
-
     try:
-        pkgs = get_installed_distributions(
-            interpreter=options.python,
-            supplied_paths=options.path or None,
-            local_only=options.local_only,
-            user_only=options.user_only,
-        )
+        tree = build_tree(options, log_resolved=True)
     except InterpreterQueryError as e:
         print(f"Failed to query custom interpreter: {e}", file=sys.stderr)  # noqa: T201
         return 1
+    except _FilterError as e:
+        if e.is_fatal:
+            print(str(e), file=sys.stderr)  # noqa: T201
+            return 1
+        if warning_printer.should_warn():
+            warning_printer.print_single_line(str(e))
+        return _determine_return_code(warning_printer)
+
+    render(options, tree)
+
+    return _determine_return_code(warning_printer)
+
+
+def build_tree(options: Options, *, log_resolved: bool = False) -> PackageDAG:
+    """
+    Discover packages and build the (optionally reversed/filtered) dependency tree.
+
+    Shared by the CLI and the programmatic :func:`pipdeptree.render` API.
+
+    :raises InterpreterQueryError: if querying a custom interpreter failed
+    :raises _FilterError: if the include/exclude filter cannot be satisfied
+    """
+    options.python = _resolve_python(options.python, log_resolved=log_resolved)
+
+    pkgs = get_installed_distributions(
+        interpreter=options.python,
+        supplied_paths=options.path or None,
+        local_only=options.local_only,
+        user_only=options.user_only,
+    )
 
     tree = PackageDAG.from_pkgs(pkgs, extras=options.extras)
 
@@ -58,30 +91,28 @@ def main(args: Sequence[str] | None = None) -> int | None:
     if include is not None or exclude is not None:
         try:
             tree = tree.filter_nodes(include, exclude, exclude_deps=options.exclude_dependencies)
-        except IncludeExcludeOverlapError:
-            print("Cannot have --packages and --exclude contain the same entries", file=sys.stderr)  # noqa: T201
-            return 1
+        except IncludeExcludeOverlapError as e:
+            raise _FilterError(_OVERLAP_MESSAGE, is_fatal=True) from e
         except IncludePatternNotFoundError as e:
-            if warning_printer.should_warn():
-                warning_printer.print_single_line(str(e))
-            return _determine_return_code(warning_printer)
+            raise _FilterError(str(e), is_fatal=False) from e
 
-    render(options, tree)
-
-    return _determine_return_code(warning_printer)
+    return tree
 
 
-def _resolve_python(python: str | None) -> str:
+def _resolve_python(python: str | None, *, log_resolved: bool = False) -> str:
     # Default (None): auto-detect the active virtual environment, silently falling back to the running interpreter so
     # users outside a virtual environment keep the historical behavior. "auto" stays strict and fails if none is found.
+    # log_resolved keeps the resolved-path note CLI-only so the programmatic API stays quiet in notebooks.
     if python is None:
         if resolved_path := find_active_interpreter():
-            print(f"(resolved python: {resolved_path})", file=sys.stderr)  # noqa: T201
+            if log_resolved:
+                print(f"(resolved python: {resolved_path})", file=sys.stderr)  # noqa: T201
             return resolved_path
         return sys.executable
     if python == "auto":
         resolved_path = detect_active_interpreter()
-        print(f"(resolved python: {resolved_path})", file=sys.stderr)  # noqa: T201
+        if log_resolved:
+            print(f"(resolved python: {resolved_path})", file=sys.stderr)  # noqa: T201
         return resolved_path
     return python
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+import pipdeptree
+from pipdeptree import _RenderResult
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+    from tests.conftest import MockDistMaker
+
+
+@pytest.fixture
+def patched_env(mocker: MockerFixture, make_mock_dist: MockDistMaker) -> None:
+    pkgs = [
+        make_mock_dist(name="a", version="1.0.0", requires=["b>=1.0"]),
+        make_mock_dist(name="b", version="2.0.0"),
+    ]
+    mocker.patch("pipdeptree.__main__.get_installed_distributions", return_value=pkgs)
+
+
+@pytest.mark.usefixtures("patched_env")
+def test_render_returns_text_tree() -> None:
+    out = pipdeptree.render()
+    assert isinstance(out, str)
+    assert "a==1.0.0" in out
+    assert "b [required: >=1.0, installed: 2.0.0]" in out
+
+
+@pytest.mark.usefixtures("patched_env")
+def test_render_text_mimebundle_offers_mermaid_html_and_plain() -> None:
+    out = pipdeptree.render()
+    assert isinstance(out, _RenderResult)
+    bundle = out._repr_mimebundle_()
+    assert set(bundle) == {"text/vnd.mermaid", "text/html", "text/plain"}
+    assert bundle["text/vnd.mermaid"].startswith("flowchart TD")
+    assert bundle["text/html"].startswith("<pre")
+    assert bundle["text/plain"] == str(out)
+
+
+@pytest.mark.usefixtures("patched_env")
+def test_render_text_mimebundle_respects_include() -> None:
+    out = pipdeptree.render()
+    assert isinstance(out, _RenderResult)
+    bundle = out._repr_mimebundle_(include={"text/plain"})
+    assert set(bundle) == {"text/plain"}
+
+
+@pytest.mark.usefixtures("patched_env")
+def test_render_json_has_no_rich_mimebundle() -> None:
+    out = pipdeptree.render(output_format="json")
+    assert not hasattr(out, "_repr_mimebundle_")
+
+
+@pytest.mark.usefixtures("patched_env")
+def test_render_json_returns_valid_json() -> None:
+    payload = json.loads(pipdeptree.render(output_format="json"))
+    assert {entry["package"]["key"] for entry in payload} == {"a", "b"}
+
+
+@pytest.mark.usefixtures("patched_env")
+def test_render_json_tree_returns_valid_json() -> None:
+    payload = json.loads(pipdeptree.render(output_format="json-tree"))
+    assert any(entry["key"] == "a" for entry in payload)
+
+
+@pytest.mark.usefixtures("patched_env")
+def test_render_mermaid() -> None:
+    assert pipdeptree.render(output_format="mermaid").startswith("flowchart TD")
+
+
+@pytest.mark.usefixtures("patched_env")
+def test_render_dot_returns_graphviz_source() -> None:
+    assert pipdeptree.render(output_format="dot").startswith("digraph {")
+
+
+@pytest.mark.usefixtures("patched_env")
+def test_render_packages_filter() -> None:
+    assert pipdeptree.render(packages="b").strip() == "b==2.0.0"
+
+
+@pytest.mark.usefixtures("patched_env")
+def test_render_exclude_filter() -> None:
+    out = pipdeptree.render(exclude="b")
+    assert "b==2.0.0" not in out
+    assert "a==1.0.0" in out
+
+
+@pytest.mark.usefixtures("patched_env")
+def test_render_reverse() -> None:
+    assert pipdeptree.render(reverse=True).startswith("b==2.0.0")
+
+
+@pytest.mark.usefixtures("patched_env")
+def test_render_depth_limits_text_tree() -> None:
+    out = pipdeptree.render(depth=0)
+    assert "a==1.0.0" in out
+    assert "required:" not in out
+
+
+def test_render_passes_select_options_through(mocker: MockerFixture, make_mock_dist: MockDistMaker) -> None:
+    discovery = mocker.patch(
+        "pipdeptree.__main__.get_installed_distributions",
+        return_value=[make_mock_dist(name="a", version="1.0.0")],
+    )
+    pipdeptree.render(python="/some/python", user_only=True)
+    assert discovery.call_args.kwargs["interpreter"] == "/some/python"
+    assert discovery.call_args.kwargs["user_only"] is True
+
+
+def test_render_local_only_passed_through(mocker: MockerFixture, make_mock_dist: MockDistMaker) -> None:
+    discovery = mocker.patch(
+        "pipdeptree.__main__.get_installed_distributions",
+        return_value=[make_mock_dist(name="a", version="1.0.0")],
+    )
+    pipdeptree.render(local_only=True)
+    assert discovery.call_args.kwargs["local_only"] is True
+
+
+def test_render_extras_passed_through(mocker: MockerFixture, make_mock_dist: MockDistMaker) -> None:
+    spy = mocker.spy(pipdeptree.__main__.PackageDAG, "from_pkgs")
+    mocker.patch(
+        "pipdeptree.__main__.get_installed_distributions",
+        return_value=[make_mock_dist(name="a", version="1.0.0")],
+    )
+    pipdeptree.render(extras=True)
+    assert spy.call_args.kwargs["extras"] == "explicit"
+
+
+def test_render_extras_mode_passed_through(mocker: MockerFixture, make_mock_dist: MockDistMaker) -> None:
+    spy = mocker.spy(pipdeptree.__main__.PackageDAG, "from_pkgs")
+    mocker.patch(
+        "pipdeptree.__main__.get_installed_distributions",
+        return_value=[make_mock_dist(name="a", version="1.0.0")],
+    )
+    pipdeptree.render(extras="active")
+    assert spy.call_args.kwargs["extras"] == "active"
+
+
+def test_render_invalid_filter_returns_empty(mocker: MockerFixture, make_mock_dist: MockDistMaker) -> None:
+    mocker.patch(
+        "pipdeptree.__main__.get_installed_distributions",
+        return_value=[make_mock_dist(name="a", version="1.0.0")],
+    )
+    assert not pipdeptree.render(packages="does-not-exist")
+
+
+def test_render_warnings_do_not_leak_by_default(
+    mocker: MockerFixture,
+    capsys: pytest.CaptureFixture[str],
+    make_mock_dist: MockDistMaker,
+) -> None:
+    mocker.patch(
+        "pipdeptree.__main__.get_installed_distributions",
+        return_value=[make_mock_dist(name="a", version="1.0.0", requires=["missing>=1"])],
+    )
+    pipdeptree.render()
+    assert not capsys.readouterr().err
+
+
+@pytest.mark.usefixtures("patched_env")
+def test_render_unknown_output_format_raises() -> None:
+    with pytest.raises(ValueError, match="unknown output_format 'xml'"):
+        pipdeptree.render(output_format="xml")
+
+
+@pytest.mark.usefixtures("patched_env")
+def test_render_binary_graphviz_format_raises() -> None:
+    with pytest.raises(ValueError, match="binary Graphviz formats"):
+        pipdeptree.render(output_format="png")

--- a/tests/test_main_python.py
+++ b/tests/test_main_python.py
@@ -18,9 +18,22 @@ def test_resolve_python_default_uses_detected_env(
 ) -> None:
     mocker.patch("pipdeptree.__main__.find_active_interpreter", return_value=str(tmp_path))
 
-    assert _resolve_python(None) == str(tmp_path)
+    assert _resolve_python(None, log_resolved=True) == str(tmp_path)
 
     assert capsys.readouterr().err == f"(resolved python: {tmp_path})\n"
+
+
+def test_resolve_python_default_note_silent_without_log(
+    tmp_path: Path, mocker: MockFixture, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # The programmatic API resolves without log_resolved, so notebooks get no stderr note.
+    mocker.patch("pipdeptree.__main__.find_active_interpreter", return_value=str(tmp_path))
+
+    assert _resolve_python(None) == str(tmp_path)
+
+    captured = capsys.readouterr()
+    assert not captured.out
+    assert not captured.err
 
 
 def test_resolve_python_default_falls_back_silently(mocker: MockFixture, capsys: pytest.CaptureFixture[str]) -> None:
@@ -38,7 +51,7 @@ def test_resolve_python_auto_uses_strict_detection(
 ) -> None:
     mocker.patch("pipdeptree.__main__.detect_active_interpreter", return_value=str(tmp_path))
 
-    assert _resolve_python("auto") == str(tmp_path)
+    assert _resolve_python("auto", log_resolved=True) == str(tmp_path)
 
     assert capsys.readouterr().err == f"(resolved python: {tmp_path})\n"
 


### PR DESCRIPTION
Closes #583.

pipdeptree only spoke argv-in, stdout-out, so using it from a Jupyter or JupyterLite cell meant shelling out, which JupyterLite can't do. 📓 This exposes a real Python API.

`import pipdeptree; pipdeptree.render(...)` returns the rendered tree as a string. It takes keyword arguments for the common knobs (`packages`, `exclude`, `output_format`, `extras`, `reverse`, `depth`, `local_only`, `user_only`, `python`, `encoding`, `warn`) and reuses the CLI pipeline rather than reimplementing it: the kwargs map onto an argv list fed through `get_options`, so all validation and context setup come for free, and the shared discovery-build-render core was extracted out of `main()`. Warnings default to silent so notebooks stay clean. Binary graphviz formats raise a clear `ValueError` since they can't be returned as text; `mermaid`, `json`, `text`, and the rest work.

One structural choice to confirm: the public `render()` lives in `__init__.py` and imports the shared core from `__main__`, so `import pipdeptree` pulls `__main__` in (guarded, so nothing runs). It works and is covered, but if you'd rather not have the package import `__main__`, moving the core into a small `_core.py` that both import is a clean follow-up. #583 is labeled `tobeconfirmed`, so treat this as a concrete proposal of the API shape as much as a fix.