### PR TITLE
🔧 build: cap hatchling <1.30 so pkg_meta produces publishable metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,10 @@
 build-backend = "hatchling.build"
 requires = [
   "hatch-vcs>=0.5",
-  "hatchling>=1.27",
+  # hatchling 1.30 emits Metadata-Version 2.5 (PEP 794), which neither released twine (the
+  # validator monkeypatch removed in pypa/twine#1317 is unreleased) nor PyPI (pypi/warehouse#19083)
+  # accepts yet. Cap until both ship 2.5 support, then drop this and bump the twine floor.
+  "hatchling>=1.27,<1.30",
 ]
 
 [project]


### PR DESCRIPTION
The `pkg_meta` CI environment started failing on every branch with:

```
twine check ... ERROR InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

hatchling 1.30.0 began emitting `Metadata-Version: 2.5` (PEP 794, adding `Import-Name`/`Import-Namespace`), and `[build-system].requires` pinned only `hatchling>=1.27`, so fresh CI resolved to 1.30. 🔧 The problem is not just the checker: metadata 2.5 cannot actually be published today.

- The latest released twine (6.2.0) monkeypatches `packaging`'s validator to a hardcoded list ending at 2.4, so `twine check` rejects 2.5. The monkeypatch was removed in pypa/twine#1317, but that is unreleased — there is no twine release that accepts 2.5, so bumping the `twine>=` floor is not an option.
- PyPI itself does not accept Metadata-Version 2.5 uploads yet — pypi/warehouse#19083 is still open; warehouse supports up to 2.4.

So a 2.5 wheel is unpublishable regardless of the checker, and `pkg_meta`'s red is correct signal. The minimal fix that keeps the package genuinely publishable is to cap the build backend just below the version that introduced 2.5:

```
hatchling>=1.27,<1.30
```

This produces Metadata-Version 2.4, which both released twine and PyPI accept. Verified `tox -e pkg_meta` goes green (uv build + twine check + check-wheel-contents). ⏳ A comment in `pyproject.toml` marks this as removable once twine ships pypa/twine#1317 and PyPI implements pypi/warehouse#19083 — at which point the cap should drop and the `twine>=` floor bump instead.

Refs:
- pypa/twine#1146 — twine fails on latest metadata-version (tracking)
- pypa/twine#1317 — removes the validator monkeypatch (merged, unreleased)
- pypi/warehouse#19083 — PyPI support for Metadata 2.5 (open)