### PR TITLE
⏪ build: drop hatchling <1.30 cap now that 1.30 is yanked

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,7 @@
 build-backend = "hatchling.build"
 requires = [
   "hatch-vcs>=0.5",
-  # hatchling 1.30 emits Metadata-Version 2.5 (PEP 794), which neither released twine (the
-  # validator monkeypatch removed in pypa/twine#1317 is unreleased) nor PyPI (pypi/warehouse#19083)
-  # accepts yet. Cap until both ship 2.5 support, then drop this and bump the twine floor.
-  "hatchling>=1.27,<1.30",
+  "hatchling>=1.27",
 ]
 
 [project]


### PR DESCRIPTION
Follow-up to #591. That PR capped `hatchling<1.30` because 1.30 emitted Metadata-Version 2.5 (PEP 794), which no released twine and PyPI accept yet.

hatchling 1.30.0 has since been **yanked** from PyPI, with the yank reason: *"the default core metadata version was increased to 2.5 and some major projects like twine do not yet support it."* pip and uv skip yanked releases during resolution, so the build now lands on 1.29.0 (Metadata-Version 2.4) without any upper bound. ⏪ The explicit cap is therefore redundant.

Dropping it back to `hatchling>=1.27` keeps us forward compatible: the full chain to publishing 2.5 needs a twine release (pypa/twine#1317), then a pypa/gh-action-pypi-publish release, then dependabot bumping the pinned publish action — once that lands, a future unyanked hatchling can emit 2.5 without another pyproject edit.

Verified locally: with no cap the build resolves to hatchling 1.29.0, emits Metadata-Version 2.4, and `tox -e pkg_meta` passes (uv build + twine check + check-wheel-contents).

Refs:
- #591 — the cap this reverts
- pypa/twine#1317 — removes the validator monkeypatch (merged, unreleased)
- pypi/warehouse#19083 — PyPI support for Metadata 2.5 (open)