### PR TITLE
✨ feat(cli): add from-index subcommand to resolve a tree from a package index

### DIFF
--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -65,6 +65,60 @@ Circular dependency detection uses cycle detection on the directed dependency gr
         style X fill:#e67e22,color:#fff
         style Y fill:#e67e22,color:#fff
 
+from-index: resolving from an index instead of inspecting
+---------------------------------------------------------
+
+The default command reads ``importlib.metadata`` for packages that are *already installed*: each one has a
+``METADATA`` file and real files on disk, so pipdeptree can report its version, dependencies, license, metadata
+fields and on-disk size.
+
+The ``from-index`` subcommand answers a different question -- "what *would* this tree look like?" -- so it cannot
+read installed state, because nothing is installed. It hands the requirements to the optional index resolver, which
+runs a PubGrub solve against a package index (PyPI) and picks a consistent set of versions *without downloading or
+installing anything*. The name says where the answer comes from: the index server, not the Python environment.
+It reads requirements files as standard ``requirements.txt`` files, so nested ``-r``, ``-c`` constraints,
+environment markers and comments all carry through. Editable installs, local paths and pinned git requirements
+resolve from the checkout itself rather than the index (see below). Bare wheel/sdist archive URLs and non-git VCS
+schemes stay out of scope, since the resolver has no way to map them. pipdeptree then renders that resolved graph
+through the same machinery as the default command.
+
+PubGrub is a version-solving algorithm: the resolver asks the index for the candidate versions of each
+requirement, follows their declared dependencies, and backtracks when two constraints cannot hold at once until it
+reaches a single consistent assignment or proves none exists. Querying the index is why the subcommand needs the
+network and the extra. The default command reads files already on disk, so it needs neither.
+
+This solve depends on the same environment markers that govern a real install. A requirement guarded by
+``; python_version < "3.9"`` enters the resolve only when the marker evaluates true, so the Python version you
+resolve for can change which packages appear. The resolver evaluates markers against the interpreter running
+pipdeptree, which matters when you preview a tree for a version other than your own.
+
+The resolver handles a checkout (an editable install, a local path, or a cloned git repo) by reading its metadata
+rather than querying the index. It reads the project's PEP 621 ``[project]`` table -- and PEP 643 static metadata
+in sdists -- *statically*, with no build. It runs a build backend only when a target declares its dependencies
+dynamically and offers no static fallback. Most local and git dependencies resolve without any build; a project
+that computes its dependencies at build time pays for one.
+
+.. mermaid::
+
+    flowchart TD
+        S["requirements /<br/>pyproject.toml"] --> R["PubGrub resolver<br/>(index = PyPI)"]
+        R --> G["Resolved graph<br/>(names, versions, edges)"]
+        G --> E["Render output"]
+        style S fill:#2c3e50,color:#ecf0f1
+        style R fill:#2980b9,color:#fff
+        style G fill:#27ae60,color:#fff
+        style E fill:#8e44ad,color:#fff
+
+Index selection feeds the resolver's index list. ``--index-url``/``--extra-index-url``, their ``PIP_*``/``UV_*``
+environment fallbacks, and a ``--pyproject``'s ``[tool.nab].indexes`` each supply that list; with none set the
+resolve uses PyPI.
+
+The resolver yields only names, versions and dependency edges, so ``from-index`` drops the installed-only display
+options: ``--metadata``, ``--computed`` and ``--license`` each need a ``METADATA`` file or on-disk files that never
+exist for un-downloaded packages, and the environment-inspection options (``--python``, ``--path``, ``-l``/``-u``)
+have no environment to point at. The pure graph/version/render flags -- filtering, depth, ``--reverse``,
+``--extras`` and the output formats -- apply unchanged.
+
 Optional dependencies (extras)
 ------------------------------
 
@@ -103,7 +157,10 @@ Limitations
 -----------
 
 - pipdeptree only sees packages that are already installed. It cannot predict what a ``pip install`` will do.
-- If you need a dependency resolver that works without installing packages first, consider :pypi:`uv`.
+- To preview the tree for a set of requirements without installing them, use the ``from-index`` subcommand (see
+  :doc:`/how-to/usage` and the "from-index: resolving from an index instead of inspecting" section above), which
+  resolves them via the optional index resolver. For a full-featured standalone resolver, :pypi:`uv` is another
+  option.
 - Optional dependencies show by default (``--extras=explicit``); use ``--extras=none`` to omit them,
   or ``--extras=active`` to also include extras that are merely satisfiable.
 - ``--extras`` cannot reconstruct extras that were requested only on the command line

--- a/docs/how-to/output-formats.rst
+++ b/docs/how-to/output-formats.rst
@@ -221,3 +221,7 @@ Other formats render the graph directly to binary output:
 
 The format is specified as ``graphviz-<format>`` where ``<format>`` is any
 `Graphviz output format <https://graphviz.org/docs/outputs/>`_ (dot, pdf, png, svg, jpeg, etc.).
+
+Every format above also works with the ``from-index`` subcommand, e.g.
+``pipdeptree from-index --requirements requirements.txt -o json``
+to render a tree resolved from the package index without installing. See :doc:`/how-to/usage` for details.

--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -33,6 +33,342 @@ default, which silently falls back to the running interpreter):
 
 Alternatively, install pipdeptree inside the virtualenv and run it directly.
 
+from-index (resolve by querying the index)
+-------------------------------------------
+
+pipdeptree inspects an installed environment by default. The ``from-index`` subcommand resolves a set of
+requirements by querying the package index (PyPI) and shows the resulting tree **without installing or inspecting
+anything**. It uses the optional index resolver, so install the extra first:
+
+.. code-block:: console
+
+    $ pip install pipdeptree[index]
+
+You name each source; pipdeptree never guesses one from a path's shape. Positional arguments are inline PEP 508
+requirements, the same strings you pass to ``pip install``. You supply files with repeatable flags:
+
+- positional ``REQUIREMENT`` -- an inline PEP 508 requirement string, version specifiers and extras included;
+- ``--requirements FILE`` -- a standard ``requirements.txt`` or ``.in`` style file;
+- ``--pyproject FILE`` -- a ``pyproject.toml`` handed to the resolver, which reads ``[project].dependencies`` and
+  honors its ``[tool.nab]`` configuration.
+
+Pass at least one source. Each edge shows the candidate version the resolver selected, never a package on your
+machine: the resolver produces a single version per package with no requirement range, so edges read
+``[candidate: <version>]`` instead of the ``[required: ..., installed: ...]`` pair shown for an installed
+environment.
+
+Resolve inline requirements
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A single requirement resolves to its full tree:
+
+.. code-block:: console
+
+    $ pipdeptree from-index "starlette"
+    starlette==1.2.1
+    ├── anyio [candidate: 4.13.0]
+    │   ├── idna [candidate: 3.18]
+    │   └── typing-extensions [candidate: 4.15.0]
+    └── typing-extensions [candidate: 4.15.0]
+
+Several requirements resolve together into one graph, and a version specifier bounds the pick:
+
+.. code-block:: console
+
+    $ pipdeptree from-index "fastapi<=0.115.2" starlette
+    fastapi==0.115.2
+    ├── pydantic [candidate: 2.13.4]
+    │   ├── annotated-types [candidate: 0.7.0]
+    │   ├── pydantic-core [candidate: 2.46.4]
+    │   │   └── typing-extensions [candidate: 4.15.0]
+    │   ├── typing-extensions [candidate: 4.15.0]
+    │   └── typing-inspection [candidate: 0.4.2]
+    │       └── typing-extensions [candidate: 4.15.0]
+    ├── starlette [candidate: 0.40.0]
+    │   └── anyio [candidate: 4.13.0]
+    │       ├── idna [candidate: 3.18]
+    │       └── typing-extensions [candidate: 4.15.0]
+    └── typing-extensions [candidate: 4.15.0]
+
+Request extras with the ``name[extra]`` syntax. The resolver pulls the extra's dependencies into the tree, where
+they appear as ordinary children (here ``pysocks``) with the pinned version the resolve picked, not as edges
+labeled with the extra:
+
+.. code-block:: console
+
+    $ pipdeptree from-index "requests[socks]"
+    requests==2.34.2
+    ├── certifi [candidate: 2026.5.20]
+    ├── charset-normalizer [candidate: 3.4.7]
+    ├── idna [candidate: 3.18]
+    ├── pysocks [candidate: 1.7.1]
+    └── urllib3 [candidate: 2.7.0]
+
+An environment marker gates a requirement on the interpreter the resolve targets: when the marker is true the
+requirement resolves and shows in the tree, when false it drops out. Quote the whole argument so the shell keeps
+the marker attached:
+
+.. code-block:: console
+
+    $ pipdeptree from-index 'idna; python_version >= "3.10"'
+    idna==3.18
+
+Resolve from a requirements file
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Point ``--requirements`` at a ``requirements.txt``:
+
+.. code-block:: console
+
+    $ pipdeptree from-index --requirements requirements.txt
+
+pipdeptree parses the file as a standard requirements file, so a real-world one resolves as-is. Take this
+``requirements.txt``:
+
+.. code-block:: text
+
+    -r base.txt                        # nested include, followed
+    -c constraints.txt                 # constraints, fed to the resolver
+    httpx[http2]                       # extras kept
+    tomli; python_version < "3.11"     # environment marker kept
+    # pin chosen by the security team   <- comment, ignored
+    requests==2.32.3 \
+        --hash=sha256:0000000000000000000000000000000000000000000000000000000000000000
+
+Each directive maps as follows: the ``-r base.txt`` include is read inline, the ``-c constraints.txt`` pins bound
+the resolve, the marker and the ``[http2]`` extra reach the resolver intact, the comment drops out, and the
+``--hash`` line resolves ``requests`` while the hash itself is ignored (the resolver verifies nothing from the
+index). The same goes for ``--index-url`` and similar pip-only options.
+
+Resolve from a pyproject.toml
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Give ``--pyproject`` as the only source and the resolver reads it natively: the full ``[project]`` table and any
+``[tool.nab]`` configuration in the file:
+
+.. code-block:: console
+
+    $ pipdeptree from-index --pyproject pyproject.toml
+
+Add any other source and the ``[project].dependencies`` from that pyproject merge into one combined resolve
+instead. Its ``[tool.nab]`` settings drop out on this path:
+
+.. code-block:: console
+
+    $ pipdeptree from-index --pyproject pyproject.toml httpx
+
+Combine and repeat sources
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Both flags repeat, and every source folds into a single resolve alongside the positional requirements:
+
+.. code-block:: console
+
+    $ pipdeptree from-index --requirements a.txt --requirements b.txt --pyproject p.toml extra-pkg
+
+Use a private or custom index
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default the resolve runs against PyPI. Point it at an internal index with ``--index-url`` and add more with
+``--extra-index-url`` (repeatable):
+
+.. code-block:: console
+
+    $ pipdeptree from-index "internal-lib" --index-url https://nexus.corp/repository/pypi/simple
+    $ pipdeptree from-index "internal-lib" --extra-index-url https://nexus.corp/repository/pypi/simple
+
+``--index-url`` replaces PyPI as the primary index, matching pip's ``--index-url``. ``--extra-index-url`` keeps
+PyPI as the primary and appends each extra after it. When a flag is absent, the value falls back to the environment:
+``--index-url`` reads ``PIP_INDEX_URL`` then ``UV_INDEX_URL``, and ``--extra-index-url`` reads
+``PIP_EXTRA_INDEX_URL`` then ``UV_EXTRA_INDEX_URL`` (both whitespace separated, like pip and uv). With nothing set
+the resolve uses PyPI.
+
+The resolver searches indexes in order and the first index that has a package wins. This differs from pip, which
+merges every index and picks the highest version across all of them. Order your indexes so the one you trust for a
+given package comes first.
+
+The index flags and their environment fallbacks override a ``--pyproject``'s own ``[tool.nab].indexes``. With no
+flag and no environment override, the resolve uses the indexes declared in the pyproject.
+
+.. code-block:: console
+
+    $ PIP_INDEX_URL=https://nexus.corp/repository/pypi/simple pipdeptree from-index "internal-lib"
+    $ pipdeptree from-index --pyproject pyproject.toml --index-url https://nexus.corp/repository/pypi/simple
+
+Apply render flags
+~~~~~~~~~~~~~~~~~~~
+
+The graph and render flags behave as they do for the default command. Emit JSON for tooling:
+
+.. code-block:: console
+
+    $ pipdeptree from-index "starlette" -o json
+    [
+        {
+            "package": {
+                "key": "anyio",
+                "package_name": "anyio",
+                "candidate_version": "4.13.0"
+            },
+            "dependencies": [
+                {
+                    "key": "idna",
+                    "package_name": "idna",
+                    "candidate_version": "3.18"
+                },
+                {
+                    "key": "typing-extensions",
+                    "package_name": "typing-extensions",
+                    "candidate_version": "4.15.0"
+                }
+            ]
+        },
+        {
+            "package": {
+                "key": "idna",
+                "package_name": "idna",
+                "candidate_version": "3.18"
+            },
+            "dependencies": []
+        },
+        {
+            "package": {
+                "key": "starlette",
+                "package_name": "starlette",
+                "candidate_version": "1.2.1"
+            },
+            "dependencies": [
+                {
+                    "key": "anyio",
+                    "package_name": "anyio",
+                    "candidate_version": "4.13.0"
+                },
+                {
+                    "key": "typing-extensions",
+                    "package_name": "typing-extensions",
+                    "candidate_version": "4.15.0"
+                }
+            ]
+        },
+        {
+            "package": {
+                "key": "typing-extensions",
+                "package_name": "typing-extensions",
+                "candidate_version": "4.15.0"
+            },
+            "dependencies": []
+        }
+    ]
+
+Trace why the resolver pulled a package in with ``--reverse`` (``-r``):
+
+.. code-block:: console
+
+    $ pipdeptree from-index "fastapi<=0.115.2" --reverse --packages anyio
+    anyio==4.13.0
+    └── starlette==0.40.0 [requires: anyio==4.13.0]
+        └── fastapi==0.115.2 [requires: starlette==0.40.0]
+
+The rest carry over too: ``-o mermaid`` and the ``graphviz-*`` formats, ``--depth`` (``-d``) to cap the tree,
+``--packages`` (``-p``) and ``--exclude`` (``-e``) to filter, ``--extras`` (``-x``) to control optional edges, and
+``--encoding``:
+
+.. code-block:: console
+
+    $ pipdeptree from-index "fastapi<=0.115.2" --depth 1
+    $ pipdeptree from-index "fastapi<=0.115.2" -o mermaid
+    $ pipdeptree from-index "fastapi<=0.115.2" --packages starlette
+    $ pipdeptree from-index "fastapi<=0.115.2" --exclude anyio
+    $ pipdeptree from-index "requests[socks]" --extras none
+
+Resolve editable, local and git requirements
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For a requirement that points at a checkout instead of the index, the resolver reads the target's PEP 621
+metadata. It reads the project's ``[project]`` table (name, version, dependencies) statically, with no build, and
+falls back to a build backend only when the target declares its dependencies dynamically. A project with a static
+``[project]`` resolves with no build; a dynamic-metadata project triggers its backend.
+
+Editable installs are a ``--requirements`` file directive, so pass them through a file:
+
+.. code-block:: console
+
+    $ printf -- '-e ./mypkg\n' > requirements.txt
+    $ pipdeptree from-index --requirements requirements.txt
+
+Local paths (``./mypkg``, ``file:///abs/path``) work the same, as positional arguments or file lines. For a pinned
+git requirement, the resolver clones the repo to its cache and reads the metadata:
+
+.. code-block:: console
+
+    $ pipdeptree from-index "mypkg @ git+https://github.com/o/r.git@<full-40-char-commit-sha>"
+
+The git ref must be a full 40-character commit sha; pipdeptree refuses a tag or branch so the resolve stays
+reproducible. Bare wheel/sdist archive URLs and non-git VCS schemes (``hg+``/``bzr+``/``svn+``) stay out of scope.
+
+Handle errors
+~~~~~~~~~~~~~
+
+A ``--requirements`` or ``--pyproject`` file must exist; a missing one stops the command. Positional arguments are
+requirement strings, never file paths:
+
+.. code-block:: console
+
+    $ pipdeptree from-index --requirements missing.txt
+    source file does not exist: missing.txt
+
+A bare wheel/sdist archive URL or a non-git VCS scheme (``hg+``/``bzr+``/``svn+``) has no index mapping, so
+pipdeptree names the file and line that carried it:
+
+.. code-block:: console
+
+    $ pipdeptree from-index --requirements requirements.txt
+    URL requirements are not supported by the index resolver: foo @ https://h/foo-1.0-py3-none-any.whl (requirements.txt:3)
+
+An unpinned git ref fails the same way, and so does a constraint that carries extras or a URL.
+
+The installed-only display options inspect on-disk files, so ``from-index`` does not accept them. Passing one is an
+error:
+
+.. code-block:: console
+
+    $ pipdeptree from-index "starlette" --metadata license
+    ...
+    pipdeptree: error: unrecognized arguments: --metadata license
+
+The same holds for ``--computed`` (``-c``), ``--license``, and the environment-inspection options (``--python``,
+``--path``, ``-l``/``-u``): none have a downloaded package or an environment to read. Giving no source at all is
+also an error:
+
+.. code-block:: console
+
+    $ pipdeptree from-index
+    ...
+    pipdeptree: error: from-index needs at least one REQUIREMENT, --requirements FILE, or --pyproject FILE
+
+Limitations
+~~~~~~~~~~~
+
+- A ``--requirements`` or ``--pyproject`` file must exist, or the command errors (shown above). Positional
+  arguments are always requirement strings, never file paths.
+- Extras resolve everywhere a requirement can appear: a positional ``requests[socks]``, a ``requests[socks]`` line
+  in a ``--requirements`` file (including nested ``-r`` includes), and ``[project.optional-dependencies]`` reached
+  through a ``--pyproject``. The one exception is a ``-c`` constraint line: pip and the resolver both reject an
+  extra on a constraint (``foo[bar]<2``), because a constraint bounds a version without pulling the package in, so
+  the extra has nothing to attach to.
+- The resolver reads PEP 621 metadata for editable installs (``-e``), local paths (``./pkg``, ``file://``) and
+  pinned git requirements (``package @ git+https://...@<sha>``), as the resolve subsection covers above. Bare
+  wheel/sdist archive URLs and non-git VCS (``hg+``/``bzr+``/``svn+``) stay out of scope and error with the
+  offending file and line; a constraint that carries a URL fails the same way.
+- ``from-index`` rejects the installed-only display options (``--metadata``/``-m``, ``--computed``/``-c``,
+  ``--license``) and the environment-inspection options (``--python``, ``--path``, ``-l``/``-u``), since the
+  resolver produces only names, versions and dependency edges. Extras (``-x``) work, since they are part of the
+  resolved graph.
+- A ``--pyproject`` keeps its ``[tool.nab]`` configuration only when it is the lone source; mixing it with other
+  sources merges its ``[project].dependencies`` and drops its ``[tool.nab]``.
+- The subcommand needs network access and the ``pipdeptree[index]`` extra. Without the extra installed, it errors
+  with an install hint.
+
 Filtering packages
 ------------------
 

--- a/docs/tutorial/getting-started.rst
+++ b/docs/tutorial/getting-started.rst
@@ -139,6 +139,59 @@ Limit the tree depth:
     ├── chardet [required: >=3.0.0, installed: 7.1.0]
     └── pluggy [required: >=0.13.1,<2, installed: 1.6.0]
 
+Preview a tree before installing
+--------------------------------
+
+So far you have looked at packages that are already installed. You can also peek at the tree a package *would*
+pull in before you commit to installing it. This lives in the ``from-index`` subcommand, which queries PyPI
+instead of inspecting your environment. It ships in an optional extra, so install that first:
+
+.. code-block:: console
+
+    $ pip install pipdeptree[index]
+
+Now ask what ``starlette`` brings along:
+
+.. code-block:: console
+
+    $ pipdeptree from-index "starlette"
+    starlette==1.2.1
+    ├── anyio [candidate: 4.13.0]
+    │   ├── idna [candidate: 3.17]
+    │   └── typing-extensions [candidate: 4.15.0]
+    └── typing-extensions [candidate: 4.15.0]
+
+Read this the same way as the tree from your environment. The top line is the requirement you asked for and the
+indented lines are its dependencies. Each edge shows the candidate version the resolver selected from PyPI:
+nothing is installed and the resolver produces a single version per package without a requirement range, so the
+edges read ``[candidate: <version>]`` rather than the ``[required: ..., installed: ...]`` pair you see for an
+installed environment.
+
+The positional argument is a PEP 508 requirement, the same string you would pass to ``pip install``, so you can
+pin or bound it. Bound ``fastapi`` and resolve it alongside ``starlette`` -- the pin lands on the upper bound:
+
+.. code-block:: console
+
+    $ pipdeptree from-index "fastapi<=0.115.2" starlette
+    fastapi==0.115.2
+    ├── pydantic [candidate: 2.13.4]
+    │   ├── annotated-types [candidate: 0.7.0]
+    │   ├── pydantic-core [candidate: 2.46.4]
+    │   │   └── typing-extensions [candidate: 4.15.0]
+    │   ├── typing-extensions [candidate: 4.15.0]
+    │   └── typing-inspection [candidate: 0.4.2]
+    │       └── typing-extensions [candidate: 4.15.0]
+    ├── starlette [candidate: 0.40.0]
+    │   └── anyio [candidate: 4.13.0]
+    │       ├── idna [candidate: 3.17]
+    │       └── typing-extensions [candidate: 4.15.0]
+    └── typing-extensions [candidate: 4.15.0]
+
+The constraint moves the top-level pin to ``0.115.2`` and the dependency picks follow from it. You can also resolve
+a ``pyproject.toml`` with ``--pyproject`` or a requirements file with ``--requirements``, and even a local checkout
+or a pinned git requirement, where the resolver reads the target's metadata. See :doc:`/how-to/usage` for those
+sources, the render flags, and the inputs the resolver rejects.
+
 Next steps
 ----------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,12 +48,18 @@ dependencies = [
 optional-dependencies.graphviz = [
   "graphviz>=0.21",
 ]
+optional-dependencies.index = [
+  "nab-index>=0.0.4",
+  "nab-python>=0.0.4",
+  "pip-requirements-parser>=32",
+]
 optional-dependencies.rich = [
   "rich>=14.3.3",
 ]
 optional-dependencies.test = [
   "covdefaults>=2.3",
   "diff-cover>=9.7.1",
+  "pipdeptree[index]",
   "pytest>=8.4.2",
   "pytest-cov>=7",
   "pytest-mock>=3.15.1",

--- a/src/pipdeptree/__main__.py
+++ b/src/pipdeptree/__main__.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from pipdeptree._cli import Options, get_options, parse_packages
 from pipdeptree._detect_env import detect_active_interpreter, find_active_interpreter
 from pipdeptree._discovery import InterpreterQueryError, get_installed_distributions
+from pipdeptree._from_index import FromIndexInputError, FromIndexUnavailableError, resolve_from_index
 from pipdeptree._models import PackageDAG
 from pipdeptree._models.dag import IncludeExcludeOverlapError, IncludePatternNotFoundError
 from pipdeptree._render import render
@@ -43,6 +44,9 @@ def main(args: Sequence[str] | None = None) -> int | None:
     except InterpreterQueryError as e:
         print(f"Failed to query custom interpreter: {e}", file=sys.stderr)  # noqa: T201
         return 1
+    except (FromIndexUnavailableError, FromIndexInputError) as e:
+        print(str(e), file=sys.stderr)  # noqa: T201
+        return 1
     except _FilterError as e:
         if e.is_fatal:
             print(str(e), file=sys.stderr)  # noqa: T201
@@ -63,16 +67,28 @@ def build_tree(options: Options, *, log_resolved: bool = False) -> PackageDAG:
     Shared by the CLI and the programmatic :func:`pipdeptree.render` API.
 
     :raises InterpreterQueryError: if querying a custom interpreter failed
+    :raises FromIndexUnavailableError: if from-index is used but the optional nab resolver is missing
+    :raises FromIndexInputError: if a from-index source is missing or a requirements file uses an unsupported directive
     :raises _FilterError: if the include/exclude filter cannot be satisfied
     """
-    options.python = _resolve_python(options.python, log_resolved=log_resolved)
-
-    pkgs = get_installed_distributions(
-        interpreter=options.python,
-        supplied_paths=options.path or None,
-        local_only=options.local_only,
-        user_only=options.user_only,
-    )
+    if options.command == "from-index":
+        # from-index resolves requirements by querying the package index instead of inspecting an installed
+        # environment, so interpreter resolution is skipped entirely.
+        pkgs = resolve_from_index(
+            requirements=options.requirement,
+            requirement_files=options.requirements or [],
+            pyproject_files=options.pyproject or [],
+            index_url=options.index_url,
+            extra_index_url=options.extra_index_url,
+        )
+    else:
+        options.python = _resolve_python(options.python, log_resolved=log_resolved)
+        pkgs = get_installed_distributions(
+            interpreter=options.python,
+            supplied_paths=options.path or None,
+            local_only=options.local_only,
+            user_only=options.user_only,
+        )
 
     include, requested_extras = parse_packages(options.packages)
     tree = PackageDAG.from_pkgs(pkgs, extras=options.extras, requested_extras=requested_extras)

--- a/src/pipdeptree/_cli.py
+++ b/src/pipdeptree/_cli.py
@@ -21,6 +21,12 @@ class Options(Namespace):
     freeze: bool
     python: str | None
     path: list[str]
+    command: str | None
+    requirement: list[str]
+    requirements: list[str] | None
+    pyproject: list[str] | None
+    index_url: str | None
+    extra_index_url: list[str] | None
     all: bool
     local_only: bool
     user_only: bool
@@ -90,22 +96,18 @@ class _Formatter(ArgumentDefaultsHelpFormatter):
 
 
 def build_parser() -> ArgumentParser:
+    # The render/select flags shared by the default command and the from-index subcommand are defined once on a
+    # parent parser; both the top-level parser and the from-index subparser inherit them via parents=[...], so the
+    # flags stay single-sourced and the top-level CLI keeps its existing behavior.
+    render_parent = _build_render_parent()
+
     parser = ArgumentParser(
-        prog="pipdeptree", description="Dependency tree of the installed python packages", formatter_class=_Formatter
+        prog="pipdeptree",
+        description="Dependency tree of the installed python packages",
+        formatter_class=_Formatter,
+        parents=[render_parent],
     )
     parser.add_argument("-v", "--version", action="version", version=f"{__version__}")
-    parser.add_argument(
-        "-w",
-        "--warn",
-        dest="warn",
-        type=str,
-        choices=["silence", "suppress", "fail"],
-        default="suppress",
-        help=(
-            "warning control: suppress will show warnings but return 0 whether or not they are present; silence will "
-            "not show warnings at all and  always return 0; fail will show warnings and  return 1 if any are present"
-        ),
-    )
 
     select = parser.add_argument_group(title="select", description="choose what to render")
     select.add_argument(
@@ -122,7 +124,104 @@ def build_parser() -> ArgumentParser:
         help="passes a path used to restrict where packages should be looked for (can be used multiple times)",
         action="append",
     )
-    select.add_argument(
+
+    scope = select.add_mutually_exclusive_group()
+    scope.add_argument(
+        "-l",
+        "--local-only",
+        action="store_true",
+        help="if in a virtualenv that has global access do not show globally installed packages",
+    )
+    scope.add_argument("-u", "--user-only", action="store_true", help="only show installations in the user site dir")
+
+    _add_installed_metadata_arguments(parser)
+
+    sub = parser.add_subparsers(dest="command")
+    from_index = sub.add_parser(
+        "from-index",
+        parents=[render_parent],
+        formatter_class=_Formatter,
+        help="resolve requirements by querying a package index and render their tree (needs the index extra)",
+        description=(
+            "Resolve the given requirements by querying the package index (PyPI) and render the dependency tree "
+            "without installing or inspecting the environment. Positional arguments are inline PEP 508 requirements; "
+            "files are supplied explicitly via --requirements and --pyproject. A lone --pyproject is resolved "
+            "natively (honoring [tool.nab]); otherwise every source merges into one resolve. Needs the optional "
+            "index resolver (pip install pipdeptree[index])."
+        ),
+    )
+    from_index.add_argument(
+        "requirement",
+        nargs="*",
+        metavar="REQUIREMENT",
+        help="inline PEP 508 requirement to resolve, like a pip install argument; repeatable",
+    )
+    from_index.add_argument(
+        "--requirements",
+        action="append",
+        metavar="FILE",
+        help="a requirements.txt or .in style file (nested -r, -c constraints, markers and comments supported); "
+        "repeatable",
+    )
+    from_index.add_argument(
+        "--pyproject",
+        action="append",
+        metavar="FILE",
+        help="a pyproject.toml handed natively to the resolver when it is the only source; repeatable",
+    )
+    from_index.add_argument(
+        "--index-url",
+        metavar="URL",
+        default=None,
+        help="primary package index to resolve against, replacing PyPI; falls back to PIP_INDEX_URL then "
+        "UV_INDEX_URL when unset, and defaults to PyPI",
+    )
+    from_index.add_argument(
+        "--extra-index-url",
+        action="append",
+        metavar="URL",
+        default=None,
+        help="additional package index to resolve against, repeatable; falls back to PIP_EXTRA_INDEX_URL then "
+        "UV_EXTRA_INDEX_URL (whitespace separated) when unset",
+    )
+
+    # Bare ``pipdeptree`` does not visit the subparser, so seed defaults for its attributes to keep Options total. The
+    # installed-only display options (license/metadata/computed) are not exposed on the from-index subparser, so seed
+    # them too: this keeps Options total whichever path argparse takes, so get_options can post-process it always.
+    parser.set_defaults(
+        command=None,
+        requirement=[],
+        requirements=None,
+        pyproject=None,
+        index_url=None,
+        extra_index_url=None,
+        license=False,
+        metadata="",
+        computed="",
+    )
+    return parser
+
+
+def _build_render_parent() -> ArgumentParser:
+    parent = ArgumentParser(add_help=False)
+    parent.add_argument(
+        "-w",
+        "--warn",
+        dest="warn",
+        type=str,
+        choices=["silence", "suppress", "fail"],
+        default="suppress",
+        help=(
+            "warning control: suppress will show warnings but return 0 whether or not they are present; silence will "
+            "not show warnings at all and  always return 0; fail will show warnings and  return 1 if any are present"
+        ),
+    )
+    _add_render_arguments(parent)
+    return parent
+
+
+def _add_render_arguments(parser: ArgumentParser) -> None:
+    parser.add_argument(
         "-p",
         "--packages",
         help=(
@@ -131,19 +230,19 @@ def build_parser() -> ArgumentParser:
         ),
         metavar="P",
     )
-    select.add_argument(
+    parser.add_argument(
         "-e",
         "--exclude",
         help="comma separated list of packages to not show - wildcards are supported, like 'somepackage.*'. "
         "(cannot combine with -p or -a)",
         metavar="P",
     )
-    select.add_argument(
+    parser.add_argument(
         "--exclude-dependencies",
         help="used along with --exclude to also exclude dependencies of packages",
         action="store_true",
     )
-    select.add_argument(
+    parser.add_argument(
         "-x",
         "--extras",
         nargs="?",
@@ -156,42 +255,28 @@ def build_parser() -> ArgumentParser:
             "installed; 'none' shows none. Bare --extras means 'explicit'"
         ),
     )
-
-    scope = select.add_mutually_exclusive_group()
-    scope.add_argument(
-        "-l",
-        "--local-only",
-        action="store_true",
-        help="if in a virtualenv that has global access do not show globally installed packages",
-    )
-    scope.add_argument("-u", "--user-only", action="store_true", help="only show installations in the user site dir")
-
-    render = parser.add_argument_group(
-        title="render",
-        description="choose how to render the dependency tree",
-    )
-    render.add_argument(
+    parser.add_argument(
         "-f", "--freeze", action="store_true", help="(Deprecated, use -o) print names so as to write freeze files"
     )
-    render.add_argument(
+    parser.add_argument(
         "--encoding",
         dest="encoding",
         default=sys.stdout.encoding,
         help="the encoding to use when writing to the output",
         metavar="E",
     )
-    render.add_argument(
+    parser.add_argument(
         "-a", "--all", action="store_true", help="list all deps at top level (text, rich, and freeze render only)"
     )
-    render.add_argument(
+    parser.add_argument(
         "-d",
         "--depth",
-        type=lambda x: int(x) if x.isdigit() and (int(x) >= 0) else parser.error("Depth must be a number that is >= 0"),
+        type=_positive_int,
         default=float("inf"),
         help="limit the depth of the tree (text, rich, freeze, and graphviz render only)",
         metavar="D",
     )
-    render.add_argument(
+    parser.add_argument(
         "-r",
         "--reverse",
         action="store_true",
@@ -201,28 +286,7 @@ def build_parser() -> ArgumentParser:
             "packages that need them under them"
         ),
     )
-    render.add_argument(
-        "--license",
-        action="store_true",
-        help="(Deprecated, use --metadata license) list the license(s) of a package",
-    )
-    render.add_argument(
-        "-m",
-        "--metadata",
-        default="",
-        help="comma separated list of metadata fields to display from the package METADATA file"
-        " (e.g. license,summary,author,home-page,requires-python)",
-        metavar="M",
-    )
-    render.add_argument(
-        "-c",
-        "--computed",
-        default="",
-        help=f"comma separated list of computed fields to display: {', '.join(sorted(ALLOWED_COMPUTED_FIELDS))}",
-        metavar="C",
-    )
-
-    render_type = render.add_mutually_exclusive_group()
+    render_type = parser.add_mutually_exclusive_group()
     render_type.add_argument(
         "-j",
         "--json",
@@ -259,7 +323,39 @@ def build_parser() -> ArgumentParser:
         help=f"specify how to render the tree; supported formats: {', '.join(ALLOWED_RENDER_FORMATS)}, or graphviz-*\
             (e.g. graphviz-png, graphviz-dot)",
     )
-    return parser
+
+
+def _add_installed_metadata_arguments(parser: ArgumentParser) -> None:
+    # These read state of already-installed packages (METADATA file contents, on-disk file sizes), so they only make
+    # sense for the default command that inspects an environment. The from-index subcommand renders resolver output for
+    # packages that are never installed, so it intentionally omits them.
+    parser.add_argument(
+        "--license",
+        action="store_true",
+        help="(Deprecated, use --metadata license) list the license(s) of a package",
+    )
+    parser.add_argument(
+        "-m",
+        "--metadata",
+        default="",
+        help="comma separated list of metadata fields to display from the package METADATA file"
+        " (e.g. license,summary,author,home-page,requires-python)",
+        metavar="M",
+    )
+    parser.add_argument(
+        "-c",
+        "--computed",
+        default="",
+        help=f"comma separated list of computed fields to display: {', '.join(sorted(ALLOWED_COMPUTED_FIELDS))}",
+        metavar="C",
+    )
+
+
+def _positive_int(value: str) -> int:
+    if value.isdigit() and int(value) >= 0:
+        return int(value)
+    msg = "Depth must be a number that is >= 0"
+    raise ArgumentTypeError(msg)
 
 
 def get_options(args: Sequence[str] | None) -> Options:
@@ -287,6 +383,8 @@ def get_options(args: Sequence[str] | None) -> Options:
 
     options.context = RenderContext(metadata=options.metadata, computed=options.computed)
 
+    if options.command == "from-index" and not (options.requirement or options.requirements or options.pyproject):
+        return parser.error("from-index needs at least one REQUIREMENT, --requirements FILE, or --pyproject FILE")
     if options.exclude_dependencies and not options.exclude:
         return parser.error("must use --exclude-dependencies with --exclude")
     if options.path and (options.local_only or options.user_only):

--- a/src/pipdeptree/_from_index.py
+++ b/src/pipdeptree/_from_index.py
@@ -1,0 +1,436 @@
+"""
+Resolve a set of requirements into a dependency tree by querying a package index.
+
+This is the engine behind the ``from-index`` CLI subcommand. It defers to the optional :pypi:`nab-python`
+resolver, which resolves a ``[project].dependencies`` table against the package index (PyPI) -- returning pinned
+versions plus a forward edge graph -- without touching the active environment. The resolved pins and edges are
+adapted into lightweight ``importlib.metadata.Distribution`` look-alikes so the existing
+:class:`~pipdeptree._models.PackageDAG` and every renderer work unchanged.
+
+Inputs are explicit, never guessed from a path's shape:
+
+- inline PEP 508 requirement strings (the positional arguments);
+- ``--requirements`` files -- standard ``requirements.txt``/``.in``-style files parsed with
+  :pypi:`pip-requirements-parser`, so nested ``-r``, ``-c`` constraints, environment markers and comments all work;
+- ``--pyproject`` files -- handed natively to nab, which reads ``[project].dependencies`` and honors ``[tool.nab]``.
+
+A lone pyproject (the only source) is resolved natively for full fidelity; otherwise every source is reduced to a
+merged list of requirement strings resolved through a temporary ``pyproject.toml``.
+
+Editable installs (``-e ./pkg``), local-path requirements (``./pkg``, ``file://``) and pinned git VCS requirements
+(``pkg @ git+https://.../r.git@<sha>``) are not handed to the index. Instead they are translated into nab's
+source-override config: a ``[[tool.nab.local-sources]]`` / ``[[tool.nab.vcs-sources]]`` entry plus the package name
+added to ``[project].dependencies``. nab reads the target's PEP 621 ``[project]`` metadata statically (no build);
+it only invokes a build backend when that metadata is dynamic. Bare wheel/sdist URLs and non-git VCS schemes have no
+nab mapping and are still rejected.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+import string
+import tempfile
+from dataclasses import dataclass, field
+from email.message import Message
+from importlib.metadata import Distribution
+from itertools import starmap
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Final
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from email.message import Message as MessageType
+
+# nab's recognized git VCS schemes (see nab_python._vcs_admission._VCS_SCHEMES); only these map to a vcs-source.
+_GIT_SCHEMES: Final[tuple[str, ...]] = ("git+https", "git+ssh", "git+http", "git+file", "git+git")
+# A pinned git ref is a full 40-char hex commit sha; nab's require-pin (default true) refuses anything looser.
+_SHA_LENGTH: Final[int] = 40
+
+
+class FromIndexUnavailableError(Exception):
+    """Raised when ``from-index`` is requested but the optional index resolver is not installed."""
+
+
+class FromIndexInputError(ValueError):
+    """Raised when a from-index source cannot be read (missing file, unsupported requirements directive)."""
+
+
+_INSTALL_HINT: Final[str] = (
+    "The from-index subcommand requires the optional index resolver. Install it with: pip install pipdeptree[index]"
+)
+
+
+@dataclass
+class _LocalSource:
+    """A directory translated into a ``[[tool.nab.local-sources]]`` override."""
+
+    name: str
+    path: str
+    editable: bool
+
+
+@dataclass
+class _VcsSource:
+    """A pinned git URL translated into a ``[[tool.nab.vcs-sources]]`` override."""
+
+    name: str
+    url: str
+
+
+@dataclass
+class _ParsedInputs:
+    """Accumulated roots plus the source-overrides translated out of editable/local/VCS requirements."""
+
+    requirements: list[str] = field(default_factory=list)
+    constraints: list[str] = field(default_factory=list)
+    local_sources: list[_LocalSource] = field(default_factory=list)
+    vcs_sources: list[_VcsSource] = field(default_factory=list)
+    indexes: list[tuple[str, str]] | None = None
+
+
+def resolve_from_index(
+    *,
+    requirements: list[str],
+    requirement_files: list[str],
+    pyproject_files: list[str],
+    index_url: str | None = None,
+    extra_index_url: list[str] | None = None,
+) -> list[Distribution]:
+    """
+    Resolve the explicit inputs into Distribution-like objects by querying the package index.
+
+    :param requirements: inline PEP 508 requirement strings (the positional arguments).
+    :param requirement_files: ``requirements.txt``/``.in``-style file paths, parsed into PEP 508 strings.
+    :param pyproject_files: ``pyproject.toml`` file paths handed natively to nab.
+    :param index_url: primary index URL, replacing PyPI; ``None`` falls back to env then PyPI.
+    :param extra_index_url: additional index URLs; ``None`` falls back to env.
+    :returns: a list of :class:`importlib.metadata.Distribution` look-alikes ready for
+        :meth:`pipdeptree._models.PackageDAG.from_pkgs`.
+    :raises FromIndexUnavailableError: if the index resolver is not installed.
+    :raises FromIndexInputError: if a source file is missing or a requirements file uses an unsupported directive.
+    """
+    indexes = _resolve_indexes(index_url, extra_index_url)
+    if not requirements and not requirement_files and len(pyproject_files) == 1:
+        # A lone pyproject.toml is resolved natively so nab can honor [tool.nab] and the full [project] table; any
+        # local/VCS deps there are the user's own [tool.nab] concern, so this path is left untranslated.
+        result = _resolve_pyproject_path(_require_existing(Path(pyproject_files[0])), indexes)
+    else:
+        # Mixed/multiple sources lose native fidelity: fold every pyproject's [project].dependencies into the
+        # merged requirement list and resolve them all through one temporary pyproject.
+        inputs = _ParsedInputs(
+            requirements=[
+                dep for path in pyproject_files for dep in _read_pyproject_dependencies(_require_existing(Path(path)))
+            ],
+            indexes=indexes,
+        )
+        # A merged --pyproject keeps its [project].dependencies but NOT its own [tool.nab].constraints; only
+        # constraints declared via --requirements (-c) files flow into the resolve. Acceptable known gap.
+        for path in requirement_files:
+            _parse_requirements_file(_require_existing(Path(path)), inputs)
+        # Inline positional requirements are scanned for the same editable/local/VCS forms a file would carry.
+        _parse_inline_requirements(requirements, inputs)
+        result = _resolve_requirements(inputs)
+    return _adapt(result)
+
+
+def _resolve_indexes(index_url: str | None, extra_index_url: list[str] | None) -> list[tuple[str, str]] | None:
+    """
+    Resolve the effective ordered indexes from flags then env, or ``None`` to use nab's PyPI default.
+
+    Precedence per slot: explicit flag, then PIP_*, then UV_*. The primary replaces PyPI (matching pip's
+    ``--index-url``); with only extras given, PyPI stays primary. nab tries indexes in order and the first
+    carrying the package wins, unlike pip's merge-and-pick-highest.
+    """
+    primary = index_url or os.environ.get("PIP_INDEX_URL") or os.environ.get("UV_INDEX_URL") or None
+    if extra_index_url is not None:
+        extras = extra_index_url
+    else:
+        extras = (os.environ.get("PIP_EXTRA_INDEX_URL") or os.environ.get("UV_EXTRA_INDEX_URL") or "").split()
+    if primary is None and not extras:
+        return None
+
+    from nab_python.fetch import (  # noqa: PLC0415
+        DEFAULT_INDEX_NAME,
+        DEFAULT_INDEX_URL,
+    )
+
+    # Only extras given: keep PyPI as the primary so the extras are genuinely additional, not a replacement.
+    if primary is None:
+        resolved = [(DEFAULT_INDEX_NAME, DEFAULT_INDEX_URL)]
+    else:
+        name = DEFAULT_INDEX_NAME if primary == DEFAULT_INDEX_URL else "primary"
+        resolved = [(name, primary)]
+    # nab requires unique index names; generate stable extra-N names that cannot collide with the primary slot.
+    resolved.extend((f"extra-{position}", url) for position, url in enumerate(extras, start=1))
+    return resolved
+
+
+def _require_existing(path: Path) -> Path:
+    if not path.is_file():
+        msg = f"source file does not exist: {path}"
+        raise FromIndexInputError(msg)
+    return path
+
+
+def _parse_requirements_file(path: Path, inputs: _ParsedInputs) -> None:
+    """
+    Parse a requirements file into ``inputs``, following nested ``-r``/``-c`` files.
+
+    The parser routes comment and bare-option lines (``--hash``, ``--index-url``) to its ``options``/``comments``,
+    so they drop out silently. Editable/local/git-VCS entries become nab source-overrides; inputs with no nab
+    mapping (bare archive URLs, non-git VCS) and constraints bearing extras are rejected.
+    """
+    # pip-requirements-parser ships in the optional 'index' extra, so it is guarded like nab below.
+    from pip_requirements_parser import RequirementsFile  # noqa: PLC0415
+
+    parsed = RequirementsFile.from_file(str(path), include_nested=True)
+    for entry in parsed.requirements:
+        location = f"{entry.line} ({path}:{entry.line_number})"
+        if entry.is_editable or entry.link is not None:
+            # Editable lines carry ``req is None``; a relative path is resolved against the requirements file's dir.
+            _translate_source(entry, base_dir=path.parent, location=location, inputs=inputs)
+            continue
+        # The parser routes comment/option-only lines to its ``options``/``comments``; everything left here that is
+        # not editable/link-backed carries a parsed PEP 508 ``req``.
+        assert entry.req is not None
+        if entry.is_constraint:
+            if entry.req.extras:
+                msg = f"the index resolver cannot constrain extras: {location}"
+                raise FromIndexInputError(msg)
+            inputs.constraints.append(str(entry.req))
+        else:
+            # pip-requirements-parser moves the marker off ``req`` onto ``entry.marker``; reattach it so the
+            # resolver still sees marker-gated requirements.
+            text = str(entry.req)
+            inputs.requirements.append(f"{text}; {entry.marker}" if entry.marker is not None else text)
+
+
+def _parse_inline_requirements(requirements: list[str], inputs: _ParsedInputs) -> None:
+    """
+    Translate editable/local/VCS forms from positional requirements like file entries.
+
+    Plain PEP 508 strings pass through verbatim; only path/URL-shaped inputs go through the parser, since they
+    need a link object to classify and locate.
+    """
+    translatable = [req for req in requirements if _looks_like_source(req)]
+    inputs.requirements.extend(req for req in requirements if not _looks_like_source(req))
+    if not translatable:
+        return
+    from pip_requirements_parser import RequirementsFile  # noqa: PLC0415
+
+    # The parser has no working per-line API (its from_string is broken), so route the lines through a temp file;
+    # relative paths in a positional argument resolve against the current working directory.
+    with tempfile.TemporaryDirectory() as tmp:
+        listing = Path(tmp) / "inline.txt"
+        listing.write_text("\n".join(translatable) + "\n", encoding="utf-8")
+        parsed = RequirementsFile.from_file(str(listing), include_nested=True)
+    for entry in parsed.requirements:
+        _translate_source(entry, base_dir=Path.cwd(), location=str(entry.line), inputs=inputs)
+
+
+def _looks_like_source(requirement: str) -> bool:
+    # A positional source is a ``name @ <url>`` form or a bare local path; everything else is a plain PEP 508 req.
+    stripped = requirement.strip()
+    return (
+        "://" in stripped
+        or stripped.startswith(("./", "../", "/", "file:"))
+        or (Path(stripped).exists() and (Path(stripped) / "pyproject.toml").exists())
+    )
+
+
+def _translate_source(entry: Any, *, base_dir: Path, location: str, inputs: _ParsedInputs) -> None:
+    """Translate one editable/local/git-VCS entry into a nab source-override, or reject an unmappable URL."""
+    link = entry.link
+    scheme = "" if link is None else link.scheme
+    if entry.is_vcs_url or scheme.startswith("git+"):
+        if not scheme.startswith("git+"):
+            # Non-git VCS (hg+/bzr+/svn+) has no nab mapping.
+            msg = f"only git VCS requirements are supported by the index resolver: {location}"
+            raise FromIndexInputError(msg)
+        inputs.vcs_sources.append(_to_vcs_source(entry, location))
+    elif entry.is_editable or scheme in {"", "file"}:
+        # Empty scheme is a bare/editable local path; ``file`` is a file:// URL -- both name a local directory.
+        inputs.local_sources.append(_to_local_source(entry, base_dir, location))
+    else:
+        # Bare wheel/sdist archive URLs (https/http) have no nab source-override.
+        msg = f"URL requirements are not supported by the index resolver: {location}"
+        raise FromIndexInputError(msg)
+
+
+def _to_vcs_source(entry: Any, location: str) -> _VcsSource:
+    # pip's ``name @ git+...`` and ``git+...#egg=name`` both populate ``req.name``; without a name nab cannot map it.
+    if entry.req is None or entry.req.name is None:
+        msg = f"VCS requirement needs an explicit name (use 'name @ git+...'): {location}"
+        raise FromIndexInputError(msg)
+    url = entry.link.url
+    # Preempt nab's require-pin so the error names the line; a pinned ref is a 40-char hex sha after the last '@'.
+    ref = url.split("#", 1)[0].split("://", 1)[-1].rsplit("@", 1)
+    if len(ref) != 2 or len(ref[1]) != _SHA_LENGTH or not all(c in string.hexdigits for c in ref[1]):
+        msg = f"VCS requirement must be pinned to a full commit sha: {location}"
+        raise FromIndexInputError(msg)
+    return _VcsSource(name=entry.req.name, url=url)
+
+
+def _to_local_source(entry: Any, base_dir: Path, location: str) -> _LocalSource:
+    link = entry.link
+    # A file:// URL exposes file_path; a bare/editable path is a (possibly relative) filesystem path in link.url.
+    raw_path = link.file_path if link.scheme == "file" else link.url
+    directory = Path(raw_path)
+    if not directory.is_absolute():
+        directory = (base_dir / directory).resolve()
+    if not (directory / "pyproject.toml").is_file():
+        msg = f"editable/local source must be a directory with a pyproject.toml: {location}"
+        raise FromIndexInputError(msg)
+    if (name := _read_pyproject_name(directory)) is None:
+        msg = f"cannot determine package name for editable/local source {directory}: its pyproject.toml has no [project].name"  # noqa: E501
+        raise FromIndexInputError(msg)
+    return _LocalSource(name=name, path=str(directory), editable=bool(entry.is_editable))
+
+
+def _read_pyproject_name(directory: Path) -> str | None:
+    # read_pyproject_name lives in nab_python, guarded like the resolver imports below.
+    try:
+        from nab_python.requirements_file import read_pyproject_name  # noqa: PLC0415
+    except ImportError as exc:
+        raise FromIndexUnavailableError(_INSTALL_HINT) from exc
+    return read_pyproject_name(directory / "pyproject.toml")
+
+
+def _adapt(result: Any) -> list[Distribution]:
+    pins: Mapping[str, object] = result.pins
+    dependencies: Mapping[str, tuple[str, ...]] = result.lock_input.dependencies
+    return [
+        _FromIndexDistribution(
+            name,
+            str(version),
+            tuple(f"{child}=={pins[child]}" for child in dependencies.get(name, ())),
+        )
+        for name, version in pins.items()
+    ]
+
+
+def _read_pyproject_dependencies(path: Path) -> list[str]:
+    # Reading TOML only happens on the mixed-sources path, which already requires nab installed; nab-python
+    # depends on tomli, so it is available on 3.10 where stdlib tomllib does not yet exist.
+    import sys  # noqa: PLC0415
+
+    if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
+        import tomllib  # noqa: PLC0415
+    else:  # pragma: <3.11 cover
+        import tomli as tomllib  # noqa: PLC0415
+
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    dependencies = data.get("project", {}).get("dependencies", [])
+    return [str(dep) for dep in dependencies]
+
+
+def _resolve_requirements(inputs: _ParsedInputs) -> Any:
+    with tempfile.TemporaryDirectory() as tmp:
+        pyproject = Path(tmp) / "pyproject.toml"
+        # The temp pyproject already carries the [[tool.nab.indexes]] tables, so the resolve path reads them from the
+        # file rather than overriding the config; pass None to leave the read config untouched.
+        pyproject.write_text(_render_pyproject(inputs), encoding="utf-8")
+        return _resolve_pyproject_path(pyproject, None)
+
+
+def _resolve_pyproject_path(pyproject: Path, indexes: list[tuple[str, str]] | None) -> Any:
+    # Imports are deferred and guarded so the optional nab dependency stays out of the core import path; this
+    # mirrors how the graphviz renderer guards its import (see _render/graphviz.py).
+    try:
+        # nab is an optional dependency, absent from a minimal (non-index) install.
+        from nab_index.multi_index import IndexConfig  # noqa: PLC0415
+        from nab_index.urllib3_async_transport import (  # noqa: PLC0415
+            Urllib3AsyncTransport,
+        )
+        from nab_python.config import read_pyproject_config  # noqa: PLC0415
+        from nab_python.resolve import resolve_pyproject  # noqa: PLC0415
+    except ImportError as exc:
+        raise FromIndexUnavailableError(_INSTALL_HINT) from exc
+
+    config = read_pyproject_config(pyproject)
+    if indexes is not None:
+        # An explicit --index-url/--extra-index-url (or its env fallback) overrides a --pyproject's own
+        # [tool.nab].indexes; with no override (indexes is None) the pyproject's own indexes apply.
+        config = dataclasses.replace(config, indexes=tuple(starmap(IndexConfig, indexes)))
+    return resolve_pyproject(pyproject, Urllib3AsyncTransport(), config=config)
+
+
+def _render_pyproject(inputs: _ParsedInputs) -> str:
+    # A source-override only changes HOW a package is sourced; the package must also be a root requirement to enter
+    # the tree, so every translated source name is added to [project].dependencies.
+    roots = [*inputs.requirements, *(s.name for s in inputs.local_sources), *(s.name for s in inputs.vcs_sources)]
+    deps = "".join(f"  {_toml_quote(req)},\n" for req in roots)
+    rendered = f'[project]\nname = "pipdeptree-from-index"\nversion = "0"\ndependencies = [\n{deps}]\n'
+
+    has_sources = bool(inputs.local_sources or inputs.vcs_sources)
+    if inputs.constraints or has_sources:
+        rendered += "[tool.nab]\n"
+    if inputs.constraints:
+        # nab reads constraints only from [tool.nab].constraints; resolve_pyproject has no per-call argument for
+        # them, so requirements-file -c entries must be threaded through this temporary pyproject.
+        rendered_constraints = "".join(f"  {_toml_quote(con)},\n" for con in inputs.constraints)
+        rendered += f"constraints = [\n{rendered_constraints}]\n"
+    if has_sources:
+        # WHY build-remote with local/VCS sources: nab extracts static PEP 621 metadata first, so a static
+        # [project] target resolves with NO build; a build only fires when the target's metadata is dynamic. Using
+        # build-remote (vs build-local) keeps that escape hatch open for cloned VCS targets too. Plain resolves
+        # (no sources) leave nab's default policy untouched.
+        rendered += 'build-policy = "build-remote"\n'
+    if inputs.vcs_sources:
+        # nab refuses VCS by default (policy=block, empty allowlist); opt in to every recognized git scheme and
+        # leave allowed-repos unset (any repo) and require-pin at its default true (reproducible: full sha needed).
+        schemes = ", ".join(_toml_quote(scheme) for scheme in _GIT_SCHEMES)
+        rendered += f'[tool.nab.vcs]\npolicy = "allow"\nallowed-schemes = [{schemes}]\n'
+    for source in inputs.local_sources:
+        rendered += (
+            "[[tool.nab.local-sources]]\n"
+            f"name = {_toml_quote(source.name)}\n"
+            f"path = {_toml_quote(source.path)}\n"
+            f"editable = {'true' if source.editable else 'false'}\n"
+        )
+    for source in inputs.vcs_sources:
+        rendered += f"[[tool.nab.vcs-sources]]\nname = {_toml_quote(source.name)}\nurl = {_toml_quote(source.url)}\n"
+    # An override replaces nab's default PyPI index; with no override the default applies, so nothing is emitted.
+    for name, url in inputs.indexes or ():
+        rendered += f"[[tool.nab.indexes]]\nname = {_toml_quote(name)}\nurl = {_toml_quote(url)}\n"
+    return rendered
+
+
+def _toml_quote(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+class _FromIndexDistribution(Distribution):
+    """A Distribution backed by resolved name/version/edges rather than an on-disk package."""
+
+    def __init__(self, name: str, version: str, children: tuple[str, ...]) -> None:
+        self._metadata = Message()
+        self._metadata["Name"] = name
+        self._metadata["Version"] = version
+        # children are already pinned requirement strings (e.g. "foo==1.2.3"), so the existing
+        # DistPackage.requires() reconstructs exact edges with no renderer changes.
+        for child in children:
+            self._metadata["Requires-Dist"] = child
+
+    @property
+    def metadata(self) -> MessageType:
+        return self._metadata
+
+    @property
+    def version(self) -> str:
+        return self._metadata["Version"]
+
+    def read_text(self, filename: str) -> str | None:  # noqa: ARG002, PLR6301
+        return None
+
+    def locate_file(self, path: str | os.PathLike[str]) -> Path:  # noqa: PLR6301
+        return Path(path)
+
+
+__all__ = [
+    "FromIndexInputError",
+    "FromIndexUnavailableError",
+    "resolve_from_index",
+]

--- a/src/pipdeptree/_models/package.py
+++ b/src/pipdeptree/_models/package.py
@@ -5,7 +5,7 @@ from functools import cached_property
 from importlib import import_module
 from importlib.metadata import Distribution, PackageMetadata, PackageNotFoundError, metadata, version
 from inspect import ismodule
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from packaging.requirements import InvalidRequirement, Requirement
 from packaging.utils import canonicalize_name
@@ -14,6 +14,8 @@ from pipdeptree._parser import distribution_to_specifier
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+
+RenderMode = Literal["default", "resolved"]
 
 
 class InvalidRequirementError(ValueError):
@@ -86,11 +88,11 @@ class Package(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def render_as_branch(self, *, frozen: bool) -> str:
+    def render_as_branch(self, *, frozen: bool, mode: RenderMode = "default") -> str:
         raise NotImplementedError
 
     @abstractmethod
-    def as_dict(self) -> dict[str, str]:
+    def as_dict(self, *, mode: RenderMode = "default") -> dict[str, str]:
         raise NotImplementedError
 
     def render(
@@ -98,9 +100,11 @@ class Package(ABC):
         parent: DistPackage | ReqPackage | None = None,
         *,
         frozen: bool = False,
+        mode: RenderMode = "default",
     ) -> str:
-        render = self.render_as_branch if parent else self.render_as_root
-        return render(frozen=frozen)
+        if parent:
+            return self.render_as_branch(frozen=frozen, mode=mode)
+        return self.render_as_root(frozen=frozen)
 
     @staticmethod
     def as_frozen_repr(distribution: Distribution) -> str:
@@ -197,7 +201,9 @@ class DistPackage(Package):
     def render_as_root(self, *, frozen: bool) -> str:
         return self.as_frozen_repr(self._obj) if frozen else f"{self.project_name}=={self.version}"
 
-    def render_as_branch(self, *, frozen: bool) -> str:
+    def render_as_branch(self, *, frozen: bool, mode: RenderMode = "default") -> str:  # noqa: ARG002
+        # resolved mode only relabels ReqPackage branches; a DistPackage branch appears in reverse mode
+        # where the "[requires: parent]" label describes the parent edge, so it is left unchanged.
         assert self.req is not None
         if not frozen:
             parent_ver_spec = self.req.version_spec
@@ -236,8 +242,9 @@ class DistPackage(Package):
             return f"[{self.req.extra}] {version}"
         return version
 
-    def as_dict(self) -> dict[str, str]:
-        return {"key": self.key, "package_name": self.project_name, "installed_version": self.version}
+    def as_dict(self, *, mode: RenderMode = "default") -> dict[str, str]:
+        version_key = "candidate_version" if mode == "resolved" else "installed_version"
+        return {"key": self.key, "package_name": self.project_name, version_key: self.version}
 
 
 class ReqPackage(Package):
@@ -264,10 +271,14 @@ class ReqPackage(Package):
             return self.as_frozen_repr(self.dist.unwrap())
         return self.project_name
 
-    def render_as_branch(self, *, frozen: bool) -> str:
+    def render_as_branch(self, *, frozen: bool, mode: RenderMode = "default") -> str:
         if not frozen:
-            req_ver = self.version_spec or "Any"
             extra_str = f", extra: {self.extra}" if self.extra else ""
+            if mode == "resolved":
+                # nab resolves one version per package and discards the per-edge range, so there is no
+                # "required" to show; surface only the selected candidate.
+                return f"{self.project_name} [candidate: {self.installed_version}{extra_str}]"
+            req_ver = self.version_spec or "Any"
             return f"{self.project_name} [required: {req_ver}, installed: {self.installed_version}{extra_str}]"
         return self.render_as_root(frozen=frozen)
 
@@ -313,13 +324,22 @@ class ReqPackage(Package):
     def is_missing(self) -> bool:
         return self.installed_version == self.UNKNOWN_VERSION
 
-    def as_dict(self) -> dict[str, str]:
-        result = {
-            "key": self.key,
-            "package_name": self.project_name,
-            "installed_version": self.installed_version,
-            "required_version": self.version_spec if self.version_spec is not None else "Any",
-        }
+    def as_dict(self, *, mode: RenderMode = "default") -> dict[str, str]:
+        if mode == "resolved":
+            # nab discards the per-edge range, so drop required_version and report the single resolved
+            # version under candidate_version.
+            result = {
+                "key": self.key,
+                "package_name": self.project_name,
+                "candidate_version": self.installed_version,
+            }
+        else:
+            result = {
+                "key": self.key,
+                "package_name": self.project_name,
+                "installed_version": self.installed_version,
+                "required_version": self.version_spec if self.version_spec is not None else "Any",
+            }
         if self.extra:
             result["extra"] = self.extra
         return result
@@ -334,5 +354,6 @@ def _try_parse_requirement(raw_req: str) -> Requirement | str:
 
 __all__ = [
     "DistPackage",
+    "RenderMode",
     "ReqPackage",
 ]

--- a/src/pipdeptree/_render/__init__.py
+++ b/src/pipdeptree/_render/__init__.py
@@ -13,20 +13,24 @@ from .text import render_text
 if TYPE_CHECKING:
     from pipdeptree._cli import Options
     from pipdeptree._models import PackageDAG
+    from pipdeptree._models.package import RenderMode
 
 
 def render(options: Options, tree: PackageDAG) -> None:
     output_format = options.output_format
+    # from-index/from-lock build a tree from resolved data: one version per package and no per-edge
+    # range, so edges show "[candidate: <version>]" instead of "[required:, installed:]".
+    mode: RenderMode = "resolved" if options.command in {"from-index", "from-lock"} else "default"
     if output_format == "json":
-        render_json(tree, context=options.context)
+        render_json(tree, context=options.context, mode=mode)
     elif output_format == "json-tree":
-        render_json_tree(tree, context=options.context)
+        render_json_tree(tree, context=options.context, mode=mode)
     elif output_format == "mermaid":
         render_mermaid(tree, context=options.context)
     elif output_format == "freeze":
         render_freeze(tree, max_depth=options.depth, list_all=options.all)
     elif output_format == "rich":
-        render_rich_text(tree, max_depth=options.depth, list_all=options.all, context=options.context)
+        render_rich_text(tree, max_depth=options.depth, list_all=options.all, context=options.context, mode=mode)
     elif output_format.startswith("graphviz-"):
         render_graphviz(
             tree,
@@ -42,6 +46,7 @@ def render(options: Options, tree: PackageDAG) -> None:
             encoding=options.encoding,
             list_all=options.all,
             context=options.context,
+            mode=mode,
         )
 
 

--- a/src/pipdeptree/_render/json.py
+++ b/src/pipdeptree/_render/json.py
@@ -8,12 +8,14 @@ from pipdeptree._computed import ComputedValues
 if TYPE_CHECKING:
     from pipdeptree._cli import RenderContext
     from pipdeptree._models import PackageDAG
+    from pipdeptree._models.package import RenderMode
 
 
 def render_json(
     tree: PackageDAG,
     *,
     context: RenderContext | None = None,
+    mode: RenderMode = "default",
 ) -> None:
     """
     Convert the tree into a flat json representation.
@@ -24,13 +26,14 @@ def render_json(
 
     :param tree: dependency tree
     :param context: metadata and computed fields to include
+    :param mode: "resolved" emits candidate_version instead of installed/required for resolved trees
     :returns: JSON representation of the tree
 
     """
     tree = tree.sort()
 
     def _package_dict(k: Any) -> dict[str, Any]:
-        d: dict[str, Any] = k.as_dict()
+        d: dict[str, Any] = k.as_dict(mode=mode)
         if context and context.metadata:
             d["metadata"] = k.get_metadata_dict(list(context.metadata))
         if context and context.computed:
@@ -38,7 +41,7 @@ def render_json(
         return d
 
     output = json.dumps(
-        [{"package": _package_dict(k), "dependencies": [v.as_dict() for v in vs]} for k, vs in tree.items()],
+        [{"package": _package_dict(k), "dependencies": [v.as_dict(mode=mode) for v in vs]} for k, vs in tree.items()],
         indent=4,
     )
     print(output)  # noqa: T201

--- a/src/pipdeptree/_render/json_tree.py
+++ b/src/pipdeptree/_render/json_tree.py
@@ -10,12 +10,14 @@ from pipdeptree._models import ReqPackage
 if TYPE_CHECKING:
     from pipdeptree._cli import RenderContext
     from pipdeptree._models import DistPackage, PackageDAG
+    from pipdeptree._models.package import RenderMode
 
 
 def render_json_tree(
     tree: PackageDAG,
     *,
     context: RenderContext | None = None,
+    mode: RenderMode = "default",
 ) -> None:
     """
     Convert the tree into a nested json representation.
@@ -30,6 +32,7 @@ def render_json_tree(
 
     :param tree: dependency tree
     :param context: metadata and computed fields to include
+    :param mode: "resolved" emits candidate_version instead of installed/required for resolved trees
     :returns: json representation of the tree
 
     """
@@ -45,11 +48,14 @@ def render_json_tree(
         if cur_chain is None:
             cur_chain = [node.project_name]
 
-        d: dict[str, str | list[Any] | None] = node.as_dict()  # ty: ignore[invalid-assignment]
-        if parent:
-            d["required_version"] = node.version_spec if isinstance(node, ReqPackage) and node.version_spec else "Any"
-        else:
-            d["required_version"] = d["installed_version"]
+        d: dict[str, str | list[Any] | None] = node.as_dict(mode=mode)  # ty: ignore[invalid-assignment]
+        if mode == "default":
+            if parent:
+                d["required_version"] = (
+                    node.version_spec if isinstance(node, ReqPackage) and node.version_spec else "Any"
+                )
+            else:
+                d["required_version"] = d["installed_version"]
 
         if context and context.metadata:
             d["metadata"] = node.get_metadata_dict(list(context.metadata))  # ty: ignore[invalid-assignment]

--- a/src/pipdeptree/_render/rich_text.py
+++ b/src/pipdeptree/_render/rich_text.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 
     from pipdeptree._cli import RenderContext
     from pipdeptree._models import PackageDAG
+    from pipdeptree._models.package import RenderMode
 
 
 def render_rich_text(
@@ -21,6 +22,7 @@ def render_rich_text(
     max_depth: float,
     list_all: bool = True,
     context: RenderContext | None = None,
+    mode: RenderMode = "default",
 ) -> None:
     """
     Print tree using Rich library for enhanced terminal output.
@@ -29,6 +31,7 @@ def render_rich_text(
     :param max_depth: the maximum depth of the dependency tree
     :param list_all: whether to list all the pkgs at the root level or only those that are the sub-dependencies
     :param context: metadata and computed fields to display
+    :param mode: "resolved" renders edges as "candidate: <version>" for resolved trees
     :returns: None
     """
     try:
@@ -45,10 +48,10 @@ def render_rich_text(
     console = Console()
 
     for node in nodes:
-        root_label = _format_node(node, parent=None, context=context, tree=tree)
+        root_label = _format_node(node, parent=None, context=context, tree=tree, mode=mode)
         rich_tree = Tree(root_label, guide_style="bold bright_blue")
         _add_metadata_leaves(node, rich_tree, context)
-        _build_tree(tree, node, rich_tree, max_depth=max_depth, depth=0, cur_chain=[], context=context)
+        _build_tree(tree, node, rich_tree, max_depth=max_depth, depth=0, cur_chain=[], context=context, mode=mode)
         console.print(rich_tree)
 
 
@@ -61,18 +64,9 @@ def _build_tree(  # noqa: PLR0913
     depth: int,
     cur_chain: list[str],
     context: RenderContext | None,
+    mode: RenderMode = "default",
 ) -> None:
-    """
-    Recursively build the rich tree structure.
-
-    :param tree: the package tree
-    :param node: current node
-    :param rich_tree: the rich Tree object to add children to
-    :param max_depth: maximum depth
-    :param depth: current depth
-    :param cur_chain: chain of package names to detect cycles
-    :param context: metadata and computed fields to display
-    """
+    """Recursively build the rich tree structure."""
     if depth >= max_depth:
         return
 
@@ -81,7 +75,7 @@ def _build_tree(  # noqa: PLR0913
         if child.project_name in cur_chain:
             continue
 
-        child_label = _format_node(child, parent=node, context=context, tree=tree)
+        child_label = _format_node(child, parent=node, context=context, tree=tree, mode=mode)
         child_tree = rich_tree.add(child_label)
         _add_metadata_leaves(child, child_tree, context)
 
@@ -93,6 +87,7 @@ def _build_tree(  # noqa: PLR0913
             depth=depth + 1,
             cur_chain=[*cur_chain, child.project_name],
             context=context,
+            mode=mode,
         )
 
 
@@ -102,17 +97,10 @@ def _format_node(
     *,
     context: RenderContext | None,
     tree: PackageDAG,
+    mode: RenderMode = "default",
 ) -> str:
-    """
-    Format a node for display with rich styling.
-
-    :param node: the node to format
-    :param parent: the parent node (if any)
-    :param context: metadata and computed fields to display
-    :param tree: the package tree (needed for computed fields)
-    :return: formatted string with rich markup
-    """
-    node_str = node.render(parent, frozen=False)
+    """Format a node for display with rich styling."""
+    node_str = node.render(parent, frozen=False, mode=mode)
 
     rich_exclude = frozenset({"unique-deps-names"})
 
@@ -133,7 +121,7 @@ def _format_node(
         and any(f.startswith("unique-deps") for f in context.computed)
         and node.key in ComputedValues(parent.key, tree, context.full_tree if context else None).unique_deps
     )
-    return _format_branch_node(node_str, node, suffix, is_unique=is_unique)
+    return _format_branch_node(node_str, node, suffix, is_unique=is_unique, mode=mode)
 
 
 def _add_metadata_leaves(
@@ -164,10 +152,25 @@ def _format_root_node(node_str: str, suffix: str = "") -> str:
 
 
 def _format_branch_node(
-    node_str: str, node: DistPackage | ReqPackage, suffix: str = "", *, is_unique: bool = False
+    node_str: str,
+    node: DistPackage | ReqPackage,
+    suffix: str = "",
+    *,
+    is_unique: bool = False,
+    mode: RenderMode = "default",
 ) -> str:
     """Format a branch node (dependency)."""
     suffix_str = f" [dim blue]{suffix.strip()}[/dim blue]" if suffix else ""
+    if mode == "resolved" and isinstance(node, ReqPackage):
+        match = re.match(r"^(.+?)\s+\[candidate:\s*(.+?)(?:,\s+extra:\s*(.+?))?\]$", node_str)
+        assert match, f"Unexpected candidate branch node format: {node_str}"
+        name, version, extra = match.groups()
+        status_icon = _get_status_icon(node, is_unique=is_unique)
+        extra_str = f" [magenta]\\[extra: {extra}][/magenta]" if extra else ""
+        return (
+            f"{status_icon}[bold cyan]{name}[/bold cyan] "
+            f"[dim]candidate:[/dim] {_format_version(version, node)}{extra_str}{suffix_str}"
+        )
     if isinstance(node, ReqPackage) and (
         match := re.match(
             r"""

--- a/src/pipdeptree/_render/text.py
+++ b/src/pipdeptree/_render/text.py
@@ -8,15 +8,17 @@ from pipdeptree._computed import ComputedValues
 if TYPE_CHECKING:
     from pipdeptree._cli import RenderContext
     from pipdeptree._models import DistPackage, PackageDAG, ReqPackage
+    from pipdeptree._models.package import RenderMode
 
 
-def render_text(
+def render_text(  # noqa: PLR0913
     tree: PackageDAG,
     *,
     max_depth: float,
     encoding: str,
     list_all: bool = True,
     context: RenderContext | None = None,
+    mode: RenderMode = "default",
 ) -> None:
     """
     Print tree as text on console.
@@ -26,15 +28,16 @@ def render_text(
     :param encoding: encoding to use (use "utf-8", "utf-16", "utf-32" for unicode or anything else for legacy output)
     :param list_all: whether to list all the pkgs at the root level or only those that are the sub-dependencies
     :param context: metadata and computed fields to display
+    :param mode: "resolved" renders edges as "[candidate: <version>]" for resolved trees
     :returns: None
 
     """
     nodes = get_top_level_nodes(tree, list_all=list_all)
 
     if encoding in {"utf-8", "utf-16", "utf-32"}:
-        _render_text_with_unicode(tree, nodes, max_depth, context)
+        _render_text_with_unicode(tree, nodes, max_depth, context, mode=mode)
     else:
-        _render_text_simple(tree, nodes, max_depth, context=context)
+        _render_text_simple(tree, nodes, max_depth, context=context, mode=mode)
 
 
 def get_top_level_nodes(tree: PackageDAG, *, list_all: bool) -> list[DistPackage]:
@@ -59,6 +62,8 @@ def _render_text_with_unicode(
     nodes: list[DistPackage],
     max_depth: float,
     context: RenderContext | None,
+    *,
+    mode: RenderMode = "default",
 ) -> None:
     def aux(  # noqa: PLR0913, PLR0917
         node: DistPackage | ReqPackage,
@@ -72,7 +77,7 @@ def _render_text_with_unicode(
         parent_is_last_child: bool = False,  # noqa: FBT001, FBT002
     ) -> list[Any]:
         cur_chain = cur_chain or []
-        node_str = node.render(parent, frozen=False)
+        node_str = node.render(parent, frozen=False, mode=mode)
         if context and context.active:
             node_str += _build_suffix(node, context, tree)
         next_prefix = ""
@@ -128,6 +133,7 @@ def _render_text_simple(  # noqa: PLR0913
     context: RenderContext | None = None,
     frozen: bool = False,
     bullet: str = "- ",
+    mode: RenderMode = "default",
 ) -> None:
     def aux(
         node: DistPackage | ReqPackage,
@@ -137,7 +143,7 @@ def _render_text_simple(  # noqa: PLR0913
         depth: int = 0,
     ) -> list[Any]:
         cur_chain = cur_chain or []
-        node_str = node.render(parent, frozen=frozen)
+        node_str = node.render(parent, frozen=frozen, mode=mode)
         if context and context.active:
             node_str += _build_suffix(node, context, tree)
         if parent:

--- a/tests/_models/test_package.py
+++ b/tests/_models/test_package.py
@@ -188,6 +188,30 @@ def test_req_package_render_as_branch() -> None:
     assert rp.render_as_branch(frozen=False) == "bar [required: >=4.0, installed: 4.1.0]"
 
 
+def test_req_package_render_as_branch_candidate() -> None:
+    bar = Mock(metadata={"Name": "bar"}, version="4.1.0")
+    bar_req = MagicMock(specifier=[">=4.0"])
+    bar_req.name = "bar"
+    rp = ReqPackage(bar_req, dist=bar)
+    assert rp.render_as_branch(frozen=False, mode="resolved") == "bar [candidate: 4.1.0]"
+
+
+def test_req_package_render_as_branch_candidate_with_extra() -> None:
+    bar = Mock(metadata={"Name": "bar"}, version="4.1.0")
+    bar_req = MagicMock(specifier=[">=4.0"])
+    bar_req.name = "bar"
+    rp = ReqPackage(bar_req, dist=bar, extra="dev")
+    assert rp.render_as_branch(frozen=False, mode="resolved") == "bar [candidate: 4.1.0, extra: dev]"
+
+
+def test_req_package_render_as_branch_default_unchanged() -> None:
+    bar = Mock(metadata={"Name": "bar"}, version="4.1.0")
+    bar_req = MagicMock(specifier=[">=4.0"])
+    bar_req.name = "bar"
+    rp = ReqPackage(bar_req, dist=bar)
+    assert rp.render_as_branch(frozen=False, mode="default") == "bar [required: >=4.0, installed: 4.1.0]"
+
+
 def test_req_package_is_conflicting_handle_dev_versions() -> None:
     # ensure that we can handle development versions when detecting conflicts
     # see https://github.com/tox-dev/pipdeptree/issues/393
@@ -278,6 +302,36 @@ def test_req_package_as_dict_with_no_version_spec() -> None:
     rp = ReqPackage(bar_req, dist=bar)
     result = rp.as_dict()
     expected = {"key": "bar", "package_name": "bar", "installed_version": "4.1.0", "required_version": "Any"}
+    assert expected == result
+
+
+def test_req_package_as_dict_candidate() -> None:
+    bar = Mock(metadata={"Name": "bar"}, version="4.1.0")
+    bar_req = MagicMock(specifier=[">=4.0"])
+    bar_req.name = "bar"
+    rp = ReqPackage(bar_req, dist=bar)
+    result = rp.as_dict(mode="resolved")
+    expected = {"key": "bar", "package_name": "bar", "candidate_version": "4.1.0"}
+    assert expected == result
+    assert "required_version" not in result
+    assert "installed_version" not in result
+
+
+def test_req_package_as_dict_default_unchanged() -> None:
+    bar = Mock(metadata={"Name": "bar"}, version="4.1.0")
+    bar_req = MagicMock(specifier=[">=4.0"])
+    bar_req.name = "bar"
+    rp = ReqPackage(bar_req, dist=bar)
+    result = rp.as_dict(mode="default")
+    expected = {"key": "bar", "package_name": "bar", "installed_version": "4.1.0", "required_version": ">=4.0"}
+    assert expected == result
+
+
+def test_dist_package_as_dict_candidate() -> None:
+    foo = Mock(metadata={"Name": "foo"}, version="1.3.2b1")
+    dp = DistPackage(foo)
+    result = dp.as_dict(mode="resolved")
+    expected = {"key": "foo", "package_name": "foo", "candidate_version": "1.3.2b1"}
     assert expected == result
 
 

--- a/tests/render/test_candidate.py
+++ b/tests/render/test_candidate.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from pipdeptree._cli import Options, RenderContext
+from pipdeptree._render import render
+
+if TYPE_CHECKING:
+    from pipdeptree._models import PackageDAG
+
+
+def _options(*, command: str | None, output_format: str) -> Options:
+    options = Options()
+    options.command = command
+    options.output_format = output_format
+    options.context = RenderContext()
+    options.depth = float("inf")
+    options.encoding = "utf-8"
+    options.all = True
+    options.reverse = False
+    return options
+
+
+@pytest.mark.parametrize(
+    "command", [pytest.param("from-index", id="from-index"), pytest.param("from-lock", id="from-lock")]
+)
+def test_render_text_candidate(command: str, example_dag: PackageDAG, capsys: pytest.CaptureFixture[str]) -> None:
+    render(_options(command=command, output_format="text"), example_dag)
+    out = capsys.readouterr().out
+    assert "[candidate: 2.3.1]" in out
+    assert "required:" not in out
+    assert "installed:" not in out
+
+
+def test_render_text_default_unchanged(example_dag: PackageDAG, capsys: pytest.CaptureFixture[str]) -> None:
+    render(_options(command=None, output_format="text"), example_dag)
+    out = capsys.readouterr().out
+    assert "[required: >=2.0.0, installed: 2.3.1]" in out
+    assert "candidate:" not in out
+
+
+def test_render_json_candidate(example_dag: PackageDAG, capsys: pytest.CaptureFixture[str]) -> None:
+    render(_options(command="from-index", output_format="json"), example_dag)
+    data = json.loads(capsys.readouterr().out)
+    dep = next(d for entry in data for d in entry["dependencies"])
+    assert "candidate_version" in dep
+    assert "required_version" not in dep
+    assert "installed_version" not in dep
+
+
+def test_render_json_default_unchanged(example_dag: PackageDAG, capsys: pytest.CaptureFixture[str]) -> None:
+    render(_options(command=None, output_format="json"), example_dag)
+    data = json.loads(capsys.readouterr().out)
+    dep = next(d for entry in data for d in entry["dependencies"])
+    assert "required_version" in dep
+    assert "installed_version" in dep
+    assert "candidate_version" not in dep
+
+
+def test_render_json_tree_candidate(example_dag: PackageDAG, capsys: pytest.CaptureFixture[str]) -> None:
+    render(_options(command="from-index", output_format="json-tree"), example_dag)
+    data = json.loads(capsys.readouterr().out)
+    dep = next(d for entry in data for d in entry["dependencies"])
+    assert "candidate_version" in dep
+    assert "required_version" not in dep
+    assert "installed_version" not in dep
+
+
+def test_render_rich_candidate(example_dag: PackageDAG, capsys: pytest.CaptureFixture[str]) -> None:
+    render(_options(command="from-index", output_format="rich"), example_dag)
+    out = capsys.readouterr().out
+    assert "candidate:" in out
+    assert "required:" not in out
+    assert "installed:" not in out

--- a/tests/render/test_render.py
+++ b/tests/render/test_render.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 def test_json_routing(option: list[str], mocker: MockerFixture) -> None:
     render = mocker.patch("pipdeptree._render.render_json")
     main(option)
-    render.assert_called_once_with(ANY, context=RenderContext())
+    render.assert_called_once_with(ANY, context=RenderContext(), mode="default")
 
 
 @pytest.mark.parametrize(
@@ -29,7 +29,7 @@ def test_json_routing(option: list[str], mocker: MockerFixture) -> None:
 def test_json_tree_routing(option: list[str], mocker: MockerFixture) -> None:
     render = mocker.patch("pipdeptree._render.render_json_tree")
     main(option)
-    render.assert_called_once_with(ANY, context=RenderContext())
+    render.assert_called_once_with(ANY, context=RenderContext(), mode="default")
 
 
 @pytest.mark.parametrize(
@@ -59,7 +59,9 @@ def test_grahpviz_routing(option: list[str], mocker: MockerFixture) -> None:
 def test_text_routing(option: list[str], mocker: MockerFixture) -> None:
     render = mocker.patch("pipdeptree._render.render_text")
     main(option)
-    render.assert_called_once_with(ANY, encoding="utf-8", max_depth=inf, list_all=False, context=RenderContext())
+    render.assert_called_once_with(
+        ANY, encoding="utf-8", max_depth=inf, list_all=False, context=RenderContext(), mode="default"
+    )
 
 
 @pytest.mark.parametrize(
@@ -76,4 +78,4 @@ def test_freeze_routing(option: list[str], mocker: MockerFixture) -> None:
 def test_rich_routing(option: list[str], mocker: MockerFixture) -> None:
     render = mocker.patch("pipdeptree._render.render_rich_text")
     main(option)
-    render.assert_called_once_with(ANY, max_depth=inf, list_all=False, context=RenderContext())
+    render.assert_called_once_with(ANY, max_depth=inf, list_all=False, context=RenderContext(), mode="default")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -115,6 +115,88 @@ def test_get_options_path_with_either_local_or_user_not_supported(
     assert "cannot use --path with --user-only or --local-only" in err
 
 
+def test_get_options_default_has_no_subcommand() -> None:
+    options = get_options([])
+    assert options.command is None
+    assert options.requirement == []
+    assert options.requirements is None
+    assert options.pyproject is None
+
+
+def test_get_options_default_top_level_flag_still_works() -> None:
+    options = get_options(["-o", "json"])
+    assert options.command is None
+    assert options.output_format == "json"
+
+
+@pytest.mark.parametrize(
+    "requirements",
+    [
+        pytest.param(["fastapi<=0.115.2"], id="single"),
+        pytest.param(["fastapi", "starlette"], id="multiple"),
+    ],
+)
+def test_get_options_from_index_requirements(requirements: list[str]) -> None:
+    options = get_options(["from-index", *requirements])
+    assert options.command == "from-index"
+    assert options.requirement == requirements
+
+
+def test_get_options_from_index_accumulates_file_flags() -> None:
+    options = get_options(["from-index", "--requirements", "r.txt", "--pyproject", "p.toml"])
+    assert options.command == "from-index"
+    assert options.requirement == []
+    assert options.requirements == ["r.txt"]
+    assert options.pyproject == ["p.toml"]
+
+
+def test_get_options_from_index_requires_a_source(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit, match="2"):
+        get_options(["from-index"])
+    out, err = capsys.readouterr()
+    assert not out
+    assert "from-index needs at least one REQUIREMENT, --requirements FILE, or --pyproject FILE" in err
+
+
+def test_get_options_from_index_shares_render_flags() -> None:
+    options = get_options(["from-index", "fastapi", "-o", "json"])
+    assert options.command == "from-index"
+    assert options.requirement == ["fastapi"]
+    assert options.output_format == "json"
+
+
+def test_get_options_from_index_keeps_extras() -> None:
+    options = get_options(["from-index", "fastapi", "-x", "active"])
+    assert options.command == "from-index"
+    assert options.extras == "active"
+
+
+def test_get_options_from_index_defaults_installed_metadata_options() -> None:
+    options = get_options(["from-index", "fastapi"])
+    assert options.license is False
+    assert options.metadata == []
+    assert options.computed == []
+    assert options.context.active is False
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        pytest.param(["--license"], id="license"),
+        pytest.param(["--metadata", "license"], id="metadata"),
+        pytest.param(["--computed", "size"], id="computed"),
+    ],
+)
+def test_get_options_from_index_rejects_installed_metadata_options(
+    args: list[str], capsys: pytest.CaptureFixture[str]
+) -> None:
+    with pytest.raises(SystemExit, match="2"):
+        get_options(["from-index", "fastapi", *args])
+    out, err = capsys.readouterr()
+    assert not out
+    assert "unrecognized arguments" in err
+
+
 def test_get_options_exclude_dependencies_without_exclude(capsys: pytest.CaptureFixture[str]) -> None:
     with pytest.raises(SystemExit, match="2"):
         get_options(["--exclude-dependencies"])

--- a/tests/test_from_index.py
+++ b/tests/test_from_index.py
@@ -1,0 +1,813 @@
+from __future__ import annotations
+
+import dataclasses
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+import pytest
+
+from pipdeptree.__main__ import main
+from pipdeptree._cli import get_options
+from pipdeptree._from_index import (
+    FromIndexInputError,
+    FromIndexUnavailableError,
+    _FromIndexDistribution,
+    _LocalSource,
+    _parse_requirements_file,
+    _ParsedInputs,
+    _read_pyproject_name,
+    _render_pyproject,
+    _resolve_indexes,
+    _resolve_pyproject_path,
+    _VcsSource,
+    resolve_from_index,
+)
+from pipdeptree._models import PackageDAG
+
+_PYPI_NAME = "pypi"
+_PYPI_URL = "https://pypi.org/simple"
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from importlib.metadata import Distribution
+
+    from pytest_mock import MockerFixture
+
+
+@pytest.fixture
+def fake_result() -> SimpleNamespace:
+    return SimpleNamespace(
+        pins={"fastapi": "0.115.2", "starlette": "0.41.3", "anyio": "4.6.2"},
+        lock_input=SimpleNamespace(dependencies={"fastapi": ("starlette",), "starlette": ("anyio",), "anyio": ()}),
+    )
+
+
+@pytest.fixture
+def captured_pyproject(mocker: MockerFixture, fake_result: SimpleNamespace) -> dict[str, str]:
+    """Capture the pyproject content nab is asked to resolve, bypassing the real (absent) resolver."""
+    captured: dict[str, str] = {}
+
+    def fake_resolve(path: Path, indexes: object) -> SimpleNamespace:  # noqa: ARG001
+        captured["content"] = path.read_text(encoding="utf-8")
+        return fake_result
+
+    mocker.patch("pipdeptree._from_index._resolve_pyproject_path", side_effect=fake_resolve)
+    return captured
+
+
+@pytest.fixture
+def fake_nab(mocker: MockerFixture, fake_result: SimpleNamespace) -> SimpleNamespace:
+    """Stub the optional nab modules in ``sys.modules`` so ``_resolve_pyproject_path`` runs without nab installed."""
+    # The path may live in a TemporaryDirectory that is gone after resolve returns, so read its content eagerly.
+    captured = SimpleNamespace(paths=[], contents=[])
+
+    def fake_resolve_pyproject(path: Path, transport: object, *, config: object) -> SimpleNamespace:  # noqa: ARG001
+        captured.paths.append(path)
+        captured.contents.append(path.read_text(encoding="utf-8"))
+        return fake_result
+
+    nab_resolve = mocker.MagicMock()
+    nab_resolve.resolve_pyproject = fake_resolve_pyproject
+    mocker.patch.dict(
+        "sys.modules",
+        {
+            "nab_index": mocker.MagicMock(),
+            "nab_index.multi_index": mocker.MagicMock(),
+            "nab_index.urllib3_async_transport": mocker.MagicMock(),
+            "nab_python": mocker.MagicMock(),
+            "nab_python.config": mocker.MagicMock(),
+            "nab_python.resolve": nab_resolve,
+        },
+    )
+    return captured
+
+
+@pytest.fixture
+def write_pyproject(tmp_path: Path) -> Callable[[], Path]:
+    def func() -> Path:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text('[project]\nname = "x"\nversion = "0"\ndependencies = ["fastapi"]\n', encoding="utf-8")
+        return pyproject
+
+    return func
+
+
+def _resolve(
+    requirements: list[str] | None = None,
+    requirement_files: list[str] | None = None,
+    pyproject_files: list[str] | None = None,
+) -> list[Distribution]:
+    return resolve_from_index(
+        requirements=requirements or [],
+        requirement_files=requirement_files or [],
+        pyproject_files=pyproject_files or [],
+    )
+
+
+def test_resolve_from_index_builds_tree(mocker: MockerFixture, fake_result: SimpleNamespace) -> None:
+    mocker.patch("pipdeptree._from_index._resolve_pyproject_path", return_value=fake_result)
+
+    dag = PackageDAG.from_pkgs(_resolve(["fastapi<=0.115.2"]))
+
+    by_key = {str(pkg.key): pkg for pkg in dag}
+    assert set(by_key) == {"fastapi", "starlette", "anyio"}
+    assert by_key["fastapi"].version == "0.115.2"
+    assert [child.key for child in dag.get_children("fastapi")] == ["starlette"]
+    assert [child.key for child in dag.get_children("starlette")] == ["anyio"]
+    assert dag.get_children("anyio") == []
+
+
+def test_resolve_from_index_pins_children_versions(mocker: MockerFixture, fake_result: SimpleNamespace) -> None:
+    mocker.patch("pipdeptree._from_index._resolve_pyproject_path", return_value=fake_result)
+
+    dag = PackageDAG.from_pkgs(_resolve(["fastapi"]))
+
+    (starlette,) = dag.get_children("fastapi")
+    assert starlette.version_spec == "==0.41.3"
+
+
+@pytest.mark.parametrize(
+    ("requirements", "expected"),
+    [
+        pytest.param(['foo>=1,<2; python_version >= "3.10"'], 'foo>=1,<2; python_version >= \\"3.10\\"', id="inline"),
+        pytest.param(["fastapi", "starlette"], '"starlette",', id="multiple-inline"),
+    ],
+)
+def test_resolve_from_index_writes_requirement(
+    captured_pyproject: dict[str, str], requirements: list[str], expected: str
+) -> None:
+    _resolve(requirements)
+
+    assert expected in captured_pyproject["content"]
+
+
+def test_resolve_from_index_requirements_file_parsed(captured_pyproject: dict[str, str], tmp_path: Path) -> None:
+    req = tmp_path / "requirements.txt"
+    req.write_text("fastapi\nstarlette\n", encoding="utf-8")
+
+    _resolve(requirement_files=[str(req)])
+
+    content = captured_pyproject["content"]
+    assert '"fastapi",' in content
+    assert '"starlette",' in content
+
+
+def test_resolve_from_index_mixed_sources_merged(
+    captured_pyproject: dict[str, str], write_pyproject: Callable[[], Path], tmp_path: Path
+) -> None:
+    pyproject = write_pyproject()
+    req = tmp_path / "requirements.txt"
+    req.write_text("starlette\n", encoding="utf-8")
+
+    _resolve(["anyio"], requirement_files=[str(req)], pyproject_files=[str(pyproject)])
+
+    content = captured_pyproject["content"]
+    assert '"fastapi",' in content
+    assert '"starlette",' in content
+    assert '"anyio",' in content
+
+
+def test_resolve_from_index_missing_nab_raises(mocker: MockerFixture) -> None:
+    # Setting the modules to None makes the guarded import raise, simulating nab not being installed.
+    mocker.patch.dict("sys.modules", dict.fromkeys(("nab_index", "nab_python.resolve")))
+    with pytest.raises(FromIndexUnavailableError, match="pip install pipdeptree\\[index\\]"):
+        _resolve(["starlette"])
+
+
+@pytest.mark.parametrize(
+    "kind",
+    [
+        pytest.param("requirement_files", id="requirements-flag"),
+        pytest.param("pyproject_files", id="pyproject-flag"),
+    ],
+)
+def test_resolve_from_index_missing_file(tmp_path: Path, kind: str) -> None:
+    with pytest.raises(FromIndexInputError, match="source file does not exist"):
+        _resolve(**{kind: [str(tmp_path / "absent")]})
+
+
+def test_resolve_from_index_lone_pyproject_resolved_natively(
+    mocker: MockerFixture, fake_result: SimpleNamespace, write_pyproject: Callable[[], Path]
+) -> None:
+    pyproject = write_pyproject()
+    resolve = mocker.patch("pipdeptree._from_index._resolve_pyproject_path", return_value=fake_result)
+
+    _resolve(pyproject_files=[str(pyproject)])
+
+    resolve.assert_called_once_with(pyproject, None)
+
+
+def test_resolve_from_index_writes_temp_pyproject_and_calls_nab(fake_nab: SimpleNamespace) -> None:
+    result = _resolve(["fastapi<=0.115.2"])
+
+    assert result[0].metadata["Name"] == "fastapi"
+    (content,) = fake_nab.contents
+    assert 'name = "pipdeptree-from-index"' in content
+    assert '"fastapi<=0.115.2",' in content
+
+
+def test_resolve_pyproject_path_passes_path_natively(
+    fake_nab: SimpleNamespace, write_pyproject: Callable[[], Path]
+) -> None:
+    pyproject = write_pyproject()
+
+    _resolve_pyproject_path(pyproject, None)
+
+    assert fake_nab.paths == [pyproject]
+
+
+def test_render_pyproject_quotes_special_chars() -> None:
+    rendered = _render_pyproject(_ParsedInputs(requirements=['foo>=1; extra == "bar"']))
+    assert 'dependencies = [\n  "foo>=1; extra == \\"bar\\"",\n]' in rendered
+
+
+def test_from_index_distribution_file_helpers() -> None:
+    dist = _FromIndexDistribution("foo", "1.0", ("bar==2.0",))
+    assert dist.read_text("METADATA") is None
+    assert dist.locate_file("METADATA") == Path("METADATA")
+
+
+@pytest.mark.parametrize(
+    ("body", "expected_reqs"),
+    [
+        pytest.param(
+            "# a full-line comment\n\nfastapi  # inline comment\nanyio>=4\n",
+            ["fastapi", "anyio>=4"],
+            id="comments-and-blank-lines",
+        ),
+        pytest.param(
+            "--index-url https://example.com\nfoo --hash=sha256:abcd\nbar\n",
+            ["foo", "bar"],
+            id="options-ignored",
+        ),
+        pytest.param(
+            'fastapi[all]>=0.100; python_version >= "3.10"\n',
+            ['fastapi[all]>=0.100; python_version >= "3.10"'],
+            id="markers-and-extras-kept",
+        ),
+    ],
+)
+def test_parse_requirements_file(tmp_path: Path, body: str, expected_reqs: list[str]) -> None:
+    req = tmp_path / "requirements.txt"
+    req.write_text(body, encoding="utf-8")
+
+    inputs = _ParsedInputs()
+    _parse_requirements_file(req, inputs)
+
+    assert inputs.requirements == expected_reqs
+    assert inputs.constraints == []
+
+
+def test_parse_requirements_file_follows_nested(tmp_path: Path) -> None:
+    (tmp_path / "base.txt").write_text("anyio>=4\n", encoding="utf-8")
+    req = tmp_path / "requirements.txt"
+    req.write_text("-r base.txt\nfastapi\n", encoding="utf-8")
+
+    inputs = _ParsedInputs()
+    _parse_requirements_file(req, inputs)
+
+    assert inputs.requirements == ["anyio>=4", "fastapi"]
+    assert inputs.constraints == []
+
+
+def test_parse_requirements_file_collects_constraints(tmp_path: Path) -> None:
+    (tmp_path / "constraints.txt").write_text("urllib3<2\ncertifi\n", encoding="utf-8")
+    req = tmp_path / "requirements.txt"
+    req.write_text("-c constraints.txt\nrequests\n", encoding="utf-8")
+
+    inputs = _ParsedInputs()
+    _parse_requirements_file(req, inputs)
+
+    assert inputs.requirements == ["requests"]
+    assert inputs.constraints == ["urllib3<2", "certifi"]
+
+
+@pytest.mark.parametrize(
+    ("line", "match"),
+    [
+        pytest.param(
+            "foo @ https://example.com/foo-1.0-py3-none-any.whl", r"URL requirements are not supported", id="wheel-url"
+        ),
+        pytest.param("foo @ hg+https://example.com/r", r"only git VCS requirements", id="hg-vcs"),
+        pytest.param("foo @ git+https://example.com/foo.git", r"must be pinned to a full commit sha", id="vcs-no-sha"),
+        pytest.param("-e .", r"must be a directory with a pyproject.toml", id="editable-no-pyproject"),
+    ],
+)
+def test_parse_requirements_file_rejects_unmappable(tmp_path: Path, line: str, match: str) -> None:
+    req = tmp_path / "requirements.txt"
+    req.write_text(f"fastapi\n{line}\n", encoding="utf-8")
+
+    with pytest.raises(FromIndexInputError, match=match):
+        _parse_requirements_file(req, _ParsedInputs())
+
+
+def test_parse_requirements_file_rejects_constraint_extras(tmp_path: Path) -> None:
+    (tmp_path / "constraints.txt").write_text("fastapi[all]<1\n", encoding="utf-8")
+    req = tmp_path / "requirements.txt"
+    req.write_text("-c constraints.txt\nrequests\n", encoding="utf-8")
+
+    with pytest.raises(FromIndexInputError, match=r"cannot constrain extras"):
+        _parse_requirements_file(req, _ParsedInputs())
+
+
+def test_resolve_from_index_constraints_reach_nab(captured_pyproject: dict[str, str], tmp_path: Path) -> None:
+    (tmp_path / "constraints.txt").write_text("urllib3<2\n", encoding="utf-8")
+    req = tmp_path / "requirements.txt"
+    req.write_text("-c constraints.txt\nrequests\n", encoding="utf-8")
+
+    _resolve(requirement_files=[str(req)])
+
+    content = captured_pyproject["content"]
+    assert '"requests",' in content
+    assert '[tool.nab]\nconstraints = [\n  "urllib3<2",\n]' in content
+
+
+def test_render_pyproject_omits_tool_nab_without_constraints() -> None:
+    assert "[tool.nab]" not in _render_pyproject(_ParsedInputs(requirements=["fastapi"]))
+
+
+@pytest.fixture
+def read_name(mocker: MockerFixture) -> None:
+    """Stand in for nab's read_pyproject_name (absent here); a minimal name read avoids a tomllib dep on 3.10."""
+
+    def fake_read(directory: Path) -> str | None:
+        for line in (directory / "pyproject.toml").read_text(encoding="utf-8").splitlines():
+            if line.startswith("name = "):
+                return line.removeprefix("name = ").strip().strip('"')
+        return None
+
+    mocker.patch("pipdeptree._from_index._read_pyproject_name", side_effect=fake_read)
+
+
+@pytest.fixture
+def local_pkg(tmp_path: Path) -> Path:
+    pkg = tmp_path / "localpkg"
+    pkg.mkdir()
+    (pkg / "pyproject.toml").write_text(
+        '[project]\nname = "localpkg"\nversion = "1.0"\ndependencies = ["anyio"]\n', encoding="utf-8"
+    )
+    return pkg
+
+
+def test_translate_editable_local_source(
+    captured_pyproject: dict[str, str],
+    read_name: None,  # noqa: ARG001
+    local_pkg: Path,
+    tmp_path: Path,
+) -> None:
+    req = tmp_path / "requirements.txt"
+    req.write_text("-e ./localpkg\n", encoding="utf-8")
+
+    _resolve(requirement_files=[str(req)])
+
+    content = captured_pyproject["content"]
+    assert '"localpkg",' in content
+    assert f'[[tool.nab.local-sources]]\nname = "localpkg"\npath = "{local_pkg}"\neditable = true\n' in content
+    assert 'build-policy = "build-remote"' in content
+
+
+def test_translate_file_url_local_source_not_editable(
+    captured_pyproject: dict[str, str],
+    read_name: None,  # noqa: ARG001
+    local_pkg: Path,
+    tmp_path: Path,
+) -> None:
+    req = tmp_path / "requirements.txt"
+    req.write_text(f"localpkg @ file://{local_pkg}\n", encoding="utf-8")
+
+    _resolve(requirement_files=[str(req)])
+
+    content = captured_pyproject["content"]
+    assert f'[[tool.nab.local-sources]]\nname = "localpkg"\npath = "{local_pkg}"\neditable = false\n' in content
+
+
+def test_translate_local_source_without_project_name(
+    read_name: None,  # noqa: ARG001
+    tmp_path: Path,
+) -> None:
+    pkg = tmp_path / "nameless"
+    pkg.mkdir()
+    (pkg / "pyproject.toml").write_text("[build-system]\nrequires = []\n", encoding="utf-8")
+    req = tmp_path / "requirements.txt"
+    req.write_text("-e ./nameless\n", encoding="utf-8")
+
+    with pytest.raises(FromIndexInputError, match=r"has no \[project\].name"):
+        _resolve(requirement_files=[str(req)])
+
+
+def test_translate_git_vcs_source(captured_pyproject: dict[str, str], tmp_path: Path) -> None:
+    sha = "1234567890abcdef1234567890abcdef12345678"
+    req = tmp_path / "requirements.txt"
+    req.write_text(f"pkg @ git+https://h/r.git@{sha}\n", encoding="utf-8")
+
+    _resolve(requirement_files=[str(req)])
+
+    content = captured_pyproject["content"]
+    assert '"pkg",' in content
+    assert '[tool.nab.vcs]\npolicy = "allow"\nallowed-schemes = ["git+https", "git+ssh"' in content
+    assert f'[[tool.nab.vcs-sources]]\nname = "pkg"\nurl = "git+https://h/r.git@{sha}"\n' in content
+    assert 'build-policy = "build-remote"' in content
+
+
+def test_translate_git_vcs_without_pin(tmp_path: Path) -> None:
+    req = tmp_path / "requirements.txt"
+    req.write_text("pkg @ git+https://h/r.git@v1.0\n", encoding="utf-8")
+
+    with pytest.raises(FromIndexInputError, match="must be pinned to a full commit sha"):
+        _resolve(requirement_files=[str(req)])
+
+
+def test_translate_mixed_sources(
+    captured_pyproject: dict[str, str],
+    read_name: None,  # noqa: ARG001
+    local_pkg: Path,  # noqa: ARG001
+    tmp_path: Path,
+) -> None:
+    sha = "1234567890abcdef1234567890abcdef12345678"
+    req = tmp_path / "requirements.txt"
+    req.write_text(f"fastapi\n-e ./localpkg\npkg @ git+https://h/r.git@{sha}\n", encoding="utf-8")
+
+    _resolve(requirement_files=[str(req)])
+
+    content = captured_pyproject["content"]
+    for dep in ('"fastapi",', '"localpkg",', '"pkg",'):
+        assert dep in content
+    assert "[[tool.nab.local-sources]]" in content
+    assert "[[tool.nab.vcs-sources]]" in content
+
+
+def test_translate_inline_git_vcs(captured_pyproject: dict[str, str]) -> None:
+    sha = "1234567890abcdef1234567890abcdef12345678"
+
+    _resolve([f"pkg @ git+https://h/r.git@{sha}"])
+
+    content = captured_pyproject["content"]
+    assert '"pkg",' in content
+    assert f'url = "git+https://h/r.git@{sha}"' in content
+
+
+def test_translate_git_vcs_without_name(tmp_path: Path) -> None:
+    sha = "1234567890abcdef1234567890abcdef12345678"
+    req = tmp_path / "requirements.txt"
+    req.write_text(f"git+https://h/r.git@{sha}\n", encoding="utf-8")
+
+    with pytest.raises(FromIndexInputError, match="VCS requirement needs an explicit name"):
+        _resolve(requirement_files=[str(req)])
+
+
+def test_read_pyproject_name_delegates_to_nab(mocker: MockerFixture, local_pkg: Path) -> None:
+    requirements_file = mocker.MagicMock()
+    requirements_file.read_pyproject_name.return_value = "localpkg"
+    mocker.patch.dict("sys.modules", {"nab_python.requirements_file": requirements_file})
+
+    assert _read_pyproject_name(local_pkg) == "localpkg"
+    requirements_file.read_pyproject_name.assert_called_once_with(local_pkg / "pyproject.toml")
+
+
+def test_translate_local_source_missing_nab(local_pkg: Path, tmp_path: Path, mocker: MockerFixture) -> None:
+    # _read_pyproject_name imports from nab_python; with it absent, the local-source path reports unavailability.
+    mocker.patch.dict("sys.modules", {"nab_python.requirements_file": None})
+    req = tmp_path / "requirements.txt"
+    req.write_text("-e ./localpkg\n", encoding="utf-8")
+    assert local_pkg.exists()
+
+    with pytest.raises(FromIndexUnavailableError, match=r"pip install pipdeptree\[index\]"):
+        _resolve(requirement_files=[str(req)])
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="stdlib tomllib (and no tomli dep) only on 3.11+")
+def test_render_pyproject_round_trips_as_toml(local_pkg: Path) -> None:
+    import tomllib  # noqa: PLC0415
+
+    inputs = _ParsedInputs(
+        requirements=["fastapi", 'foo>=1; extra == "bar"'],
+        constraints=["urllib3<2"],
+        local_sources=[_LocalSource(name="localpkg", path=str(local_pkg), editable=True)],
+        vcs_sources=[_VcsSource(name="pkg", url="git+https://h/r.git@" + "0" * 40)],
+    )
+
+    data = tomllib.loads(_render_pyproject(inputs))
+
+    assert data["project"]["dependencies"] == ["fastapi", 'foo>=1; extra == "bar"', "localpkg", "pkg"]
+    assert data["tool"]["nab"]["constraints"] == ["urllib3<2"]
+    assert data["tool"]["nab"]["build-policy"] == "build-remote"
+    assert data["tool"]["nab"]["vcs"]["policy"] == "allow"
+    assert "git+https" in data["tool"]["nab"]["vcs"]["allowed-schemes"]
+    assert data["tool"]["nab"]["local-sources"] == [{"name": "localpkg", "path": str(local_pkg), "editable": True}]
+    assert data["tool"]["nab"]["vcs-sources"] == [{"name": "pkg", "url": "git+https://h/r.git@" + "0" * 40}]
+
+
+def test_render_pyproject_omits_build_policy_without_sources() -> None:
+    rendered = _render_pyproject(_ParsedInputs(requirements=["fastapi"], constraints=["urllib3<2"]))
+    assert "build-policy" not in rendered
+    assert "[tool.nab.vcs]" not in rendered
+
+
+def test_main_from_index_renders_text_tree(
+    mocker: MockerFixture, fake_result: SimpleNamespace, capsys: pytest.CaptureFixture[str]
+) -> None:
+    mocker.patch("pipdeptree.__main__.sys.argv", ["", "from-index", "fastapi"])
+    mocker.patch("pipdeptree._from_index._resolve_pyproject_path", return_value=fake_result)
+
+    assert main() == 0
+
+    out, _ = capsys.readouterr()
+    assert "fastapi==0.115.2" in out
+    assert "starlette" in out
+    assert "anyio" in out
+    assert "[candidate:" in out
+    assert "required:" not in out
+    assert "installed:" not in out
+
+
+def test_main_from_index_pyproject_renders_tree(
+    mocker: MockerFixture,
+    fake_result: SimpleNamespace,
+    write_pyproject: Callable[[], Path],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    pyproject = write_pyproject()
+    mocker.patch("pipdeptree.__main__.sys.argv", ["", "from-index", "--pyproject", str(pyproject)])
+    resolve = mocker.patch("pipdeptree._from_index._resolve_pyproject_path", return_value=fake_result)
+
+    assert main() == 0
+
+    resolve.assert_called_once_with(pyproject, None)
+    out, _ = capsys.readouterr()
+    assert "fastapi==0.115.2" in out
+
+
+def test_main_from_index_missing_nab(mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
+    mocker.patch("pipdeptree.__main__.sys.argv", ["", "from-index", "fastapi"])
+    mocker.patch(
+        "pipdeptree.__main__.resolve_from_index",
+        side_effect=FromIndexUnavailableError("The from-index subcommand requires the optional 'nab' resolver."),
+    )
+
+    assert main() == 1
+
+    out, err = capsys.readouterr()
+    assert not out
+    assert "The from-index subcommand requires the optional 'nab' resolver." in err
+
+
+def test_main_from_index_input_error(mocker: MockerFixture, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    mocker.patch("pipdeptree.__main__.sys.argv", ["", "from-index", "--requirements", str(tmp_path / "missing.txt")])
+
+    assert main() == 1
+
+    out, err = capsys.readouterr()
+    assert not out
+    assert "source file does not exist" in err
+
+
+@pytest.fixture
+def nab_index_defaults(mocker: MockerFixture) -> None:
+    """Stub nab_python.fetch so _resolve_indexes can read the PyPI default name/url without nab installed."""
+    fetch = mocker.MagicMock()
+    fetch.DEFAULT_INDEX_NAME = _PYPI_NAME
+    fetch.DEFAULT_INDEX_URL = _PYPI_URL
+    mocker.patch.dict("sys.modules", {"nab_python.fetch": fetch})
+
+
+@pytest.mark.parametrize(
+    ("index_url", "extra_index_url", "env", "expected"),
+    [
+        pytest.param(None, None, {}, None, id="nothing-set"),
+        pytest.param("https://a/simple", None, {}, [("primary", "https://a/simple")], id="index-url-only"),
+        pytest.param(_PYPI_URL, None, {}, [(_PYPI_NAME, _PYPI_URL)], id="index-url-is-pypi-named-pypi"),
+        pytest.param(
+            None,
+            ["https://x/simple", "https://y/simple"],
+            {},
+            [(_PYPI_NAME, _PYPI_URL), ("extra-1", "https://x/simple"), ("extra-2", "https://y/simple")],
+            id="extra-only-keeps-pypi-primary",
+        ),
+        pytest.param(
+            None, None, {"PIP_INDEX_URL": "https://pip/simple"}, [("primary", "https://pip/simple")], id="pip-env"
+        ),
+        pytest.param(
+            None, None, {"UV_INDEX_URL": "https://uv/simple"}, [("primary", "https://uv/simple")], id="uv-env"
+        ),
+        pytest.param(
+            None,
+            None,
+            {"PIP_INDEX_URL": "https://pip/simple", "UV_INDEX_URL": "https://uv/simple"},
+            [("primary", "https://pip/simple")],
+            id="pip-beats-uv",
+        ),
+        pytest.param(
+            "https://flag/simple",
+            None,
+            {"PIP_INDEX_URL": "https://pip/simple"},
+            [("primary", "https://flag/simple")],
+            id="flag-beats-env",
+        ),
+        pytest.param(
+            None,
+            None,
+            {"PIP_EXTRA_INDEX_URL": "https://x/simple https://y/simple"},
+            [(_PYPI_NAME, _PYPI_URL), ("extra-1", "https://x/simple"), ("extra-2", "https://y/simple")],
+            id="pip-extra-space-split",
+        ),
+        pytest.param(
+            None,
+            None,
+            {"UV_EXTRA_INDEX_URL": "https://x/simple"},
+            [(_PYPI_NAME, _PYPI_URL), ("extra-1", "https://x/simple")],
+            id="uv-extra-fallback",
+        ),
+        pytest.param(
+            None,
+            ["https://flag/simple"],
+            {"PIP_EXTRA_INDEX_URL": "https://env/simple"},
+            [(_PYPI_NAME, _PYPI_URL), ("extra-1", "https://flag/simple")],
+            id="flag-extra-beats-env-extra",
+        ),
+    ],
+)
+def test_resolve_indexes(
+    nab_index_defaults: None,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+    index_url: str | None,
+    extra_index_url: list[str] | None,
+    env: dict[str, str],
+    expected: list[tuple[str, str]] | None,
+) -> None:
+    for key in ("PIP_INDEX_URL", "UV_INDEX_URL", "PIP_EXTRA_INDEX_URL", "UV_EXTRA_INDEX_URL"):
+        monkeypatch.delenv(key, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+    resolved = _resolve_indexes(index_url, extra_index_url)
+
+    assert resolved == expected
+    if resolved is not None:
+        names = [name for name, _ in resolved]
+        assert len(names) == len(set(names))
+
+
+def test_render_pyproject_emits_indexes() -> None:
+    inputs = _ParsedInputs(
+        requirements=["fastapi"],
+        indexes=[("primary", "https://a/simple"), ("extra-1", "https://b/simple")],
+    )
+
+    rendered = _render_pyproject(inputs)
+
+    assert '[[tool.nab.indexes]]\nname = "primary"\nurl = "https://a/simple"\n' in rendered
+    assert '[[tool.nab.indexes]]\nname = "extra-1"\nurl = "https://b/simple"\n' in rendered
+    # Order: primary table precedes the extra table.
+    assert rendered.index('"primary"') < rendered.index('"extra-1"')
+
+
+def test_render_pyproject_omits_indexes_without_override() -> None:
+    assert "[[tool.nab.indexes]]" not in _render_pyproject(_ParsedInputs(requirements=["fastapi"]))
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="stdlib tomllib (and no tomli dep) only on 3.11+")
+def test_render_pyproject_indexes_round_trip_as_toml() -> None:
+    import tomllib  # noqa: PLC0415
+
+    inputs = _ParsedInputs(
+        requirements=["fastapi"],
+        indexes=[("primary", "https://a/simple"), ("extra-1", "https://b/simple")],
+    )
+
+    data = tomllib.loads(_render_pyproject(inputs))
+
+    assert data["tool"]["nab"]["indexes"] == [
+        {"name": "primary", "url": "https://a/simple"},
+        {"name": "extra-1", "url": "https://b/simple"},
+    ]
+
+
+def test_resolve_from_index_temp_path_emits_indexes(
+    nab_index_defaults: None,  # noqa: ARG001
+    captured_pyproject: dict[str, str],
+) -> None:
+    resolve_from_index(
+        requirements=["fastapi"],
+        requirement_files=[],
+        pyproject_files=[],
+        index_url="https://a/simple",
+    )
+
+    content = captured_pyproject["content"]
+    # An explicit --index-url replaces PyPI, so only the single named primary index is emitted.
+    assert '[[tool.nab.indexes]]\nname = "primary"\nurl = "https://a/simple"\n' in content
+
+
+@dataclasses.dataclass(frozen=True)
+class _FakeIndexConfig:
+    name: str
+    url: str
+
+
+@dataclasses.dataclass(frozen=True)
+class _FakeConfig:
+    indexes: tuple[_FakeIndexConfig, ...]
+
+
+def test_lone_pyproject_override_replaces_indexes(
+    nab_index_defaults: None,  # noqa: ARG001
+    mocker: MockerFixture,
+    fake_result: SimpleNamespace,
+    write_pyproject: Callable[[], Path],
+) -> None:
+    pyproject = write_pyproject()
+    original = _FakeConfig(indexes=(_FakeIndexConfig("pyproject-index", "https://own/simple"),))
+    captured: dict[str, object] = {}
+
+    def fake_resolve_pyproject(path: Path, transport: object, *, config: object) -> SimpleNamespace:  # noqa: ARG001
+        captured["config"] = config
+        return fake_result
+
+    nab_index_multi = mocker.MagicMock()
+    nab_index_multi.IndexConfig = _FakeIndexConfig
+    nab_config = mocker.MagicMock()
+    nab_config.read_pyproject_config.return_value = original
+    nab_resolve = mocker.MagicMock()
+    nab_resolve.resolve_pyproject = fake_resolve_pyproject
+    mocker.patch.dict(
+        "sys.modules",
+        {
+            "nab_index": mocker.MagicMock(),
+            "nab_index.multi_index": nab_index_multi,
+            "nab_index.urllib3_async_transport": mocker.MagicMock(),
+            "nab_python": mocker.MagicMock(),
+            "nab_python.config": nab_config,
+            "nab_python.resolve": nab_resolve,
+        },
+    )
+
+    resolve_from_index(
+        requirements=[],
+        requirement_files=[],
+        pyproject_files=[str(pyproject)],
+        index_url="https://override/simple",
+    )
+
+    config = captured["config"]
+    assert isinstance(config, _FakeConfig)
+    # The flag replaced the pyproject's own [tool.nab].indexes.
+    assert config.indexes == (_FakeIndexConfig("primary", "https://override/simple"),)
+
+
+def test_lone_pyproject_no_override_keeps_own_indexes(
+    mocker: MockerFixture, fake_result: SimpleNamespace, write_pyproject: Callable[[], Path]
+) -> None:
+    pyproject = write_pyproject()
+    original = _FakeConfig(indexes=(_FakeIndexConfig("pyproject-index", "https://own/simple"),))
+    captured: dict[str, object] = {}
+
+    def fake_resolve_pyproject(path: Path, transport: object, *, config: object) -> SimpleNamespace:  # noqa: ARG001
+        captured["config"] = config
+        return fake_result
+
+    nab_config = mocker.MagicMock()
+    nab_config.read_pyproject_config.return_value = original
+    nab_resolve = mocker.MagicMock()
+    nab_resolve.resolve_pyproject = fake_resolve_pyproject
+    mocker.patch.dict(
+        "sys.modules",
+        {
+            "nab_index": mocker.MagicMock(),
+            "nab_index.multi_index": mocker.MagicMock(),
+            "nab_index.urllib3_async_transport": mocker.MagicMock(),
+            "nab_python": mocker.MagicMock(),
+            "nab_python.config": nab_config,
+            "nab_python.resolve": nab_resolve,
+        },
+    )
+
+    resolve_from_index(requirements=[], requirement_files=[], pyproject_files=[str(pyproject)])
+
+    # No flag/env, so the pyproject's own indexes are left untouched.
+    assert captured["config"] is original
+
+
+def test_cli_index_url_flag() -> None:
+    options = get_options(["from-index", "foo", "--index-url", "https://x/simple"])
+    assert options.index_url == "https://x/simple"
+    assert options.extra_index_url is None
+
+
+def test_cli_extra_index_url_accumulates() -> None:
+    options = get_options([
+        "from-index",
+        "foo",
+        "--extra-index-url",
+        "https://x/simple",
+        "--extra-index-url",
+        "https://y/simple",
+    ])
+    assert options.extra_index_url == ["https://x/simple", "https://y/simple"]
+
+
+def test_cli_bare_top_level_seeds_index_defaults() -> None:
+    options = get_options([])
+    assert options.index_url is None
+    assert options.extra_index_url is None

--- a/tests/test_pipdeptree.py
+++ b/tests/test_pipdeptree.py
@@ -39,7 +39,7 @@ def test_console_script() -> None:
         pytest.fail(f"Unexpected error: {e}")
 
     with pytest.raises(SystemExit, match="0"):
-        pipdeptree(["", "--help"])
+        pipdeptree(["--help"])
 
 
 def test_main_log_resolved(tmp_path: Path, mocker: MockFixture, capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
Closes #187.

pipdeptree reads an installed environment, so seeing what a set of requirements would pull in meant installing them somewhere first. 🔍 The `from-index` subcommand resolves requirements by querying a package index (PyPI by default) and renders the tree without installing or inspecting anything.

```console
$ pip install pipdeptree[index]
$ pipdeptree from-index "fastapi<=0.115.2" starlette
$ pipdeptree from-index --requirements requirements.txt
$ pipdeptree from-index --pyproject pyproject.toml
```

Resolution runs through the optional [nab](https://github.com/notatallshaw/nab) PubGrub resolver, wired in behind the `pipdeptree[index]` extra so the core install stays light. Without the extra, `from-index` exits with a `pip install pipdeptree[index]` hint instead of a traceback. Inputs are explicit: positional arguments are inline PEP 508 requirements, `--requirements` takes a requirements file (parsed with `pip-requirements-parser`, so nested `-r`, `-c` constraints, environment markers and comments work), and `--pyproject` takes a pyproject. A lone `--pyproject` resolves natively so its `[tool.nab]` config applies; other combinations merge into one resolve. Editable, local-path and pinned git requirements resolve by reading the target's PEP 621 metadata, building only when that metadata is dynamic; bare wheel/sdist URLs and non-git VCS stay out of scope.

For private or mirrored indexes, `--index-url` replaces PyPI and `--extra-index-url` (repeatable) adds more. 🔐 Each falls back to the environment when its flag is absent: `--index-url` reads `PIP_INDEX_URL` then `UV_INDEX_URL`, and `--extra-index-url` reads `PIP_EXTRA_INDEX_URL` then `UV_EXTRA_INDEX_URL`. The resolver searches indexes in order and the first one carrying a package wins, which differs from pip's merge-and-pick-highest. Flags and env override a `--pyproject`'s own `[tool.nab].indexes`; that config applies when neither is set.

A resolve produces one version per package and no per-edge requirement range (nab's public result drops it), so reusing the installed-environment label `[required: ==X, installed: X]` would be both redundant and wrong. ⚙️ `from-index` renders each edge as `[candidate: <version>]` across text, rich and JSON, while the default command keeps `[required: …, installed: …]` unchanged. The subcommand shares the render and selection flags (`-o`, `-r`, `-d`, `-p`, `-e`, `-x`) through a parent parser, and omits the installed-only options (`--metadata`, `--computed`, `--license`) and environment-inspection options (`--python`, `--path`, `-l`/`-u`), which have no meaning without an installed environment.

This changes the renderer that the default command also uses, gated on the active subcommand, so bare `pipdeptree` output is unchanged. Every example tree and JSON block in the docs was captured from real runs against PyPI. nab is young, so the index extra floors it at `>=0.0.4` and the resolver-facing code stays isolated in `_from_index.py` for easy adjustment as nab evolves.