### PR TITLE
✨ feat(cli): add from-lock subcommand to render a PEP 751 lock offline

### DIFF
--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -119,6 +119,18 @@ exist for un-downloaded packages, and the environment-inspection options (``--py
 have no environment to point at. The pure graph/version/render flags -- filtering, depth, ``--reverse``,
 ``--extras`` and the output formats -- apply unchanged.
 
+``from-lock`` and ``from-index`` differ in where the answer comes from. ``from-index`` **resolves** a tree from an
+index: the versions and edges do not exist yet, so the resolver computes them and needs the ``[index]`` extra and
+network access. ``from-lock`` **reads** an already-resolved
+`PEP 751 <https://peps.python.org/pep-0751/>`_ lock (``pylock.toml``).
+
+A PEP 751 lock records each package's name, its pinned version and the forward edges between packages (its
+``[[packages]]`` and ``[[packages.dependencies]]`` tables). The tool that wrote the lock did the resolution.
+``from-lock`` runs offline: it maps the TOML tables to a graph and feeds that graph through the same render
+machinery, with no resolver, no network and no extra. The edges live in the file, so nothing is left to compute.
+``from-lock`` shares one limit with ``from-index``: a lock holds only names, versions and edges, so the
+installed-only display options stay absent.
+
 Optional dependencies (extras)
 ------------------------------
 

--- a/docs/how-to/output-formats.rst
+++ b/docs/how-to/output-formats.rst
@@ -224,4 +224,6 @@ The format is specified as ``graphviz-<format>`` where ``<format>`` is any
 
 Every format above also works with the ``from-index`` subcommand, e.g.
 ``pipdeptree from-index --requirements requirements.txt -o json``
-to render a tree resolved from the package index without installing. See :doc:`/how-to/usage` for details.
+to render a tree resolved from the package index without installing, and with the ``from-lock`` subcommand, e.g.
+``pipdeptree from-lock pylock.toml -o json`` to render an already-resolved PEP 751 lock offline. See
+:doc:`/how-to/usage` for details.

--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -369,6 +369,172 @@ Limitations
 - The subcommand needs network access and the ``pipdeptree[index]`` extra. Without the extra installed, it errors
   with an install hint.
 
+from-lock (render a PEP 751 lock)
+---------------------------------
+
+The ``from-lock`` subcommand reads a `PEP 751 <https://peps.python.org/pep-0751/>`_ lock file
+(``pylock.toml``) and renders its dependency tree. A lock is already resolved: it records the pinned packages,
+their versions and the edges between them. ``from-lock`` runs **offline** with no package index, no network and no
+extra, and it works on every supported Python. The standard-library ``tomllib`` parses the file on 3.11+, and
+:pypi:`tomli` parses it on 3.10.
+
+.. code-block:: console
+
+    $ pipdeptree from-lock pylock.toml
+    build==1.5.0
+    ├── packaging [candidate: 26.2]
+    └── pyproject-hooks [candidate: 1.2.0]
+
+Each edge shows the ``candidate:`` version the lock pinned, not a package on your machine. pipdeptree reads
+nothing off disk and installs nothing.
+
+Producing a pylock.toml
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Any PEP 751 emitter writes a file ``from-lock`` can read. :pypi:`uv` exports one from a project:
+
+.. code-block:: console
+
+    $ uv export -o pylock.toml          # or: uv lock then export
+    $ pipdeptree from-lock pylock.toml
+
+Render flags on a lock
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The lock supplies every name, version and edge, so the graph and render flags behave as they do for the default
+command: ``--packages`` (``-p``), ``--exclude`` (``-e``), ``--depth`` (``-d``), ``--extras`` (``-x``),
+``--reverse`` (``-r``), ``--encoding`` and every output format from ``-o``.
+
+Emit JSON for another tool to consume:
+
+.. code-block:: console
+
+    $ pipdeptree from-lock pylock.toml -o json
+    [
+        {
+            "package": {
+                "key": "build",
+                "package_name": "build",
+                "candidate_version": "1.5.0"
+            },
+            "dependencies": [
+                {
+                    "key": "packaging",
+                    "package_name": "packaging",
+                    "candidate_version": "26.2"
+                },
+                {
+                    "key": "pyproject-hooks",
+                    "package_name": "pyproject-hooks",
+                    "candidate_version": "1.2.0"
+                }
+            ]
+        },
+        {
+            "package": {
+                "key": "packaging",
+                "package_name": "packaging",
+                "candidate_version": "26.2"
+            },
+            "dependencies": []
+        },
+        {
+            "package": {
+                "key": "pyproject-hooks",
+                "package_name": "pyproject-hooks",
+                "candidate_version": "1.2.0"
+            },
+            "dependencies": []
+        }
+    ]
+
+Flip the edges with ``--reverse`` to see which packages pull in a given dependency:
+
+.. code-block:: console
+
+    $ pipdeptree from-lock pylock.toml --reverse
+    packaging==26.2
+    └── build==1.5.0 [requires: packaging==26.2]
+    pyproject-hooks==1.2.0
+    └── build==1.5.0 [requires: pyproject-hooks==1.2.0]
+
+Draw a Mermaid diagram for a docs page or chat client:
+
+.. code-block:: console
+
+    $ pipdeptree from-lock pylock.toml -o mermaid
+
+Narrow the tree the same way you would for an installed environment. Keep one root with ``--packages``:
+
+.. code-block:: console
+
+    $ pipdeptree from-lock pylock.toml --packages build
+
+Hide a package with ``--exclude``:
+
+.. code-block:: console
+
+    $ pipdeptree from-lock pylock.toml --exclude packaging
+
+Stop after the first level with ``--depth``:
+
+.. code-block:: console
+
+    $ pipdeptree from-lock pylock.toml --depth 1
+
+Locks without edges
+~~~~~~~~~~~~~~~~~~~~~
+
+A valid PEP 751 lock may pin packages without recording the edges between them. ``from-lock`` then renders a flat
+list of pinned packages, each with no children:
+
+.. code-block:: console
+
+    $ pipdeptree from-lock pylock.toml
+    build==1.5.0
+    packaging==26.2
+    pyproject-hooks==1.2.0
+
+Lock limitations
+~~~~~~~~~~~~~~~~~
+
+A lock carries only names, versions and edges, so the installed-only display options have nothing to read. The
+subcommand omits them, and passing one errors:
+
+.. code-block:: console
+
+    $ pipdeptree from-lock pylock.toml --metadata license
+    ...
+    pipdeptree: error: unrecognized arguments: --metadata license
+    $ pipdeptree from-lock pylock.toml --license
+
+The same holds for ``--computed`` (``-c``) and the environment-inspection options (``--python``, ``--path``,
+``-l``/``-u``): a lock has no ``METADATA`` file, no on-disk sizes and no environment to point at.
+
+A missing lock file stops the command with a message and exit code 1:
+
+.. code-block:: console
+
+    $ pipdeptree from-lock missing.toml
+    lock file does not exist: missing.toml
+    $ echo $?
+    1
+
+A malformed lock fails the same way. ``from-lock`` rejects a file that parses as TOML but has no ``packages``
+array:
+
+.. code-block:: console
+
+    $ pipdeptree from-lock pylock.toml
+    not a valid PEP 751 lock file: pylock.toml (missing 'packages' array)
+
+A package entry without a ``name`` key, or a file that is not TOML at all, reports the offending file too:
+
+.. code-block:: console
+
+    $ pipdeptree from-lock pylock.toml
+    not a valid PEP 751 lock file: pylock.toml (a package entry is missing 'name')
+
 Filtering packages
 ------------------
 

--- a/docs/tutorial/getting-started.rst
+++ b/docs/tutorial/getting-started.rst
@@ -192,6 +192,23 @@ a ``pyproject.toml`` with ``--pyproject`` or a requirements file with ``--requir
 or a pinned git requirement, where the resolver reads the target's metadata. See :doc:`/how-to/usage` for those
 sources, the render flags, and the inputs the resolver rejects.
 
+Render a lock file
+------------------
+
+If you already have a `PEP 751 <https://peps.python.org/pep-0751/>`_ lock file (a ``pylock.toml``, such as the one
+:pypi:`uv` exports), point ``from-lock`` at it to read its tree:
+
+.. code-block:: console
+
+    $ pipdeptree from-lock pylock.toml
+    build==1.5.0
+    ├── packaging [candidate: 26.2]
+    └── pyproject-hooks [candidate: 1.2.0]
+
+The lock already lists every package, version and edge, so ``from-lock`` runs offline with no install, no network
+and no extra. The filtering and output flags you used above work here too. See :doc:`/how-to/usage` for the full
+set.
+
 Next steps
 ----------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dynamic = [
 ]
 dependencies = [
   "packaging>=26",
+  "tomli>=2; python_version<'3.11'",
 ]
 optional-dependencies.graphviz = [
   "graphviz>=0.21",

--- a/src/pipdeptree/__main__.py
+++ b/src/pipdeptree/__main__.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from pipdeptree._cli import Options, get_options, parse_packages
 from pipdeptree._detect_env import detect_active_interpreter, find_active_interpreter
 from pipdeptree._discovery import InterpreterQueryError, get_installed_distributions
 from pipdeptree._from_index import FromIndexInputError, FromIndexUnavailableError, resolve_from_index
+from pipdeptree._from_lock import FromLockError, load_lock
 from pipdeptree._models import PackageDAG
 from pipdeptree._models.dag import IncludeExcludeOverlapError, IncludePatternNotFoundError
 from pipdeptree._render import render
@@ -44,7 +46,7 @@ def main(args: Sequence[str] | None = None) -> int | None:
     except InterpreterQueryError as e:
         print(f"Failed to query custom interpreter: {e}", file=sys.stderr)  # noqa: T201
         return 1
-    except (FromIndexUnavailableError, FromIndexInputError) as e:
+    except (FromIndexUnavailableError, FromIndexInputError, FromLockError) as e:
         print(str(e), file=sys.stderr)  # noqa: T201
         return 1
     except _FilterError as e:
@@ -69,6 +71,7 @@ def build_tree(options: Options, *, log_resolved: bool = False) -> PackageDAG:
     :raises InterpreterQueryError: if querying a custom interpreter failed
     :raises FromIndexUnavailableError: if from-index is used but the optional nab resolver is missing
     :raises FromIndexInputError: if a from-index source is missing or a requirements file uses an unsupported directive
+    :raises FromLockError: if a from-lock file is missing or is not a valid PEP 751 lock
     :raises _FilterError: if the include/exclude filter cannot be satisfied
     """
     if options.command == "from-index":
@@ -81,6 +84,9 @@ def build_tree(options: Options, *, log_resolved: bool = False) -> PackageDAG:
             index_url=options.index_url,
             extra_index_url=options.extra_index_url,
         )
+    elif options.command == "from-lock":
+        # A PEP 751 lock is already resolved, so it is read straight off disk -- no interpreter, network, or index.
+        pkgs = load_lock(Path(options.lock))  # ty: ignore[invalid-argument-type]
     else:
         options.python = _resolve_python(options.python, log_resolved=log_resolved)
         pkgs = get_installed_distributions(

--- a/src/pipdeptree/_cli.py
+++ b/src/pipdeptree/_cli.py
@@ -27,6 +27,7 @@ class Options(Namespace):
     pyproject: list[str] | None
     index_url: str | None
     extra_index_url: list[str] | None
+    lock: str | None
     all: bool
     local_only: bool
     user_only: bool
@@ -185,9 +186,21 @@ def build_parser() -> ArgumentParser:
         "UV_EXTRA_INDEX_URL (whitespace separated) when unset",
     )
 
+    from_lock = sub.add_parser(
+        "from-lock",
+        parents=[render_parent],
+        formatter_class=_Formatter,
+        help="render the dependency tree from a PEP 751 pylock.toml (offline; no index/network needed)",
+        description=(
+            "Read a PEP 751 lock file (pylock.toml) and render its dependency tree. The lock is already resolved, so "
+            "this is fully offline -- no package index, network, or extra is required."
+        ),
+    )
+    from_lock.add_argument("lock", metavar="PYLOCK", help="path to a PEP 751 pylock.toml lock file")
+
     # Bare ``pipdeptree`` does not visit the subparser, so seed defaults for its attributes to keep Options total. The
-    # installed-only display options (license/metadata/computed) are not exposed on the from-index subparser, so seed
-    # them too: this keeps Options total whichever path argparse takes, so get_options can post-process it always.
+    # installed-only display options (license/metadata/computed) are not exposed on the subparsers, so seed them too:
+    # this keeps Options total whichever path argparse takes, so get_options can post-process it always.
     parser.set_defaults(
         command=None,
         requirement=[],
@@ -195,6 +208,7 @@ def build_parser() -> ArgumentParser:
         pyproject=None,
         index_url=None,
         extra_index_url=None,
+        lock=None,
         license=False,
         metadata="",
         computed="",

--- a/src/pipdeptree/_from_index.py
+++ b/src/pipdeptree/_from_index.py
@@ -32,15 +32,15 @@ import os
 import string
 import tempfile
 from dataclasses import dataclass, field
-from email.message import Message
-from importlib.metadata import Distribution
 from itertools import starmap
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Final
 
+from pipdeptree._synthetic_dist import SyntheticDistribution
+
 if TYPE_CHECKING:
     from collections.abc import Mapping
-    from email.message import Message as MessageType
+    from importlib.metadata import Distribution
 
 # nab's recognized git VCS schemes (see nab_python._vcs_admission._VCS_SCHEMES); only these map to a vcs-source.
 _GIT_SCHEMES: Final[tuple[str, ...]] = ("git+https", "git+ssh", "git+http", "git+file", "git+git")
@@ -301,7 +301,7 @@ def _adapt(result: Any) -> list[Distribution]:
     pins: Mapping[str, object] = result.pins
     dependencies: Mapping[str, tuple[str, ...]] = result.lock_input.dependencies
     return [
-        _FromIndexDistribution(
+        SyntheticDistribution(
             name,
             str(version),
             tuple(f"{child}=={pins[child]}" for child in dependencies.get(name, ())),
@@ -400,33 +400,6 @@ def _render_pyproject(inputs: _ParsedInputs) -> str:
 def _toml_quote(value: str) -> str:
     escaped = value.replace("\\", "\\\\").replace('"', '\\"')
     return f'"{escaped}"'
-
-
-class _FromIndexDistribution(Distribution):
-    """A Distribution backed by resolved name/version/edges rather than an on-disk package."""
-
-    def __init__(self, name: str, version: str, children: tuple[str, ...]) -> None:
-        self._metadata = Message()
-        self._metadata["Name"] = name
-        self._metadata["Version"] = version
-        # children are already pinned requirement strings (e.g. "foo==1.2.3"), so the existing
-        # DistPackage.requires() reconstructs exact edges with no renderer changes.
-        for child in children:
-            self._metadata["Requires-Dist"] = child
-
-    @property
-    def metadata(self) -> MessageType:
-        return self._metadata
-
-    @property
-    def version(self) -> str:
-        return self._metadata["Version"]
-
-    def read_text(self, filename: str) -> str | None:  # noqa: ARG002, PLR6301
-        return None
-
-    def locate_file(self, path: str | os.PathLike[str]) -> Path:  # noqa: PLR6301
-        return Path(path)
 
 
 __all__ = [

--- a/src/pipdeptree/_from_lock.py
+++ b/src/pipdeptree/_from_lock.py
@@ -1,0 +1,97 @@
+"""
+Read a PEP 751 lock file (``pylock.toml``) and render its dependency tree.
+
+This is the engine behind the ``from-lock`` CLI subcommand. A PEP 751 lock is *already resolved* -- it carries the
+pinned packages, their versions, and the forward edges between them -- so rendering it is purely a TOML to
+:class:`~pipdeptree._models.PackageDAG` mapping. There is no resolver, no network, and no package index involved,
+which is why ``from-lock`` works fully offline and needs no optional extra.
+
+The lock's ``packages`` array becomes :class:`~pipdeptree._synthetic_dist.SyntheticDistribution` objects (the same
+adapter the ``from-index`` path uses), so the existing DAG and every renderer work unchanged. Each package's
+``dependencies`` array lists only child *names*; the child's version is looked up in the ``packages`` array by PEP 503
+canonical name so an edge ``Foo_Bar`` matches a package ``foo-bar``.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING, Any
+
+from packaging.utils import canonicalize_name
+
+from pipdeptree._synthetic_dist import SyntheticDistribution
+
+if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
+    import tomllib
+else:  # pragma: <3.11 cover
+    import tomli as tomllib
+
+if TYPE_CHECKING:
+    from importlib.metadata import Distribution
+    from pathlib import Path
+
+    from packaging.utils import NormalizedName
+
+
+class FromLockError(ValueError):
+    """Raised when a PEP 751 lock file is missing or cannot be parsed into a dependency tree."""
+
+
+def load_lock(path: Path) -> list[Distribution]:
+    """
+    Parse a PEP 751 ``pylock.toml`` into Distribution-like objects ready for the existing DAG pipeline.
+
+    :param path: the ``pylock.toml`` lock file to read.
+    :returns: a list of :class:`importlib.metadata.Distribution` look-alikes ready for
+        :meth:`pipdeptree._models.PackageDAG.from_pkgs`.
+    :raises FromLockError: if the file is missing, is not valid TOML, lacks a ``packages`` array, or has a package
+        without a ``name``.
+    """
+    if not path.is_file():
+        msg = f"lock file does not exist: {path}"
+        raise FromLockError(msg)
+
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as exc:
+        msg = f"not a valid PEP 751 lock file: {path} (malformed TOML: {exc})"
+        raise FromLockError(msg) from exc
+
+    packages = data.get("packages")
+    if not isinstance(packages, list):
+        msg = f"not a valid PEP 751 lock file: {path} (missing 'packages' array)"
+        raise FromLockError(msg)
+
+    # Versions are looked up by canonical name so an edge can reference a package under any casing/separator spelling;
+    # a package may legitimately lack a version (VCS/local/directory pins), in which case its edges render unpinned.
+    versions = {canonicalize_name(name): str(pkg.get("version", "")) for name, pkg in _named(packages, path)}
+    return [
+        SyntheticDistribution(name, str(pkg.get("version", "")), _children(pkg.get("dependencies", ()), versions))
+        for name, pkg in _named(packages, path)
+    ]
+
+
+def _named(packages: list[Any], path: Path) -> list[tuple[str, dict[str, Any]]]:
+    named: list[tuple[str, dict[str, Any]]] = []
+    for pkg in packages:
+        if not isinstance(pkg, dict) or "name" not in pkg:
+            msg = f"not a valid PEP 751 lock file: {path} (a package entry is missing 'name')"
+            raise FromLockError(msg)
+        named.append((str(pkg["name"]), pkg))
+    return named
+
+
+def _children(dependencies: Any, versions: dict[NormalizedName, str]) -> tuple[str, ...]:
+    # A leaf omits the ``dependencies`` key entirely, so the default () yields no edges. Each edge carries only the
+    # child name; pin it from the looked-up version when known, else emit a bare requirement.
+    children: list[str] = []
+    for dep in dependencies:
+        child = str(dep["name"])
+        children.append(f"{child}=={version}" if (version := versions.get(canonicalize_name(child))) else child)
+    return tuple(children)
+
+
+__all__ = [
+    "FromLockError",
+    "load_lock",
+]

--- a/src/pipdeptree/_synthetic_dist.py
+++ b/src/pipdeptree/_synthetic_dist.py
@@ -1,0 +1,51 @@
+"""
+A :class:`importlib.metadata.Distribution` look-alike backed by name/version/edges instead of an on-disk package.
+
+Both the ``from-index`` resolver and the ``from-lock`` reader produce package graphs that were never installed, yet
+the existing :class:`~pipdeptree._models.PackageDAG` and every renderer expect real ``Distribution`` objects. This
+shared adapter bridges that gap: each child is rendered as a PEP 508 ``Requires-Dist`` string so the unchanged
+:meth:`pipdeptree._models.package.DistPackage.requires` rebuilds exact edges with no renderer changes.
+"""
+
+from __future__ import annotations
+
+from email.message import Message
+from importlib.metadata import Distribution
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import os
+    from email.message import Message as MessageType
+
+
+class SyntheticDistribution(Distribution):
+    """A Distribution backed by resolved name/version/edges rather than an on-disk package."""
+
+    def __init__(self, name: str, version: str, children: tuple[str, ...]) -> None:
+        self._metadata = Message()
+        self._metadata["Name"] = name
+        self._metadata["Version"] = version
+        # children are already requirement strings (e.g. "foo==1.2.3" or bare "foo"), so the existing
+        # DistPackage.requires() reconstructs exact edges with no renderer changes.
+        for child in children:
+            self._metadata["Requires-Dist"] = child
+
+    @property
+    def metadata(self) -> MessageType:
+        return self._metadata
+
+    @property
+    def version(self) -> str:
+        return self._metadata["Version"]
+
+    def read_text(self, filename: str) -> str | None:  # noqa: ARG002, PLR6301
+        return None
+
+    def locate_file(self, path: str | os.PathLike[str]) -> Path:  # noqa: PLR6301
+        return Path(path)
+
+
+__all__ = [
+    "SyntheticDistribution",
+]

--- a/tests/test_from_index.py
+++ b/tests/test_from_index.py
@@ -13,7 +13,6 @@ from pipdeptree._cli import get_options
 from pipdeptree._from_index import (
     FromIndexInputError,
     FromIndexUnavailableError,
-    _FromIndexDistribution,
     _LocalSource,
     _parse_requirements_file,
     _ParsedInputs,
@@ -25,6 +24,7 @@ from pipdeptree._from_index import (
     resolve_from_index,
 )
 from pipdeptree._models import PackageDAG
+from pipdeptree._synthetic_dist import SyntheticDistribution
 
 _PYPI_NAME = "pypi"
 _PYPI_URL = "https://pypi.org/simple"
@@ -223,8 +223,8 @@ def test_render_pyproject_quotes_special_chars() -> None:
     assert 'dependencies = [\n  "foo>=1; extra == \\"bar\\"",\n]' in rendered
 
 
-def test_from_index_distribution_file_helpers() -> None:
-    dist = _FromIndexDistribution("foo", "1.0", ("bar==2.0",))
+def test_synthetic_distribution_file_helpers() -> None:
+    dist = SyntheticDistribution("foo", "1.0", ("bar==2.0",))
     assert dist.read_text("METADATA") is None
     assert dist.locate_file("METADATA") == Path("METADATA")
 

--- a/tests/test_from_lock.py
+++ b/tests/test_from_lock.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from pipdeptree.__main__ import main
+from pipdeptree._cli import get_options
+from pipdeptree._from_lock import FromLockError, load_lock
+from pipdeptree._models import PackageDAG
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest_mock import MockerFixture
+
+_CHAIN = """\
+lock-version = "1.0"
+created-by = "nab"
+[[packages]]
+name = "build"
+version = "1.5.0"
+[[packages.dependencies]]
+name = "packaging"
+[[packages.dependencies]]
+name = "pyproject-hooks"
+[[packages]]
+name = "packaging"
+version = "26.2"
+[[packages]]
+name = "pyproject-hooks"
+version = "1.2.0"
+"""
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    lock = tmp_path / "pylock.toml"
+    lock.write_text(body, encoding="utf-8")
+    return lock
+
+
+@pytest.mark.parametrize(
+    ("body", "expected_children", "expected_versions"),
+    [
+        pytest.param(
+            _CHAIN,
+            {"build": ["packaging", "pyproject-hooks"], "packaging": [], "pyproject-hooks": []},
+            {"build": "1.5.0", "packaging": "26.2", "pyproject-hooks": "1.2.0"},
+            id="chain-with-edges",
+        ),
+        pytest.param(
+            'lock-version = "1.0"\n'
+            "[[packages]]\n"
+            'name = "packaging"\n'
+            'version = "26.2"\n'
+            "[[packages]]\n"
+            'name = "wheel"\n'
+            'version = "0.45.1"\n',
+            {"packaging": [], "wheel": []},
+            {"packaging": "26.2", "wheel": "0.45.1"},
+            id="flat-no-edges",
+        ),
+    ],
+)
+def test_load_lock_builds_tree(
+    tmp_path: Path,
+    body: str,
+    expected_children: dict[str, list[str]],
+    expected_versions: dict[str, str],
+) -> None:
+    dag = PackageDAG.from_pkgs(load_lock(_write(tmp_path, body)))
+
+    by_key = {str(pkg.key): pkg for pkg in dag}
+    assert set(by_key) == set(expected_versions)
+    for key, version in expected_versions.items():
+        assert by_key[key].version == version
+    for key, children in expected_children.items():
+        assert sorted(child.key for child in dag.get_children(key)) == sorted(children)
+
+
+def test_load_lock_pins_child_versions(tmp_path: Path) -> None:
+    dag = PackageDAG.from_pkgs(load_lock(_write(tmp_path, _CHAIN)))
+
+    by_child = {str(child.key): child for child in dag.get_children("build")}
+    assert by_child["packaging"].version_spec == "==26.2"
+
+
+def test_load_lock_canonicalizes_edge_name(tmp_path: Path) -> None:
+    body = """\
+[[packages]]
+name = "parent"
+version = "1.0"
+[[packages.dependencies]]
+name = "Foo_Bar"
+[[packages]]
+name = "foo-bar"
+version = "2.0"
+"""
+    dag = PackageDAG.from_pkgs(load_lock(_write(tmp_path, body)))
+
+    (child,) = dag.get_children("parent")
+    assert child.key == "foo-bar"
+    assert child.version_spec == "==2.0"
+
+
+def test_load_lock_leaf_has_no_children(tmp_path: Path) -> None:
+    body = '[[packages]]\nname = "solo"\nversion = "1.0"\n'
+
+    dag = PackageDAG.from_pkgs(load_lock(_write(tmp_path, body)))
+
+    assert dag.get_children("solo") == []
+
+
+def test_load_lock_package_without_version(tmp_path: Path) -> None:
+    body = """\
+[[packages]]
+name = "parent"
+[[packages.dependencies]]
+name = "child"
+[[packages]]
+name = "child"
+"""
+    dag = PackageDAG.from_pkgs(load_lock(_write(tmp_path, body)))
+
+    by_key = {str(pkg.key): pkg for pkg in dag}
+    assert not by_key["parent"].version
+    # An unpinned edge stays unconstrained rather than crashing on the missing version.
+    (child,) = dag.get_children("parent")
+    assert child.version_spec is None
+
+
+def test_load_lock_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(FromLockError, match="lock file does not exist"):
+        load_lock(tmp_path / "absent.toml")
+
+
+@pytest.mark.parametrize(
+    ("body", "match"),
+    [
+        pytest.param("this is not = = toml", "malformed TOML", id="malformed-toml"),
+        pytest.param('name = "x"\n', "missing 'packages' array", id="missing-packages"),
+        pytest.param("packages = 3\n", "missing 'packages' array", id="packages-not-array"),
+        pytest.param('[[packages]]\nversion = "1.0"\n', "missing 'name'", id="package-missing-name"),
+    ],
+)
+def test_load_lock_malformed(tmp_path: Path, body: str, match: str) -> None:
+    with pytest.raises(FromLockError, match=match):
+        load_lock(_write(tmp_path, body))
+
+
+def test_main_from_lock_renders_text_tree(
+    tmp_path: Path, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]
+) -> None:
+    lock = _write(tmp_path, _CHAIN)
+    mocker.patch("pipdeptree.__main__.sys.argv", ["", "from-lock", str(lock)])
+
+    assert main() == 0
+
+    out, _ = capsys.readouterr()
+    assert "build==1.5.0" in out
+    assert "packaging" in out
+    assert "pyproject-hooks" in out
+
+
+def test_main_from_lock_json_output(tmp_path: Path, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
+    lock = _write(tmp_path, _CHAIN)
+    mocker.patch("pipdeptree.__main__.sys.argv", ["", "from-lock", str(lock), "-o", "json"])
+
+    assert main() == 0
+
+    out, _ = capsys.readouterr()
+    assert '"key": "build"' in out
+
+
+def test_main_from_lock_error(tmp_path: Path, mocker: MockerFixture, capsys: pytest.CaptureFixture[str]) -> None:
+    mocker.patch("pipdeptree.__main__.sys.argv", ["", "from-lock", str(tmp_path / "absent.toml")])
+
+    assert main() == 1
+
+    out, err = capsys.readouterr()
+    assert not out
+    assert "lock file does not exist" in err
+
+
+def test_get_options_from_lock_parses() -> None:
+    options = get_options(["from-lock", "pylock.toml"])
+
+    assert options.command == "from-lock"
+    assert options.lock == "pylock.toml"
+
+
+def test_get_options_bare_keeps_lock_default() -> None:
+    options = get_options([])
+
+    assert options.command is None
+    assert options.lock is None
+
+
+@pytest.mark.parametrize(
+    "flag",
+    [
+        pytest.param("--metadata", id="metadata"),
+        pytest.param("--license", id="license"),
+        pytest.param("--computed", id="computed"),
+    ],
+)
+def test_from_lock_rejects_installed_only_flags(flag: str) -> None:
+    with pytest.raises(SystemExit) as exc:
+        get_options(["from-lock", "pylock.toml", flag, "size"])
+    assert exc.value.code == 2


### PR DESCRIPTION
A companion to `from-index` (#593): `pipdeptree from-lock pylock.toml` reads a PEP 751 lock file and renders its dependency tree, offline.

```console
$ pipdeptree from-lock pylock.toml
build==1.5.0
├── packaging [candidate: 26.2]
└── pyproject-hooks [candidate: 1.2.0]
```

A pylock is already resolved: each `[[packages]]` entry carries its `version` and its `[[packages.dependencies]]` edges. 🔌 So `from-lock` parses the TOML and feeds the existing `PackageDAG` pipeline with no package index, no network and no extra. That edges-in-the-file property is the difference from `from-index`: a requirements file (even fully pinned) has no dependency edges and needs resolution, while a PEP 751 lock carries them, so the two stay separate verbs rather than one guessing command.

`from-lock` reuses the synthetic-`Distribution` adapter that this branch extracts into `_synthetic_dist.py` (shared with `from-index`), and renders each edge as `[candidate: <version>]` since a lock supplies one version per package and no requirement range. It shares every render flag (`-o`, `-r`, `-d`, `-p`, `-e`, `-x`) and omits the installed-only options (`--metadata`, `--computed`, `--license`), which need on-disk files a lock does not have. `tomli` joins the core dependencies on Python 3.10 (stdlib `tomllib` on 3.11+) so `from-lock` works everywhere without the `index` extra. A lock that omits edges renders as a flat pinned list; a malformed lock or missing file exits with a clear message.

This stacks on #593 and reuses its subcommand scaffolding, synthetic-`Distribution` adapter and candidate renderer, so the diff shows that commit until #593 merges. ⚠️ Merge #593 first, then this rebases onto `main` and its diff narrows to the from-lock commit. The example output was captured from a real pylock rendered by the built command.