### PR TITLE
✨ feat(cli): add --summary health report (text/rich/json)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,26 @@ pipdeptree -o mermaid
 pipdeptree -o graphviz-svg > deps.svg
 ```
 
+Get a one-block environment health report (counts, depth, conflicts, cycles, licenses, size):
+
+```bash
+pipdeptree --summary           # aligned text
+pipdeptree --summary -o rich   # styled table
+pipdeptree --summary -o json   # machine-readable
+```
+
+Inspect a tree without installing it. Resolve requirements against a package index (needs the `index` extra), or read an
+already-resolved [PEP 751](https://peps.python.org/pep-0751/) lock offline:
+
+```bash
+pip install pipdeptree[index]
+pipdeptree from-index "flask"          # i is a shorthand alias
+pipdeptree from-index --requirements requirements.txt
+pipdeptree from-lock pylock.toml       # l is a shorthand alias
+```
+
+Every render flag above, including `--summary`, works with both subcommands.
+
 For the full documentation, visit [pipdeptree.readthedocs.io](https://pipdeptree.readthedocs.io).
 
 - [Documentation](https://pipdeptree.readthedocs.io)

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -131,6 +131,29 @@ machinery, with no resolver, no network and no extra. The edges live in the file
 ``from-lock`` shares one limit with ``from-index``: a lock holds only names, versions and edges, so the
 installed-only display options stay absent.
 
+The summary report and its two tiers
+------------------------------------
+
+``--summary`` condenses the whole tree into one block of environment-health metrics. It is a deliberately separate
+axis from the renderers: the flag chooses *what* to produce (the aggregate report), while ``-o`` chooses *how* to
+style it (``text``, ``rich`` or ``json``). Keeping them orthogonal is why the same report can print as a styled
+table, serialize to JSON, or display as an HTML table in a notebook, and why it composes with every tree source --
+``from-index``/``from-lock`` included -- instead of being locked to one. The tree-only renderers (mermaid,
+graphviz, freeze, json-tree) have no meaning for a flat report, so the flag rejects them.
+
+The metrics fall into two tiers that mirror the same installed-vs-resolved split as the display options above.
+
+*Graph-structural* metrics -- total/direct/transitive counts, max depth and cyclic dependencies -- derive purely
+from the DAG's nodes and edges. Every command can produce them, including ``from-index`` and ``from-lock``, because
+a resolved or locked graph still has nodes and edges.
+
+*Installed-environment* metrics -- missing and conflicting dependencies, the license breakdown, the minimum
+``Requires-Python`` and total on-disk size -- read real ``METADATA`` files and files on disk. The synthetic graphs
+behind ``from-index``/``from-lock`` carry only names, versions and edges (the same reason ``--metadata`` and
+``--computed`` are unavailable there), so these metrics cannot be computed. Rather than print a misleading ``0``,
+the summary marks them ``n/a`` in text and omits them from JSON, so an automated check can tell "zero conflicts"
+apart from "conflicts were never measured".
+
 Optional dependencies (extras)
 ------------------------------
 

--- a/docs/how-to/output-formats.rst
+++ b/docs/how-to/output-formats.rst
@@ -222,8 +222,75 @@ Other formats render the graph directly to binary output:
 The format is specified as ``graphviz-<format>`` where ``<format>`` is any
 `Graphviz output format <https://graphviz.org/docs/outputs/>`_ (dot, pdf, png, svg, jpeg, etc.).
 
-Every format above also works with the ``from-index`` subcommand, e.g.
+summary
+-------
+
+``--summary`` replaces the tree with a single-block health report of the environment -- for CI gates and
+at-a-glance audits rather than per-package inspection. It is a separate axis from the renderers above: ``--summary``
+chooses *what* to show, while ``-o`` chooses *how* to style it. The styles that make sense for a flat report are
+``text`` (the default), ``rich`` and ``json``; the tree-only renderers (mermaid, graphviz, freeze, json-tree) are
+rejected. Run it over the whole environment, or scope it with ``--packages`` like the examples above:
+
+.. code-block:: console
+
+    $ pipdeptree --packages pytest --summary
+    total packages:           5
+    direct dependencies:      1
+    transitive dependencies:  4
+    max depth:                2
+    cyclic dependencies:      0
+    missing dependencies:     0
+    conflicting dependencies: 0 (0 edges)
+    licenses:                 (Apache-2.0 OR BSD-2-Clause): 1, (BSD-2-Clause): 1, (MIT License): 1, (MIT): 2
+    unknown licenses:         0
+    copyleft licenses:        no
+    min requires-python:      3.10
+    total size:               6.0 MB
+
+For terminals, ``--summary -o rich`` prints the same metrics as a styled table. For automation, ``-o json`` emits
+a machine-readable object:
+
+.. code-block:: console
+
+    $ pipdeptree --packages pytest --summary -o json
+
+.. code-block:: json
+
+    {
+      "total_packages": 5,
+      "direct_dependencies": 1,
+      "transitive_dependencies": 4,
+      "max_depth": 2,
+      "cyclic_dependencies": 0,
+      "missing_dependencies": 0,
+      "conflicting_dependencies": {
+        "packages": 0,
+        "edges": 0
+      },
+      "licenses": {
+        "breakdown": {
+          "(Apache-2.0 OR BSD-2-Clause)": 1,
+          "(BSD-2-Clause)": 1,
+          "(MIT License)": 1,
+          "(MIT)": 2
+        },
+        "unknown": 0,
+        "copyleft": false
+      },
+      "min_requires_python": "3.10",
+      "total_size": "6.0 MB",
+      "total_size_raw": 6320765
+    }
+
+``--summary`` composes with the tree sources too: ``pipdeptree from-lock pylock.toml --summary`` and
+``pipdeptree from-index 'flask' --summary`` summarize a resolved tree. The graph-structural metrics (the first
+five) come from the tree alone and work everywhere. The installed-environment metrics (missing/conflicting deps,
+licenses, requires-python, size) read real distribution metadata and files, which the ``from-index``/``from-lock``
+synthetic trees do not carry, so under those subcommands they report ``n/a`` (text) or are omitted (JSON) rather
+than a misleading zero. See :doc:`/explanation` for the reasoning.
+
+Every format above also works with the ``from-index`` subcommand (alias ``i``), e.g.
 ``pipdeptree from-index --requirements requirements.txt -o json``
-to render a tree resolved from the package index without installing, and with the ``from-lock`` subcommand, e.g.
-``pipdeptree from-lock pylock.toml -o json`` to render an already-resolved PEP 751 lock offline. See
-:doc:`/how-to/usage` for details.
+to render a tree resolved from the package index without installing, and with the ``from-lock`` subcommand
+(alias ``l``), e.g. ``pipdeptree from-lock pylock.toml -o json`` to render an already-resolved PEP 751 lock offline.
+See :doc:`/how-to/usage` for details.

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -5,3 +5,48 @@ CLI reference
     :module: pipdeptree._cli
     :func: build_parser
     :title:
+
+Summary metrics
+---------------
+
+Fields emitted by ``--summary`` (styled with ``-o text``, ``rich`` or ``json``). The *Modes* column notes where
+each is available: *all* works for every command; *default* needs an installed environment and is reported as
+``n/a`` (omitted in JSON) under ``from-index``/``from-lock``.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 25 55 20
+
+    * - Field
+      - Meaning
+      - Modes
+    * - ``total_packages``
+      - Number of packages in the tree.
+      - all
+    * - ``direct_dependencies``
+      - Top-level packages (not required by any other package).
+      - all
+    * - ``transitive_dependencies``
+      - Packages pulled in only as a dependency of another (``total - direct``).
+      - all
+    * - ``max_depth``
+      - Longest dependency chain, counted in packages.
+      - all
+    * - ``cyclic_dependencies``
+      - Number of dependency cycles detected.
+      - all
+    * - ``missing_dependencies``
+      - Distinct packages required but not installed.
+      - default
+    * - ``conflicting_dependencies``
+      - ``packages`` with an unsatisfied requirement and the total conflicting ``edges``.
+      - default
+    * - ``licenses``
+      - ``breakdown`` per license string, count of ``unknown`` licenses, and a ``copyleft`` flag.
+      - default
+    * - ``min_requires_python``
+      - Highest ``Requires-Python`` lower bound across packages (the effective floor).
+      - default
+    * - ``total_size`` / ``total_size_raw``
+      - On-disk size of all packages, human-readable and in bytes.
+      - default

--- a/docs/tutorial/getting-started.rst
+++ b/docs/tutorial/getting-started.rst
@@ -139,6 +139,28 @@ Limit the tree depth:
     ├── chardet [required: >=3.0.0, installed: 7.1.0]
     └── pluggy [required: >=0.13.1,<2, installed: 1.6.0]
 
+Get an at-a-glance health report with ``--summary``:
+
+.. code-block:: console
+
+    $ pipdeptree --packages pytest --summary
+    total packages:           5
+    direct dependencies:      1
+    transitive dependencies:  4
+    max depth:                2
+    cyclic dependencies:      0
+    missing dependencies:     0
+    conflicting dependencies: 0 (0 edges)
+    licenses:                 (Apache-2.0 OR BSD-2-Clause): 1, (BSD-2-Clause): 1, (MIT License): 1, (MIT): 2
+    unknown licenses:         0
+    copyleft licenses:        no
+    min requires-python:      3.10
+    total size:               6.0 MB
+
+Drop ``--packages`` to report on the whole environment. Add ``-o rich`` for a styled table, or ``-o json`` for a
+machine-readable version to gate CI on. The programmatic ``pipdeptree.render(summary=True)`` returns the same report
+and displays as an HTML table in a notebook. See :doc:`/how-to/output-formats` for the full field list.
+
 Preview a tree before installing
 --------------------------------
 

--- a/src/pipdeptree/__init__.py
+++ b/src/pipdeptree/__init__.py
@@ -26,7 +26,8 @@ from typing import TYPE_CHECKING
 
 from pipdeptree import _render
 from pipdeptree.__main__ import _FilterError, build_tree
-from pipdeptree._cli import get_options
+from pipdeptree._cli import SUMMARY_RENDER_FORMATS, get_options
+from pipdeptree._render.summary import summary_html
 from pipdeptree._warning import WarningType, get_warning_printer
 
 from .version import __version__
@@ -54,6 +55,7 @@ def render(  # noqa: PLR0913
     packages: str | None = None,
     exclude: str | None = None,
     output_format: str = "text",
+    summary: bool = False,
     reverse: bool = False,
     depth: float = inf,
     extras: bool | str = False,
@@ -69,7 +71,10 @@ def render(  # noqa: PLR0913
     :param packages: comma separated allow-list of packages to show (wildcards allowed)
     :param exclude: comma separated deny-list of packages to hide (wildcards allowed)
     :param output_format: one of ``text``, ``json``, ``json-tree``, ``mermaid`` or ``dot`` (Graphviz source); binary
-        Graphviz formats (png, svg, ...) cannot be returned as text and raise :class:`ValueError`
+        Graphviz formats (png, svg, ...) cannot be returned as text and raise :class:`ValueError`. With
+        ``summary=True`` it instead selects the summary style and must be ``text``, ``rich`` or ``json``
+    :param summary: return a one-block health report of the environment rather than the tree; in a notebook the
+        ``text`` style additionally displays as an HTML table
     :param reverse: list sub-dependencies with the packages that require them
     :param depth: limit the depth of the tree (text output only)
     :param extras: include optional (extras) dependencies in the tree; ``True`` is shorthand for ``"explicit"``
@@ -89,7 +94,13 @@ def render(  # noqa: PLR0913
     ``json-tree``, ``mermaid``, ``dot``) return a plain :class:`str` with no rich display, so their source/JSON shows
     as-is.
     """
-    argv = ["--warn", warn, "--encoding", encoding, *_format_flags(output_format)]
+    if summary and output_format not in SUMMARY_RENDER_FORMATS:
+        allowed = ", ".join(sorted(SUMMARY_RENDER_FORMATS))
+        msg = f"summary output_format must be one of {allowed}; got {output_format!r}"
+        raise ValueError(msg)
+
+    format_argv = ["--summary", "--output", output_format] if summary else _format_flags(output_format)
+    argv = ["--warn", warn, "--encoding", encoding, *format_argv]
     for flag, value in (("--packages", packages), ("--exclude", exclude), ("--python", python)):
         if value is not None:
             argv += [flag, value]
@@ -117,6 +128,13 @@ def render(  # noqa: PLR0913
         return ""
 
     text = _render_to_str(options, tree)
+    return _finalize(text, argv=argv, tree=tree, output_format=output_format, summary=summary)
+
+
+def _finalize(text: str, *, argv: list[str], tree: PackageDAG, output_format: str, summary: bool) -> str:
+    if summary:
+        # The aggregate report has no tree diagram; the text style instead displays as an HTML table in a notebook.
+        return _SummaryResult(text, html=summary_html(tree)) if output_format == "text" else text
     if output_format != "text":
         # Non-text formats (JSON, Mermaid source, Graphviz source) are returned as plain strings so they display
         # verbatim in a notebook instead of being reinterpreted as a diagram.
@@ -157,6 +175,29 @@ class _RenderResult(str):  # noqa: FURB189  # Must stay a real ``str`` so isinst
             "text/html": f"<pre>{escape(str(self))}</pre>",
             "text/plain": str(self),
         }
+        if include is not None:
+            bundle = {key: value for key, value in bundle.items() if key in include}
+        return bundle
+
+
+class _SummaryResult(str):  # noqa: FURB189  # Must stay a real ``str`` so isinstance/print/slicing keep working.
+    """A ``str`` whose value is the text summary but that also renders as an HTML table in a notebook cell."""
+
+    __slots__ = ("_html",)
+
+    _html: str
+
+    def __new__(cls, text: str, *, html: str) -> _SummaryResult:  # noqa: PYI034  # str subclass, concrete type is fine.
+        self = super().__new__(cls, text)
+        self._html = html
+        return self
+
+    def _repr_mimebundle_(  # noqa: PLW3201  # Jupyter rich-display protocol method, not a Python dunder.
+        self,
+        include: Container[str] | None = None,
+        exclude: Container[str] | None = None,  # noqa: ARG002
+    ) -> dict[str, str]:
+        bundle = {"text/html": self._html, "text/plain": str(self)}
         if include is not None:
             bundle = {key: value for key, value in bundle.items() if key in include}
         return bundle

--- a/src/pipdeptree/_cli.py
+++ b/src/pipdeptree/_cli.py
@@ -41,6 +41,7 @@ class Options(Namespace):
     mermaid: bool
     graphviz_format: str | None
     output_format: str
+    summary: bool
     extras: ExtrasMode
     depth: float
     encoding: str
@@ -88,6 +89,9 @@ class RenderContext:
 
 # NOTE: graphviz-* has been intentionally left out. Users of this var should handle it separately.
 ALLOWED_RENDER_FORMATS = ["freeze", "json", "json-tree", "mermaid", "rich", "text"]
+# Tree-specific renderers (mermaid, graphviz, freeze, json-tree) have no meaning for the aggregate summary, so
+# --summary is restricted to the styles that can present a flat report.
+SUMMARY_RENDER_FORMATS = frozenset({"text", "rich", "json"})
 ALLOWED_COMPUTED_FIELDS = frozenset({"size", "size-raw", "unique-deps-count", "unique-deps-names", "unique-deps-size"})
 
 
@@ -140,6 +144,7 @@ def build_parser() -> ArgumentParser:
     sub = parser.add_subparsers(dest="command")
     from_index = sub.add_parser(
         "from-index",
+        aliases=["i"],
         parents=[render_parent],
         formatter_class=_Formatter,
         help="resolve requirements by querying a package index and render their tree (needs the index extra)",
@@ -157,6 +162,9 @@ def build_parser() -> ArgumentParser:
         metavar="REQUIREMENT",
         help="inline PEP 508 requirement to resolve, like a pip install argument; repeatable",
     )
+    # argparse records the alias actually typed in ``command``; pin it to the canonical name so __main__ and
+    # get_options can branch on a single value regardless of whether the user typed "from-index" or "i".
+    from_index.set_defaults(command="from-index")
     from_index.add_argument(
         "--requirements",
         action="append",
@@ -188,6 +196,7 @@ def build_parser() -> ArgumentParser:
 
     from_lock = sub.add_parser(
         "from-lock",
+        aliases=["l"],
         parents=[render_parent],
         formatter_class=_Formatter,
         help="render the dependency tree from a PEP 751 pylock.toml (offline; no index/network needed)",
@@ -197,6 +206,7 @@ def build_parser() -> ArgumentParser:
         ),
     )
     from_lock.add_argument("lock", metavar="PYLOCK", help="path to a PEP 751 pylock.toml lock file")
+    from_lock.set_defaults(command="from-lock")
 
     # Bare ``pipdeptree`` does not visit the subparser, so seed defaults for its attributes to keep Options total. The
     # installed-only display options (license/metadata/computed) are not exposed on the subparsers, so seed them too:
@@ -300,6 +310,13 @@ def _add_render_arguments(parser: ArgumentParser) -> None:
             "packages that need them under them"
         ),
     )
+    parser.add_argument(
+        "--summary",
+        action="store_true",
+        default=False,
+        help="render a one-block health report of the tree instead of the tree itself; combine with -o text "
+        "(default), rich, or json. Composes with from-index/from-lock",
+    )
     render_type = parser.add_mutually_exclusive_group()
     render_type.add_argument(
         "-j",
@@ -385,24 +402,29 @@ def get_options(args: Sequence[str] | None) -> Options:
     )
     options.computed = [f.strip() for f in raw_computed.split(",") if f.strip()] if raw_computed else []
 
+    # ``parser.error`` is ``NoReturn`` (it raises ``SystemExit``), so these are terminal guards, not returns.
     if options.license:
         if "license" in options.metadata:
-            return parser.error("cannot use --license with --metadata license")
+            parser.error("cannot use --license with --metadata license")
         warnings.warn("--license is deprecated, use --metadata license instead", DeprecationWarning, stacklevel=1)
         options.metadata = ["license", *options.metadata]
 
     if invalid := set(options.computed) - ALLOWED_COMPUTED_FIELDS:
         allowed = ", ".join(sorted(ALLOWED_COMPUTED_FIELDS))
-        return parser.error(f"invalid --computed values: {', '.join(sorted(invalid))}. Allowed: {allowed}")
+        parser.error(f"invalid --computed values: {', '.join(sorted(invalid))}. Allowed: {allowed}")
 
     options.context = RenderContext(metadata=options.metadata, computed=options.computed)
 
+    if options.summary and options.output_format not in SUMMARY_RENDER_FORMATS:
+        allowed = ", ".join(sorted(SUMMARY_RENDER_FORMATS))
+        parser.error(f"--summary supports only -o {allowed} (got {options.output_format})")
+
     if options.command == "from-index" and not (options.requirement or options.requirements or options.pyproject):
-        return parser.error("from-index needs at least one REQUIREMENT, --requirements FILE, or --pyproject FILE")
+        parser.error("from-index needs at least one REQUIREMENT, --requirements FILE, or --pyproject FILE")
     if options.exclude_dependencies and not options.exclude:
-        return parser.error("must use --exclude-dependencies with --exclude")
+        parser.error("must use --exclude-dependencies with --exclude")
     if options.path and (options.local_only or options.user_only):
-        return parser.error("cannot use --path with --user-only or --local-only")
+        parser.error("cannot use --path with --user-only or --local-only")
 
     return options
 

--- a/src/pipdeptree/_computed.py
+++ b/src/pipdeptree/_computed.py
@@ -44,7 +44,7 @@ class ComputedValues:
 
     @cached_property
     def size(self) -> str:
-        return self._format_size(self.size_bytes) if self.size_bytes is not None else "0 B"
+        return self.format_size(self.size_bytes) if self.size_bytes is not None else "0 B"
 
     @cached_property
     def size_raw(self) -> int:
@@ -65,7 +65,7 @@ class ComputedValues:
             return 0
 
     @staticmethod
-    def _format_size(size_bytes: int) -> str:
+    def format_size(size_bytes: int) -> str:
         for unit in ("B", "KB", "MB", "GB"):
             if size_bytes < 1024 or unit == "GB":
                 return f"{size_bytes:.1f} {unit}" if unit != "B" else f"{size_bytes} B"
@@ -83,7 +83,7 @@ class ComputedValues:
     @cached_property
     def unique_deps_size(self) -> str:
         total = sum(ComputedValues(dep, self.tree, self.full_tree).size_raw for dep in self.unique_deps)
-        return self._format_size(total)
+        return self.format_size(total)
 
     @cached_property
     def unique_deps(self) -> set[str]:

--- a/src/pipdeptree/_render/__init__.py
+++ b/src/pipdeptree/_render/__init__.py
@@ -8,6 +8,7 @@ from .json import render_json
 from .json_tree import render_json_tree
 from .mermaid import render_mermaid
 from .rich_text import render_rich_text
+from .summary import render_summary
 from .text import render_text
 
 if TYPE_CHECKING:
@@ -21,7 +22,10 @@ def render(options: Options, tree: PackageDAG) -> None:
     # from-index/from-lock build a tree from resolved data: one version per package and no per-edge
     # range, so edges show "[candidate: <version>]" instead of "[required:, installed:]".
     mode: RenderMode = "resolved" if options.command in {"from-index", "from-lock"} else "default"
-    if output_format == "json":
+    # --summary reduces the tree to an aggregate report; output_format then only selects its presentation style.
+    if options.summary:
+        render_summary(tree, mode=mode, style=output_format)
+    elif output_format == "json":
         render_json(tree, context=options.context, mode=mode)
     elif output_format == "json-tree":
         render_json_tree(tree, context=options.context, mode=mode)

--- a/src/pipdeptree/_render/summary.py
+++ b/src/pipdeptree/_render/summary.py
@@ -1,0 +1,237 @@
+"""
+Render a single-block health summary of a dependency tree.
+
+The report has two tiers. Graph-structural metrics (counts, depth, cycles) derive purely from the DAG edges and are
+available for every command. The installed-environment tier (missing/conflicting deps, licenses, requires-python,
+size) reads real distribution metadata and on-disk files, which the ``from-index``/``from-lock`` synthetic trees do
+not carry; in that ``resolved`` mode those metrics are reported as unavailable rather than a misleading zero.
+
+The same computed metrics drive three presentation styles -- aligned ``text``, a ``rich`` table, and ``json`` -- plus
+an HTML table for notebook display, all built from the one shared row list.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from html import escape
+from itertools import chain
+from typing import TYPE_CHECKING
+
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.version import InvalidVersion, Version
+
+from pipdeptree._computed import ComputedValues
+from pipdeptree._models.package import Package
+from pipdeptree._validate import conflicting_deps, cyclic_deps
+
+if TYPE_CHECKING:
+    from pipdeptree._models import PackageDAG
+    from pipdeptree._models.package import RenderMode
+
+# Weak and strong copyleft families worth flagging for compliance review; matched case-insensitively as substrings.
+_COPYLEFT_MARKERS = ("AGPL", "LGPL", "GPL", "MPL", "EUPL", "CDDL")
+_RESOLVED_NOTE = "n/a (resolved from index/lock - package metadata unavailable)"
+
+
+@dataclass
+class _Summary:
+    total_packages: int
+    direct_dependencies: int
+    transitive_dependencies: int
+    max_depth: int
+    cyclic_dependencies: int
+    resolved: bool
+    missing_dependencies: int | None = None
+    conflicting_packages: int | None = None
+    conflicting_edges: int | None = None
+    licenses: dict[str, int] | None = None
+    unknown_licenses: int | None = None
+    copyleft_licenses: bool | None = None
+    min_requires_python: str | None = None
+    total_size: str | None = None
+    total_size_raw: int | None = None
+
+
+def render_summary(tree: PackageDAG, *, mode: RenderMode = "default", style: str = "text") -> None:
+    """
+    Print a one-block summary of the dependency tree.
+
+    :param tree: the package tree
+    :param mode: ``"resolved"`` (from-index/from-lock) drops the installed-environment metrics that synthetic
+        distributions cannot supply
+    :param style: presentation style -- ``"text"`` (aligned), ``"rich"`` (table) or ``"json"``
+    """
+    summary = _collect(tree, resolved=mode == "resolved")
+    if style == "json":
+        print(_as_json(summary))  # noqa: T201
+    elif style == "rich":
+        _as_rich(summary)
+    else:
+        print(_as_text(summary))  # noqa: T201
+
+
+def summary_html(tree: PackageDAG, *, mode: RenderMode = "default") -> str:
+    """Return the summary as an HTML ``<table>`` for notebook rich display."""
+    return _as_html(_collect(tree, resolved=mode == "resolved"))
+
+
+def _collect(tree: PackageDAG, *, resolved: bool) -> _Summary:
+    child_keys = {str(r.key) for r in chain.from_iterable(tree.values())}
+    total = len(tree)
+    direct = sum(1 for p in tree if p.key not in child_keys)
+    summary = _Summary(
+        total_packages=total,
+        direct_dependencies=direct,
+        transitive_dependencies=total - direct,
+        max_depth=_max_depth(tree, child_keys),
+        cyclic_dependencies=len(cyclic_deps(tree)),
+        resolved=resolved,
+    )
+    if resolved:
+        return summary
+
+    conflicts = conflicting_deps(tree)
+    licenses = _license_breakdown(tree)
+    total_bytes = sum(ComputedValues(p.key, tree).size_raw for p in tree)
+    summary.missing_dependencies = len({r.key for reqs in tree.values() for r in reqs if r.is_missing})
+    summary.conflicting_packages = len(conflicts)
+    summary.conflicting_edges = sum(len(reqs) for reqs in conflicts.values())
+    summary.licenses = licenses
+    summary.unknown_licenses = licenses.get(Package.UNKNOWN_LICENSE_STR, 0)
+    summary.copyleft_licenses = _has_copyleft(licenses)
+    summary.min_requires_python = _min_requires_python(tree)
+    summary.total_size = ComputedValues.format_size(total_bytes)
+    summary.total_size_raw = total_bytes
+    return summary
+
+
+def _max_depth(tree: PackageDAG, child_keys: set[str]) -> int:
+    # Longest dependency chain measured in packages. Start from roots (the longest simple path in a DAG always begins
+    # at one); if every node is inside a cycle there are no roots, so fall back to all nodes. The on-path guard keeps
+    # cyclic graphs from recursing forever and yields the longest *simple* path.
+    roots = [p.key for p in tree if p.key not in child_keys] or [p.key for p in tree]
+
+    def longest(key: str, on_path: frozenset[str]) -> int:
+        children = tree.get_children(key)
+        deeper = on_path | {key}
+        return 1 + max((longest(c.key, deeper) for c in children if c.key not in deeper), default=0)
+
+    return max((longest(root, frozenset()) for root in roots), default=0)
+
+
+def _license_breakdown(tree: PackageDAG) -> dict[str, int]:
+    return dict(sorted(Counter(pkg.licenses() for pkg in tree).items()))
+
+
+def _has_copyleft(licenses: dict[str, int]) -> bool:
+    return any(marker in label.upper() for label in licenses for marker in _COPYLEFT_MARKERS)
+
+
+def _min_requires_python(tree: PackageDAG) -> str:
+    floors: list[Version] = []
+    for pkg in tree:
+        raw = pkg.get_metadata("Requires-Python")
+        if not isinstance(raw, str) or raw == Package.NA:
+            continue
+        try:
+            specifier = SpecifierSet(raw)
+        except InvalidSpecifier:
+            continue
+        for spec in specifier:
+            if spec.operator in {">=", ">", "=="}:
+                try:
+                    floors.append(Version(spec.version))
+                except InvalidVersion:
+                    continue
+    return str(max(floors)) if floors else "n/a"
+
+
+def _rows(summary: _Summary) -> list[tuple[str, str]]:
+    rows = [
+        ("total packages", str(summary.total_packages)),
+        ("direct dependencies", str(summary.direct_dependencies)),
+        ("transitive dependencies", str(summary.transitive_dependencies)),
+        ("max depth", str(summary.max_depth)),
+        ("cyclic dependencies", str(summary.cyclic_dependencies)),
+    ]
+    if summary.resolved:
+        labels = ("missing dependencies", "conflicting dependencies", "licenses")
+        rows.extend((label, _RESOLVED_NOTE) for label in labels)
+        return rows
+    rows.extend([
+        ("missing dependencies", str(summary.missing_dependencies)),
+        ("conflicting dependencies", f"{summary.conflicting_packages} ({summary.conflicting_edges} edges)"),
+        ("licenses", _format_licenses(summary.licenses)),
+        ("unknown licenses", str(summary.unknown_licenses)),
+        ("copyleft licenses", "yes" if summary.copyleft_licenses else "no"),
+        ("min requires-python", str(summary.min_requires_python)),
+        ("total size", str(summary.total_size)),
+    ])
+    return rows
+
+
+def _format_licenses(licenses: dict[str, int] | None) -> str:
+    return ", ".join(f"{label}: {count}" for label, count in licenses.items()) if licenses else "none"
+
+
+def _as_text(summary: _Summary) -> str:
+    rows = _rows(summary)
+    width = max(len(label) for label, _ in rows)
+    return "\n".join(f"{label + ':':<{width + 1}} {value}" for label, value in rows)
+
+
+def _as_rich(summary: _Summary) -> None:
+    try:
+        from rich.console import Console  # noqa: PLC0415
+        from rich.table import Table  # noqa: PLC0415
+    except ImportError as exc:
+        print(  # noqa: T201
+            "rich is not available, but necessary for the output option. Please install it.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1) from exc
+
+    table = Table(title="environment summary", show_header=False, title_style="bold")
+    table.add_column("metric", style="bold cyan", no_wrap=True)
+    table.add_column("value")
+    for label, value in _rows(summary):
+        table.add_row(label, value, style="dim" if value == _RESOLVED_NOTE else None)
+    Console().print(table)
+
+
+def _as_html(summary: _Summary) -> str:
+    body = "".join(f"<tr><td>{escape(label)}</td><td>{escape(value)}</td></tr>" for label, value in _rows(summary))
+    return f"<table>\n<tr><th>metric</th><th>value</th></tr>\n{body}\n</table>"
+
+
+def _as_json(summary: _Summary) -> str:
+    data: dict[str, object] = {
+        "total_packages": summary.total_packages,
+        "direct_dependencies": summary.direct_dependencies,
+        "transitive_dependencies": summary.transitive_dependencies,
+        "max_depth": summary.max_depth,
+        "cyclic_dependencies": summary.cyclic_dependencies,
+    }
+    if not summary.resolved:
+        data.update(
+            missing_dependencies=summary.missing_dependencies,
+            conflicting_dependencies={"packages": summary.conflicting_packages, "edges": summary.conflicting_edges},
+            licenses={
+                "breakdown": summary.licenses,
+                "unknown": summary.unknown_licenses,
+                "copyleft": summary.copyleft_licenses,
+            },
+            min_requires_python=summary.min_requires_python,
+            total_size=summary.total_size,
+            total_size_raw=summary.total_size_raw,
+        )
+    return json.dumps(data, indent=2)
+
+
+__all__ = [
+    "render_summary",
+    "summary_html",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,6 +81,9 @@ class MockDistMaker(Protocol):
         version: str,
         requires: list[str] | None = None,
         provides_extras: list[str] | None = None,
+        *,
+        license_expression: str | None = None,
+        requires_python: list[str] | None = None,
     ) -> Distribution: ...
 
 
@@ -91,10 +94,14 @@ def make_mock_dist(mocker: MockerFixture) -> MockDistMaker:
         version: str,
         requires: list[str] | None = None,
         provides_extras: list[str] | None = None,
+        *,
+        license_expression: str | None = None,
+        requires_python: list[str] | None = None,
     ) -> Distribution:
         metadata = mocker.create_autospec(PackageMetadata, instance=True)
-        metadata.__getitem__.side_effect = {"Name": name}.get
-        metadata.get_all.side_effect = lambda key, failobj=None: provides_extras if key == "Provides-Extra" else failobj
+        metadata.__getitem__.side_effect = {"Name": name, "License-Expression": license_expression}.get
+        get_all = {"Provides-Extra": provides_extras, "Requires-Python": requires_python}
+        metadata.get_all.side_effect = lambda key, failobj=None: get_all.get(key, failobj)
         dist = mocker.create_autospec(Distribution, instance=True)
         dist.metadata = metadata
         dist.version = version

--- a/tests/render/test_candidate.py
+++ b/tests/render/test_candidate.py
@@ -16,6 +16,7 @@ def _options(*, command: str | None, output_format: str) -> Options:
     options = Options()
     options.command = command
     options.output_format = output_format
+    options.summary = False
     options.context = RenderContext()
     options.depth = float("inf")
     options.encoding = "utf-8"

--- a/tests/render/test_render.py
+++ b/tests/render/test_render.py
@@ -79,3 +79,17 @@ def test_rich_routing(option: list[str], mocker: MockerFixture) -> None:
     render = mocker.patch("pipdeptree._render.render_rich_text")
     main(option)
     render.assert_called_once_with(ANY, max_depth=inf, list_all=False, context=RenderContext(), mode="default")
+
+
+@pytest.mark.parametrize(
+    ("option", "style"),
+    [
+        pytest.param([], "text", id="default-style"),
+        pytest.param(["--output", "rich"], "rich", id="rich"),
+        pytest.param(["--output", "json"], "json", id="json"),
+    ],
+)
+def test_summary_routing(option: list[str], style: str, mocker: MockerFixture) -> None:
+    render = mocker.patch("pipdeptree._render.render_summary")
+    main(["--summary", *option])
+    render.assert_called_once_with(ANY, mode="default", style=style)

--- a/tests/render/test_summary.py
+++ b/tests/render/test_summary.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import json
+import sys
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from pipdeptree._computed import ComputedValues
+from pipdeptree._models.dag import PackageDAG
+from pipdeptree._render.summary import render_summary, summary_html
+from pipdeptree._synthetic_dist import SyntheticDistribution
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+    from importlib.metadata import Distribution
+    from unittest.mock import Mock
+
+    from pytest_mock import MockerFixture
+
+    from pipdeptree._models.package import RenderMode
+    from tests.conftest import MockDistMaker
+    from tests.our_types import MockGraph
+
+_RESOLVED_NOTE = "n/a (resolved from index/lock - package metadata unavailable)"
+
+
+@pytest.fixture
+def zero_size(mocker: MockerFixture) -> None:
+    # Summary totals stat real files via ComputedValues; pin the per-package size so the metrics stay deterministic.
+    mocker.patch.object(ComputedValues, "size_raw", 0)
+
+
+def _text_rows(out: str) -> dict[str, str]:
+    return {label.strip(): value.strip() for label, _, value in (line.partition(":") for line in out.splitlines())}
+
+
+def _summary_text(
+    dag: PackageDAG, capsys: pytest.CaptureFixture[str], *, mode: RenderMode = "default"
+) -> dict[str, str]:
+    render_summary(dag, mode=mode)
+    return _text_rows(capsys.readouterr().out)
+
+
+def _summary_json(
+    dag: PackageDAG, capsys: pytest.CaptureFixture[str], *, mode: RenderMode = "default"
+) -> dict[str, Any]:
+    render_summary(dag, mode=mode, style="json")
+    return json.loads(capsys.readouterr().out)
+
+
+@pytest.mark.parametrize(
+    ("graph", "expected"),
+    [
+        pytest.param(
+            {
+                ("a", "1.0.0"): [("b", [(">=", "2.0.0")]), ("c", [(">=", "1.0.0")])],
+                ("b", "2.0.0"): [("c", [(">=", "1.0.0")])],
+                ("c", "1.0.0"): [],
+            },
+            {"total_packages": 3, "direct_dependencies": 1, "transitive_dependencies": 2, "max_depth": 3},
+            id="chain",
+        ),
+        pytest.param(
+            {("a", "1.0.0"): [("b", [])], ("b", "1.0.0"): [("a", [])]},
+            {"total_packages": 2, "direct_dependencies": 0, "max_depth": 2, "cyclic_dependencies": 2},
+            id="cycle-terminates",
+        ),
+    ],
+)
+def test_structural_metrics(
+    graph: MockGraph,
+    expected: dict[str, int],
+    mock_pkgs: Callable[[MockGraph], Iterator[Mock]],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
+
+    data = _summary_json(dag, capsys, mode="resolved")
+
+    assert {key: data[key] for key in expected} == expected
+
+
+def test_resolved_json_drops_installed_tier(
+    mock_pkgs: Callable[[MockGraph], Iterator[Mock]], capsys: pytest.CaptureFixture[str]
+) -> None:
+    dag = PackageDAG.from_pkgs(list(mock_pkgs({("a", "1.0.0"): [("b", [])], ("b", "2.0.0"): []})))
+
+    assert _summary_json(dag, capsys, mode="resolved") == {
+        "total_packages": 2,
+        "direct_dependencies": 1,
+        "transitive_dependencies": 1,
+        "max_depth": 2,
+        "cyclic_dependencies": 0,
+    }
+
+
+def test_resolved_text_marks_metadata_unavailable(
+    mock_pkgs: Callable[[MockGraph], Iterator[Mock]], capsys: pytest.CaptureFixture[str]
+) -> None:
+    dag = PackageDAG.from_pkgs(list(mock_pkgs({("a", "1.0.0"): []})))
+
+    rows = _summary_text(dag, capsys, mode="resolved")
+
+    assert rows["licenses"] == _RESOLVED_NOTE
+    assert "total size" not in rows
+    assert "copyleft licenses" not in rows
+
+
+def test_empty_tree_json(capsys: pytest.CaptureFixture[str]) -> None:
+    data = _summary_json(PackageDAG({}), capsys)
+
+    assert data["total_packages"] == 0
+    assert data["max_depth"] == 0
+    assert data["licenses"]["breakdown"] == {}
+    assert data["total_size"] == "0 B"
+    assert data["min_requires_python"] == "n/a"
+
+
+def test_empty_tree_text(capsys: pytest.CaptureFixture[str]) -> None:
+    rows = _summary_text(PackageDAG({}), capsys)
+
+    assert rows["licenses"] == "none"
+    assert rows["copyleft licenses"] == "no"
+    assert rows["total size"] == "0 B"
+
+
+@pytest.mark.usefixtures("zero_size")
+@pytest.mark.parametrize(
+    ("build", "expected"),
+    [
+        pytest.param(
+            lambda m: [m("a", "1.0.0", requires=["b>=2.0.0", "absent-pkg-xyz"]), m("b", "1.0.0")],
+            {"conflicting_dependencies": {"packages": 1, "edges": 2}, "missing_dependencies": 1},
+            id="conflict-and-missing",
+        ),
+        pytest.param(
+            lambda m: [m("a", "1.0.0", license_expression="MIT"), m("b", "1.0.0")],
+            {"licenses": {"breakdown": {"(MIT)": 1, "(N/A)": 1}, "unknown": 1, "copyleft": False}},
+            id="license-breakdown",
+        ),
+        pytest.param(
+            lambda m: [m("a", "1.0.0", license_expression="GPL-3.0-or-later")],
+            {"licenses": {"breakdown": {"(GPL-3.0-or-later)": 1}, "unknown": 0, "copyleft": True}},
+            id="copyleft",
+        ),
+        pytest.param(
+            lambda m: [m("a", "1.0.0", requires_python=[">=3.8,<4.0"]), m("b", "1.0.0", requires_python=[">=3.10"])],
+            {"min_requires_python": "3.10"},
+            id="requires-python-floor",
+        ),
+        pytest.param(
+            lambda m: [
+                m("a", "1.0.0", requires_python=["garbage"]),
+                m("b", "1.0.0", requires_python=["==3.*"]),
+                m("c", "1.0.0", requires_python=[">=3.8", ">=3.9"]),
+            ],
+            {"min_requires_python": "n/a"},
+            id="requires-python-unparsable",
+        ),
+    ],
+)
+def test_default_metrics(
+    build: Callable[[MockDistMaker], list[Distribution]],
+    expected: dict[str, Any],
+    make_mock_dist: MockDistMaker,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    dag = PackageDAG.from_pkgs(build(make_mock_dist))
+
+    data = _summary_json(dag, capsys)
+
+    assert {key: data[key] for key in expected} == expected
+
+
+def test_default_size_total(
+    capsys: pytest.CaptureFixture[str], make_mock_dist: MockDistMaker, mocker: MockerFixture
+) -> None:
+    mocker.patch.object(ComputedValues, "size_raw", 512)
+    dag = PackageDAG.from_pkgs([make_mock_dist("a", "1.0.0"), make_mock_dist("b", "1.0.0")])
+
+    data = _summary_json(dag, capsys)
+
+    assert data["total_size_raw"] == 1024
+    assert data["total_size"] == "1.0 KB"
+
+
+@pytest.mark.usefixtures("zero_size")
+def test_default_text_tier(capsys: pytest.CaptureFixture[str], make_mock_dist: MockDistMaker) -> None:
+    dag = PackageDAG.from_pkgs([make_mock_dist("a", "1.0.0", license_expression="MIT")])
+
+    rows = _summary_text(dag, capsys)
+
+    assert rows["licenses"] == "(MIT): 1"
+    assert rows["conflicting dependencies"] == "0 (0 edges)"
+
+
+def test_from_lock_synthetic_tree(capsys: pytest.CaptureFixture[str]) -> None:
+    pkgs: list[Distribution] = [
+        SyntheticDistribution("a", "1.0.0", ("b==2.0.0",)),
+        SyntheticDistribution("b", "2.0.0", ()),
+    ]
+
+    rows = _summary_text(PackageDAG.from_pkgs(pkgs), capsys, mode="resolved")
+
+    assert rows["total packages"] == "2"
+    assert rows["max depth"] == "2"
+    assert rows["missing dependencies"] == _RESOLVED_NOTE
+
+
+@pytest.mark.usefixtures("zero_size")
+@pytest.mark.parametrize(
+    ("mode", "needle"),
+    [
+        pytest.param("default", "total packages", id="default"),
+        pytest.param("resolved", "n/a (resolved", id="resolved"),
+    ],
+)
+def test_rich_style(
+    mode: RenderMode, needle: str, make_mock_dist: MockDistMaker, capsys: pytest.CaptureFixture[str]
+) -> None:
+    dag = PackageDAG.from_pkgs([make_mock_dist("a", "1.0.0", requires=["b"]), make_mock_dist("b", "1.0.0")])
+
+    render_summary(dag, mode=mode, style="rich")
+
+    out = capsys.readouterr().out
+    assert "environment summary" in out
+    assert needle in out
+
+
+def test_rich_style_missing_import(mock_pkgs: Callable[[MockGraph], Iterator[Mock]], mocker: MockerFixture) -> None:
+    mocker.patch.dict(sys.modules, {"rich": None, "rich.console": None, "rich.table": None})
+    dag = PackageDAG.from_pkgs(list(mock_pkgs({("a", "1.0.0"): []})))
+
+    with pytest.raises(SystemExit) as exc_info:
+        render_summary(dag, mode="resolved", style="rich")
+
+    assert exc_info.value.code == 1
+
+
+def test_summary_html_table(mock_pkgs: Callable[[MockGraph], Iterator[Mock]]) -> None:
+    dag = PackageDAG.from_pkgs(list(mock_pkgs({("a", "1.0.0"): [("b", [])], ("b", "2.0.0"): []})))
+
+    html = summary_html(dag, mode="resolved")
+
+    assert html.startswith("<table>")
+    assert "<td>total packages</td><td>2</td>" in html

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,12 +6,20 @@ from typing import TYPE_CHECKING
 import pytest
 
 import pipdeptree
-from pipdeptree import _RenderResult
+from pipdeptree import _RenderResult, _SummaryResult
+from pipdeptree._computed import ComputedValues
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
     from tests.conftest import MockDistMaker
+
+
+@pytest.fixture
+def patched_env_no_size(patched_env: None, mocker: MockerFixture) -> None:  # noqa: ARG001
+    # Summary reads on-disk size via ComputedValues, which would look the mocked packages up in the real
+    # environment; pin it so the summary metrics stay deterministic.
+    mocker.patch.object(ComputedValues, "size_raw", 0)
 
 
 @pytest.fixture
@@ -160,6 +168,44 @@ def test_render_warnings_do_not_leak_by_default(
     )
     pipdeptree.render()
     assert not capsys.readouterr().err
+
+
+@pytest.mark.usefixtures("patched_env_no_size")
+def test_render_summary_text_has_html_mimebundle() -> None:
+    out = pipdeptree.render(summary=True)
+    assert isinstance(out, _SummaryResult)
+    assert out.startswith("total packages:")
+    bundle = out._repr_mimebundle_()
+    assert set(bundle) == {"text/html", "text/plain"}
+    assert bundle["text/html"].startswith("<table>")
+    assert bundle["text/plain"] == str(out)
+
+
+@pytest.mark.usefixtures("patched_env_no_size")
+def test_render_summary_text_mimebundle_respects_include() -> None:
+    out = pipdeptree.render(summary=True)
+    assert isinstance(out, _SummaryResult)
+    assert set(out._repr_mimebundle_(include={"text/plain"})) == {"text/plain"}
+
+
+@pytest.mark.usefixtures("patched_env_no_size")
+def test_render_summary_json_is_plain_str() -> None:
+    out = pipdeptree.render(summary=True, output_format="json")
+    assert not hasattr(out, "_repr_mimebundle_")
+    assert json.loads(out)["total_packages"] == 2
+
+
+@pytest.mark.usefixtures("patched_env_no_size")
+def test_render_summary_rich_is_plain_str() -> None:
+    out = pipdeptree.render(summary=True, output_format="rich")
+    assert not hasattr(out, "_repr_mimebundle_")
+    assert "environment summary" in out
+
+
+@pytest.mark.usefixtures("patched_env")
+def test_render_summary_rejects_tree_format() -> None:
+    with pytest.raises(ValueError, match="summary output_format must be one of"):
+        pipdeptree.render(summary=True, output_format="mermaid")
 
 
 @pytest.mark.usefixtures("patched_env")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -56,6 +56,34 @@ def test_get_options_output_format_that_does_not_exist(capsys: pytest.CaptureFix
     assert 'i-dont-exist" is not a known output format.' in err
 
 
+@pytest.mark.parametrize("fmt", ["text", "rich", "json"])
+def test_get_options_summary_allows_styles(fmt: str) -> None:
+    options = get_options(["--summary", "-o", fmt])
+    assert options.summary
+    assert options.output_format == fmt
+
+
+def test_get_options_summary_default_text() -> None:
+    options = get_options(["--summary"])
+    assert options.summary
+    assert options.output_format == "text"
+
+
+@pytest.mark.parametrize("fmt", ["mermaid", "json-tree", "freeze", "graphviz-png"])
+def test_get_options_summary_rejects_tree_formats(fmt: str, capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit, match="2"):
+        get_options(["--summary", "-o", fmt])
+
+    assert "--summary supports only -o json, rich, text" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(("alias", "canonical"), [("i", "from-index"), ("l", "from-lock")])
+def test_get_options_subcommand_aliases(alias: str, canonical: str) -> None:
+    args = [alias, "req"] if canonical == "from-index" else [alias, "pylock.toml"]
+    options = get_options(args)
+    assert options.command == canonical
+
+
 def test_get_options_license_deprecated() -> None:
     with pytest.warns(DeprecationWarning, match="--license is deprecated"):
         options = get_options(["--license"])


### PR DESCRIPTION
A pip environment offers no quick read of its overall health. Finding out how many packages are installed, how deep the tree runs, whether anything conflicts or cycles, which licenses are present, and how much disk it all takes meant scanning the full tree by eye or scripting against the JSON dump. 📊 This adds a `--summary` flag that condenses any tree into one block of those metrics, aimed at CI gates and at-a-glance audits.

The design keeps two axes separate: `--summary` chooses *what* to produce while `-o` chooses *how* to style it. The same report therefore renders as aligned text, a `rich` table, or machine-readable JSON, and the programmatic `render(summary=True)` displays it as an HTML table in a notebook. ✨ Because it is a flag rather than an output format, it composes with the existing tree sources, so `from-index` and `from-lock` can be summarized as well. The metrics split into two tiers: graph-structural ones (counts, depth, cycles) work everywhere, while installed-environment ones (missing/conflicting deps, licenses, `requires-python`, size) read real distribution metadata and report `n/a` under the resolved sources rather than a misleading zero. Tree-only renderers (mermaid, graphviz, freeze, json-tree) are rejected since they cannot present a flat report.

This also introduces short aliases `i` and `l` for the `from-index` and `from-lock` subcommands, normalizing the recorded command back to its canonical name so existing dispatch is unaffected. No existing output is changed; `--summary` is purely additive.


Closes #596.
