### PR TITLE
ci: Test against pypy-3.11

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         env:
-          - "pypy-3.10"
+          - "pypy-3.11"
           - "3.14"
           - "3.13"
           - "3.12"


### PR DESCRIPTION
I think we'll start testing against the latest python version that pypy can support.