### PR TITLE
Validate archive hash parts

### DIFF
--- a/src/pipdeptree/_parser/direct_url.py
+++ b/src/pipdeptree/_parser/direct_url.py
@@ -119,7 +119,8 @@ def _parse_archive_info(archive_data: dict) -> ArchiveInfo:
         if not isinstance(hash_value, str):
             msg = "archive_info.hash must be a string"
             raise DirectUrlValidationError(msg)
-        if "=" not in hash_value or len(hash_value.split("=", 1)) != 2:
+        algo, _, digest = hash_value.partition("=")
+        if not algo or not digest:
             msg = f"invalid archive_info.hash format: {hash_value!r}"
             raise DirectUrlValidationError(msg)
     hashes: dict[str, str] = {}
@@ -129,7 +130,7 @@ def _parse_archive_info(archive_data: dict) -> ArchiveInfo:
             raise DirectUrlValidationError(msg)
         hashes = {str(k): str(v) for k, v in raw_hashes.items()}
     if not hashes and hash_value:
-        algo, digest = hash_value.split("=", 1)
+        algo, _, digest = hash_value.partition("=")
         hashes = {algo: digest}
     return ArchiveInfo(hash=hash_value, hashes=hashes)
 

--- a/tests/_parser/test_direct_url.py
+++ b/tests/_parser/test_direct_url.py
@@ -205,6 +205,16 @@ def test_parse_direct_url_json(json_data: dict, check_fn: Callable[[DirectUrl], 
             id="hash-invalid-format",
         ),
         pytest.param(
+            '{"url": "https://example.com", "archive_info": {"hash": "=abc123"}}',
+            "invalid archive_info.hash format",
+            id="hash-missing-algorithm",
+        ),
+        pytest.param(
+            '{"url": "https://example.com", "archive_info": {"hash": "sha256="}}',
+            "invalid archive_info.hash format",
+            id="hash-missing-digest",
+        ),
+        pytest.param(
             '{"url": "https://example.com", "archive_info": {"hashes": "not-a-dict"}}',
             "archive_info.hashes must be a dict",
             id="hashes-not-dict",


### PR DESCRIPTION
## What changed

This validates both sides of legacy `archive_info.hash` values from `direct_url.json`.

Values such as `=abc123` and `sha256=` are now rejected as invalid instead of producing an `ArchiveInfo.hashes` entry with an empty algorithm or digest.

## Why

PEP 610's legacy `archive_info.hash` is a `name=value` string. Accepting an empty hash name or empty digest can leak malformed install metadata into `pipdeptree`'s direct URL formatting path instead of treating it as invalid metadata.

## Validation

- `python -m pip install -e .`
- `python -m pytest tests\_parser\test_direct_url.py -q` -> 54 passed
- `python -m ruff check src\pipdeptree\_parser\direct_url.py tests\_parser\test_direct_url.py`
- `python -m ruff format --check src\pipdeptree\_parser\direct_url.py tests\_parser\test_direct_url.py`
- `git diff --check`

I also tried `python -m pytest tests\_parser -q`; it gets past the direct_url tests but this Windows environment is missing the `fp` fixture used by the VCS parser tests and has existing POSIX path expectations in editable-format tests, so I kept the validation scoped to the parser module touched here.