### PR TITLE
⚡ perf: cut startup and graph costs

### DIFF
--- a/src/pipdeptree/__init__.py
+++ b/src/pipdeptree/__init__.py
@@ -22,13 +22,7 @@ import io
 from contextlib import redirect_stdout
 from html import escape
 from math import inf
-from typing import TYPE_CHECKING
-
-from pipdeptree import _render
-from pipdeptree.__main__ import _FilterError, build_tree
-from pipdeptree._cli import SUMMARY_RENDER_FORMATS, get_options
-from pipdeptree._render.summary import summary_html
-from pipdeptree._warning import WarningType, get_warning_printer
+from typing import TYPE_CHECKING, Final
 
 from .version import __version__
 
@@ -40,8 +34,8 @@ if TYPE_CHECKING:
 
 __all__ = ["__version__", "render"]
 
-_BINARY_GRAPHVIZ_FORMATS = frozenset({"png", "svg", "pdf", "jpeg", "jpg", "gif", "bmp", "ps"})
-_FORMAT_FLAGS: dict[str, list[str]] = {
+_BINARY_GRAPHVIZ_FORMATS: Final[frozenset[str]] = frozenset({"png", "svg", "pdf", "jpeg", "jpg", "gif", "bmp", "ps"})
+_FORMAT_FLAGS: Final[dict[str, list[str]]] = {
     "text": [],
     "json": ["--json"],
     "json-tree": ["--json-tree"],
@@ -94,6 +88,13 @@ def render(  # noqa: PLR0913
     ``json-tree``, ``mermaid``, ``dot``) return a plain :class:`str` with no rich display, so their source/JSON shows
     as-is.
     """
+    from pipdeptree.__main__ import _FilterError, build_tree  # noqa: PLC0415  # Keep package import lightweight.
+    from pipdeptree._cli import SUMMARY_RENDER_FORMATS, get_options  # noqa: PLC0415  # Keep package import lightweight.
+    from pipdeptree._warning import (  # noqa: PLC0415  # Keep package import lightweight.
+        WarningType,
+        get_warning_printer,
+    )
+
     if summary and output_format not in SUMMARY_RENDER_FORMATS:
         allowed = ", ".join(sorted(SUMMARY_RENDER_FORMATS))
         msg = f"summary output_format must be one of {allowed}; got {output_format!r}"
@@ -134,6 +135,8 @@ def render(  # noqa: PLR0913
 def _finalize(text: str, *, argv: list[str], tree: PackageDAG, output_format: str, summary: bool) -> str:
     if summary:
         # The aggregate report has no tree diagram; the text style instead displays as an HTML table in a notebook.
+        from pipdeptree._render.summary import summary_html  # noqa: PLC0415  # Summary is optional.
+
         return _SummaryResult(text, html=summary_html(tree)) if output_format == "text" else text
     if output_format != "text":
         # Non-text formats (JSON, Mermaid source, Graphviz source) are returned as plain strings so they display
@@ -141,12 +144,16 @@ def _finalize(text: str, *, argv: list[str], tree: PackageDAG, output_format: st
         return text
 
     # Reuse the already-discovered tree to also produce a Mermaid diagram for the rich notebook display.
+    from pipdeptree._cli import get_options  # noqa: PLC0415  # Programmatic rendering is optional.
+
     mermaid_options = get_options([*argv, "--mermaid"])
     mermaid = _render_to_str(mermaid_options, tree)
     return _RenderResult(text, mermaid=mermaid)
 
 
 def _render_to_str(options: Options, tree: PackageDAG) -> str:
+    from pipdeptree import _render  # noqa: PLC0415  # Programmatic rendering is optional.
+
     buffer = io.StringIO()
     with redirect_stdout(buffer):
         _render.render(options, tree)

--- a/src/pipdeptree/__main__.py
+++ b/src/pipdeptree/__main__.py
@@ -3,24 +3,20 @@
 from __future__ import annotations
 
 import sys
-from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
-from pipdeptree._cli import Options, get_options, parse_packages
-from pipdeptree._detect_env import detect_active_interpreter, find_active_interpreter
-from pipdeptree._discovery import InterpreterQueryError, get_installed_distributions
-from pipdeptree._from_index import FromIndexInputError, FromIndexUnavailableError, resolve_from_index
-from pipdeptree._from_lock import FromLockError, load_lock
-from pipdeptree._models import PackageDAG
-from pipdeptree._models.dag import IncludeExcludeOverlapError, IncludePatternNotFoundError
-from pipdeptree._render import render
-from pipdeptree._validate import validate
-from pipdeptree._warning import WarningPrinter, WarningType, get_warning_printer
+from pipdeptree._cli import get_options, parse_packages
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from importlib.metadata import Distribution
 
-_OVERLAP_MESSAGE = "Cannot have --packages and --exclude contain the same entries"
+    from pipdeptree._cli import Options
+    from pipdeptree._models import PackageDAG
+    from pipdeptree._models.package import DistributionInfo
+    from pipdeptree._warning import WarningPrinter
+
+_OVERLAP_MESSAGE: Final[str] = "Cannot have --packages and --exclude contain the same entries"
 
 
 class _FilterError(Exception):
@@ -35,6 +31,31 @@ def main(args: Sequence[str] | None = None) -> int | None:
     """CLI - The main function called as entry point."""
     options = get_options(args)
 
+    from pipdeptree._render import render  # noqa: PLC0415  # Help and version exit before graph imports.
+    from pipdeptree._warning import (  # noqa: PLC0415  # Help and version exit before graph imports.
+        WarningType,
+        get_warning_printer,
+    )
+
+    if options.command == "from-index":
+        from pipdeptree._from_index import (  # noqa: PLC0415  # The index resolver is optional.
+            FromIndexInputError,
+            FromIndexUnavailableError,
+        )
+
+        build_errors: tuple[type[Exception], ...] = (FromIndexUnavailableError, FromIndexInputError)
+        error_prefix = ""
+    elif options.command == "from-lock":
+        from pipdeptree._from_lock import FromLockError  # noqa: PLC0415  # Lock parsing is optional.
+
+        build_errors = (FromLockError,)
+        error_prefix = ""
+    else:
+        from pipdeptree._discovery import InterpreterQueryError  # noqa: PLC0415  # Environment discovery is optional.
+
+        build_errors = (InterpreterQueryError,)
+        error_prefix = "Failed to query custom interpreter: "
+
     # Warnings are only enabled when using text output.
     if not _is_text_output(options):
         options.warn = "silence"
@@ -43,18 +64,15 @@ def main(args: Sequence[str] | None = None) -> int | None:
 
     try:
         tree = build_tree(options, log_resolved=True)
-    except InterpreterQueryError as e:
-        print(f"Failed to query custom interpreter: {e}", file=sys.stderr)  # noqa: T201
+    except build_errors as error:
+        print(f"{error_prefix}{error}", file=sys.stderr)  # noqa: T201
         return 1
-    except (FromIndexUnavailableError, FromIndexInputError, FromLockError) as e:
-        print(str(e), file=sys.stderr)  # noqa: T201
-        return 1
-    except _FilterError as e:
-        if e.is_fatal:
-            print(str(e), file=sys.stderr)  # noqa: T201
+    except _FilterError as error:
+        if error.is_fatal:
+            print(str(error), file=sys.stderr)  # noqa: T201
             return 1
         if warning_printer.should_warn():
-            warning_printer.print_single_line(str(e))
+            warning_printer.print_single_line(str(error))
         return _determine_return_code(warning_printer)
 
     render(options, tree)
@@ -74,6 +92,14 @@ def build_tree(options: Options, *, log_resolved: bool = False) -> PackageDAG:
     :raises FromLockError: if a from-lock file is missing or is not a valid PEP 751 lock
     :raises _FilterError: if the include/exclude filter cannot be satisfied
     """
+    from pipdeptree._models import PackageDAG  # noqa: PLC0415  # Help and version do not build a graph.
+    from pipdeptree._models.dag import (  # noqa: PLC0415  # Help and version do not build a graph.
+        IncludeExcludeOverlapError,
+        IncludePatternNotFoundError,
+    )
+    from pipdeptree._validate import validate  # noqa: PLC0415  # Help and version do not validate a graph.
+
+    distribution_info = {}
     if options.command == "from-index":
         # from-index resolves requirements by querying the package index instead of inspecting an installed
         # environment, so interpreter resolution is skipped entirely.
@@ -85,6 +111,10 @@ def build_tree(options: Options, *, log_resolved: bool = False) -> PackageDAG:
             extra_index_url=options.extra_index_url,
         )
     elif options.command == "from-lock":
+        from pathlib import Path  # noqa: PLC0415  # Lock parsing is optional.
+
+        from pipdeptree._from_lock import load_lock  # noqa: PLC0415  # Lock parsing is optional.
+
         # A PEP 751 lock is already resolved, so it is read straight off disk -- no interpreter, network, or index.
         pkgs = load_lock(Path(options.lock))  # ty: ignore[invalid-argument-type]
     else:
@@ -94,10 +124,16 @@ def build_tree(options: Options, *, log_resolved: bool = False) -> PackageDAG:
             supplied_paths=options.path or None,
             local_only=options.local_only,
             user_only=options.user_only,
+            distribution_info=distribution_info,
         )
 
     include, requested_extras = parse_packages(options.packages)
-    tree = PackageDAG.from_pkgs(pkgs, extras=options.extras, requested_extras=requested_extras)
+    tree = PackageDAG.from_pkgs(
+        pkgs,
+        extras=options.extras,
+        requested_extras=requested_extras,
+        distribution_info=distribution_info,
+    )
 
     validate(tree)
 
@@ -138,6 +174,59 @@ def _resolve_python(python: str | None, *, log_resolved: bool = False) -> str:
             print(f"(resolved python: {resolved_path})", file=sys.stderr)  # noqa: T201
         return resolved_path
     return python
+
+
+def get_installed_distributions(
+    interpreter: str = sys.executable or "",
+    supplied_paths: list[str] | None = None,
+    local_only: bool = False,  # noqa: FBT001, FBT002
+    user_only: bool = False,  # noqa: FBT001, FBT002
+    distribution_info: dict[int, DistributionInfo] | None = None,
+) -> list[Distribution]:
+    """Defer environment discovery imports until a command needs an installed tree."""
+    from pipdeptree._discovery import (  # noqa: PLC0415  # Environment discovery is optional.
+        get_installed_distributions as discover,
+    )
+
+    return discover(interpreter, supplied_paths, local_only, user_only, distribution_info)
+
+
+def resolve_from_index(
+    *,
+    requirements: list[str],
+    requirement_files: list[str],
+    pyproject_files: list[str],
+    index_url: str | None = None,
+    extra_index_url: list[str] | None = None,
+) -> list[Distribution]:
+    """Defer index resolver imports until the from-index command runs."""
+    from pipdeptree._from_index import resolve_from_index as resolve  # noqa: PLC0415  # The index resolver is optional.
+
+    return resolve(
+        requirements=requirements,
+        requirement_files=requirement_files,
+        pyproject_files=pyproject_files,
+        index_url=index_url,
+        extra_index_url=extra_index_url,
+    )
+
+
+def find_active_interpreter() -> str | None:
+    """Defer interpreter detection until an installed environment needs inspection."""
+    from pipdeptree._detect_env import (  # noqa: PLC0415  # Resolved sources do not inspect an interpreter.
+        find_active_interpreter as find,
+    )
+
+    return find()
+
+
+def detect_active_interpreter() -> str:
+    """Defer strict interpreter detection until the user requests it."""
+    from pipdeptree._detect_env import (  # noqa: PLC0415  # Resolved sources do not inspect an interpreter.
+        detect_active_interpreter as detect,
+    )
+
+    return detect()
 
 
 def _is_text_output(options: Options) -> bool:

--- a/src/pipdeptree/_cli.py
+++ b/src/pipdeptree/_cli.py
@@ -4,17 +4,16 @@ import sys
 import warnings
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, ArgumentTypeError, Namespace
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, cast, get_args
-
-from pipdeptree._computed import ComputedValues
-from pipdeptree._models.dag import ExtrasMode
+from typing import TYPE_CHECKING, cast
 
 from .version import __version__
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from pipdeptree._computed import ComputedValues
     from pipdeptree._models import PackageDAG
+    from pipdeptree._models.dag import ExtrasMode
 
 
 class Options(Namespace):
@@ -58,6 +57,12 @@ class RenderContext:
     metadata: list[str] = field(default_factory=list)
     computed: list[str] = field(default_factory=list)
     full_tree: PackageDAG | None = field(default=None, repr=False, compare=False)
+    _computed_cache: dict[tuple[int, int, str], ComputedValues] = field(
+        default_factory=dict,
+        init=False,
+        repr=False,
+        compare=False,
+    )
 
     @property
     def active(self) -> bool:
@@ -70,14 +75,23 @@ class RenderContext:
         if self.metadata:
             parts.extend(self._get_metadata_label_parts(key, self.metadata, tree))
         if self.computed:
-            computed = ComputedValues(key, tree, self.full_tree)
-            for field_key, field_value in computed.as_dict(self.computed).items():
+            for field_key, field_value in self.get_computed_values(key, tree).as_dict(self.computed).items():
                 parts.append(f"{field_key}: {field_value}")
         return separator.join(parts)
 
+    def get_computed_values(self, key: str, tree: PackageDAG) -> ComputedValues:
+        from pipdeptree._computed import ComputedValues  # noqa: PLC0415  # Computed fields are optional.
+
+        cache_key = (id(tree), id(self.full_tree), key)
+        if (computed := self._computed_cache.get(cache_key)) is None:
+            computed = self._computed_cache[cache_key] = ComputedValues(key, tree, self.full_tree)
+        return computed
+
     def with_metadata(self, metadata: list[str]) -> RenderContext:
         """Return a copy with a different metadata field list."""
-        return RenderContext(metadata=metadata, computed=self.computed, full_tree=self.full_tree)
+        context = RenderContext(metadata=metadata, computed=self.computed, full_tree=self.full_tree)
+        context._computed_cache = self._computed_cache
+        return context
 
     @staticmethod
     def _get_metadata_label_parts(key: str, fields: list[str], tree: PackageDAG) -> list[str]:
@@ -271,7 +285,7 @@ def _add_render_arguments(parser: ArgumentParser) -> None:
         "--extras",
         nargs="?",
         const="explicit",
-        choices=get_args(ExtrasMode),
+        choices=("none", "explicit", "active"),
         default="explicit",
         help=(
             "which optional (extras) dependencies to include: 'explicit' (default) shows extras requested via "

--- a/src/pipdeptree/_computed.py
+++ b/src/pipdeptree/_computed.py
@@ -88,30 +88,20 @@ class ComputedValues:
     @cached_property
     def unique_deps(self) -> set[str]:
         tree = self.full_tree or self.tree
-        own_deps = self._transitive_deps(self.key, tree)
         removed = {self.key}
-        changed = True
-        while changed:
-            changed = False
-            reachable: set[str] = set()
-            for pkg in tree:
-                if pkg.key not in removed:
-                    reachable |= self._transitive_deps(pkg.key, tree, exclude=removed)
-            if newly_orphaned := own_deps - reachable - removed:
-                removed |= newly_orphaned
-                changed = True
-        return removed - {self.key}
+        parent_counts: dict[str, int] = {}
+        for dependencies in tree.values():
+            for dependency in dependencies:
+                parent_counts[dependency.key] = parent_counts.get(dependency.key, 0) + 1
 
-    @staticmethod
-    def _transitive_deps(key: str, tree: PackageDAG, exclude: set[str] | None = None) -> set[str]:
-        result: set[str] = set()
-        excluded = exclude or set()
-        stack = [c.key for c in tree.get_children(key) if c.key not in excluded]
+        stack = [self.key]
         while stack:
-            if (dep := stack.pop()) not in result:
-                result.add(dep)
-                stack.extend(c.key for c in tree.get_children(dep) if c.key not in excluded)
-        return result
+            for dependency in tree.get_children(stack.pop()):
+                parent_counts[dependency.key] -= 1
+                if parent_counts[dependency.key] == 0 and dependency.key not in removed:
+                    removed.add(dependency.key)
+                    stack.append(dependency.key)
+        return removed - {self.key}
 
 
 __all__ = [

--- a/src/pipdeptree/_discovery.py
+++ b/src/pipdeptree/_discovery.py
@@ -12,6 +12,8 @@ from packaging.utils import canonicalize_name
 
 from pipdeptree._warning import get_warning_printer
 
+from ._models.package import DistributionInfo
+
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
@@ -25,6 +27,7 @@ def get_installed_distributions(
     supplied_paths: list[str] | None = None,
     local_only: bool = False,  # noqa: FBT001, FBT002
     user_only: bool = False,  # noqa: FBT001, FBT002
+    distribution_info: dict[int, DistributionInfo] | None = None,
 ) -> list[Distribution]:
     """
     Return the distributions installed in the interpreter's environment.
@@ -46,7 +49,7 @@ def get_installed_distributions(
     if user_only:
         computed_paths = [p for p in computed_paths if p.startswith(site.getusersitepackages())]
 
-    return filter_valid_distributions(distributions(path=computed_paths))
+    return filter_valid_distributions(distributions(path=computed_paths), distribution_info)
 
 
 def query_interpreter_for_paths(interpreter: str, *, local_only: bool = False) -> list[str]:
@@ -70,7 +73,9 @@ def query_interpreter_for_paths(interpreter: str, *, local_only: bool = False) -
         raise InterpreterQueryError(str(e)) from e
 
 
-def filter_valid_distributions(iterable_dists: Iterable[Distribution]) -> list[Distribution]:
+def filter_valid_distributions(
+    iterable_dists: Iterable[Distribution], distribution_info: dict[int, DistributionInfo] | None = None
+) -> list[Distribution]:
     warning_printer = get_warning_printer()
 
     # Since importlib.metadata.distributions() can return duplicate packages, we need to handle this. pip's approach is
@@ -86,11 +91,23 @@ def filter_valid_distributions(iterable_dists: Iterable[Distribution]) -> list[D
 
     dists = []
     for dist in iterable_dists:
-        if not has_valid_metadata(dist):
+        try:
+            dist_metadata = dist.metadata
+            valid = "Name" in dist_metadata
+        except (TypeError, FileNotFoundError):
+            valid = False
+        if not valid:
             site_dir = str(dist.locate_file(""))
             site_dir_with_invalid_metadata.add(site_dir)
             continue
-        normalized_name = canonicalize_name(dist.metadata["Name"])
+        if distribution_info is not None:
+            distribution_info[id(dist)] = DistributionInfo(
+                name=dist_metadata["Name"],
+                version=dist_metadata["Version"],
+                requires=tuple(dist_metadata.get_all("Requires-Dist") or ()),
+                provides_extras=tuple(dist_metadata.get_all("Provides-Extra") or ()),
+            )
+        normalized_name = canonicalize_name(dist_metadata["Name"])
         if normalized_name not in seen_dists:
             seen_dists[normalized_name] = dist
             dists.append(dist)

--- a/src/pipdeptree/_models/dag.py
+++ b/src/pipdeptree/_models/dag.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
 
     from packaging.requirements import Requirement
 
+    from .package import DistributionInfo
+
 
 from pipdeptree._warning import get_warning_printer
 
@@ -62,9 +64,12 @@ class PackageDAG(Mapping[DistPackage, list[ReqPackage]]):
         *,
         extras: ExtrasMode = "none",
         requested_extras: Mapping[str, set[str]] | None = None,
+        distribution_info: Mapping[int, DistributionInfo] | None = None,
     ) -> PackageDAG:
         warning_printer = get_warning_printer()
-        dist_pkgs = [DistPackage(p) for p in pkgs]
+        dist_pkgs = [
+            DistPackage(p, dist_info=distribution_info.get(id(p)) if distribution_info else None) for p in pkgs
+        ]
         idx: dict[str, DistPackage] = {p.key: p for p in dist_pkgs}
         pkg_deps: dict[DistPackage, list[ReqPackage]] = {}
         dist_name_to_invalid_reqs_dict: dict[str, list[str]] = {}

--- a/src/pipdeptree/_models/package.py
+++ b/src/pipdeptree/_models/package.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from copy import copy
+from dataclasses import dataclass
+from email.message import Message
 from functools import cached_property
 from importlib import import_module
 from importlib.metadata import Distribution, PackageMetadata, PackageNotFoundError, metadata, version
@@ -16,6 +19,14 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
 RenderMode = Literal["default", "resolved"]
+
+
+@dataclass(frozen=True, slots=True)
+class DistributionInfo:
+    name: str
+    version: str | None
+    requires: tuple[str, ...]
+    provides_extras: tuple[str, ...]
 
 
 class InvalidRequirementError(ValueError):
@@ -127,20 +138,50 @@ class DistPackage(Package):
 
     """
 
-    def __init__(self, obj: Distribution, req: ReqPackage | None = None) -> None:
-        super().__init__(obj.metadata["Name"])
+    def __init__(
+        self,
+        obj: Distribution,
+        req: ReqPackage | None = None,
+        *,
+        dist_info: DistributionInfo | None = None,
+    ) -> None:
         self._obj = obj
         self.req = req
+        if dist_info is None:
+            dist_metadata = obj.metadata
+            super().__init__(dist_metadata["Name"])
+            self._raw_requires = (
+                dist_metadata.get_all("Requires-Dist") if isinstance(dist_metadata, Message) else obj.requires
+            )
+            self._provides_extras = frozenset(
+                get_all("Provides-Extra") or () if (get_all := getattr(dist_metadata, "get_all", None)) else ()
+            )
+            try:
+                metadata_version = dist_metadata["Version"]
+            except KeyError:
+                metadata_version = None
+            self._version = str(metadata_version) if metadata_version else obj.version
+        else:
+            super().__init__(dist_info.name)
+            self._raw_requires = dist_info.requires
+            self._provides_extras = frozenset(dist_info.provides_extras)
+            self._version = dist_info.version or obj.version
+
+    @cached_property
+    def _loaded_metadata(self) -> PackageMetadata:
+        return self._obj.metadata
 
     def _get_dist_metadata(self) -> PackageMetadata:
-        return self._obj.metadata
+        return self._loaded_metadata
 
     @cached_property
     def _parsed_requires(self) -> list[Requirement | str]:
         # Shared between requires() and _extras_index so PEP 508 parsing happens at most once per
         # raw entry. str entries preserve the raw text of invalid requirements so requires() can
         # still surface them via InvalidRequirementError, matching the original semantics.
-        return [_try_parse_requirement(raw_req) for raw_req in self._obj.requires or []]
+        result = [_try_parse_requirement(raw_req) for raw_req in self._raw_requires or []]
+        del self._raw_requires
+        return result
 
     def requires(self) -> Iterator[Requirement]:
         """
@@ -156,9 +197,9 @@ class DistPackage(Package):
                 # reqs from this mandatory-only iterator.
                 yield entry
 
-    @cached_property
+    @property
     def provides_extras(self) -> frozenset[str]:
-        return frozenset(self._obj.metadata.get_all("Provides-Extra") or ())
+        return self._provides_extras
 
     @cached_property
     def _extras_index(self) -> list[tuple[Requirement, list[str], str]]:
@@ -187,12 +228,12 @@ class DistPackage(Package):
                     yield req, extra, dep_key
                     break
 
-    @cached_property
+    @property
     def version(self) -> str:
         # Cached because each access reparses the METADATA file on the underlying Distribution and
         # the renderer reads it once per occurrence in the tree (tens of thousands of times for
         # large environments under --extras).
-        return self._obj.version
+        return self._version
 
     def unwrap(self) -> Distribution:
         """Exposes the internal `importlib.metadata.Distribution` object."""
@@ -233,7 +274,9 @@ class DistPackage(Package):
         """
         if req is None and self.req is None:
             return self
-        return self.__class__(self._obj, req)
+        result = copy(self)
+        result.req = req
+        return result
 
     @property
     def edge_label(self) -> str:
@@ -293,12 +336,12 @@ class ReqPackage(Package):
             return f"{self.project_name} [required: {req_ver}, installed: {self.installed_version}{extra_str}]"
         return self.render_as_root(frozen=frozen)
 
-    @property
+    @cached_property
     def version_spec(self) -> str | None:
         specs = sorted(map(str, self._obj.specifier), reverse=True)  # `reverse` makes '>' prior to '<'
         return ",".join(specs) if specs else None
 
-    @property
+    @cached_property
     def requested_extras(self) -> frozenset[str]:
         """Extras the requiring package asked for on this edge (e.g. ``urllib3[socks]`` -> ``{'socks'}``)."""
         return frozenset(self._obj.extras)
@@ -310,7 +353,7 @@ class ReqPackage(Package):
             return f"[{self.extra}] {version}"
         return version
 
-    @property
+    @cached_property
     def installed_version(self) -> str:
         if not self.dist:
             try:
@@ -370,6 +413,7 @@ def _try_parse_requirement(raw_req: str) -> Requirement | str:
 
 __all__ = [
     "DistPackage",
+    "DistributionInfo",
     "RenderMode",
     "ReqPackage",
 ]

--- a/src/pipdeptree/_render/__init__.py
+++ b/src/pipdeptree/_render/__init__.py
@@ -2,15 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from .freeze import render_freeze
-from .graphviz import render_graphviz
-from .json import render_json
-from .json_tree import render_json_tree
-from .mermaid import render_mermaid
-from .rich_text import render_rich_text
-from .summary import render_summary
-from .text import render_text
-
 if TYPE_CHECKING:
     from pipdeptree._cli import Options
     from pipdeptree._models import PackageDAG
@@ -24,18 +15,32 @@ def render(options: Options, tree: PackageDAG) -> None:
     mode: RenderMode = "resolved" if options.command in {"from-index", "from-lock"} else "default"
     # --summary reduces the tree to an aggregate report; output_format then only selects its presentation style.
     if options.summary:
+        from .summary import render_summary  # noqa: PLC0415  # Load only the selected renderer.
+
         render_summary(tree, mode=mode, style=output_format)
     elif output_format == "json":
+        from .json import render_json  # noqa: PLC0415  # Load only the selected renderer.
+
         render_json(tree, context=options.context, mode=mode)
     elif output_format == "json-tree":
+        from .json_tree import render_json_tree  # noqa: PLC0415  # Load only the selected renderer.
+
         render_json_tree(tree, context=options.context, mode=mode)
     elif output_format == "mermaid":
+        from .mermaid import render_mermaid  # noqa: PLC0415  # Load only the selected renderer.
+
         render_mermaid(tree, context=options.context)
     elif output_format == "freeze":
+        from .freeze import render_freeze  # noqa: PLC0415  # Load only the selected renderer.
+
         render_freeze(tree, max_depth=options.depth, list_all=options.all)
     elif output_format == "rich":
+        from .rich_text import render_rich_text  # noqa: PLC0415  # Load only the selected renderer.
+
         render_rich_text(tree, max_depth=options.depth, list_all=options.all, context=options.context, mode=mode)
     elif output_format.startswith("graphviz-"):
+        from .graphviz import render_graphviz  # noqa: PLC0415  # Graphviz is optional.
+
         render_graphviz(
             tree,
             output_format=output_format[len("graphviz-") :],
@@ -44,6 +49,8 @@ def render(options: Options, tree: PackageDAG) -> None:
             context=options.context,
         )
     else:
+        from .text import render_text  # noqa: PLC0415  # Load only the selected renderer.
+
         render_text(
             tree,
             max_depth=options.depth,

--- a/src/pipdeptree/_render/json.py
+++ b/src/pipdeptree/_render/json.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, Any
 
-from pipdeptree._computed import ComputedValues
-
 if TYPE_CHECKING:
     from pipdeptree._cli import RenderContext
     from pipdeptree._models import PackageDAG
@@ -37,7 +35,7 @@ def render_json(
         if context and context.metadata:
             d["metadata"] = k.get_metadata_dict(list(context.metadata))
         if context and context.computed:
-            d["computed"] = ComputedValues(k.key, tree, context.full_tree).as_dict(context.computed)
+            d["computed"] = context.get_computed_values(k.key, tree).as_dict(context.computed)
         return d
 
     output = json.dumps(

--- a/src/pipdeptree/_render/json_tree.py
+++ b/src/pipdeptree/_render/json_tree.py
@@ -4,7 +4,6 @@ import json
 from itertools import chain
 from typing import TYPE_CHECKING, Any
 
-from pipdeptree._computed import ComputedValues
 from pipdeptree._models import ReqPackage
 
 if TYPE_CHECKING:
@@ -60,7 +59,7 @@ def render_json_tree(
         if context and context.metadata:
             d["metadata"] = node.get_metadata_dict(list(context.metadata))  # ty: ignore[invalid-assignment]
         if context and context.computed:
-            d["computed"] = ComputedValues(node.key, tree, context.full_tree).as_dict(context.computed)  # ty: ignore[invalid-assignment]
+            d["computed"] = context.get_computed_values(node.key, tree).as_dict(context.computed)  # ty: ignore[invalid-assignment]
 
         d["dependencies"] = [
             aux(c, parent=node, cur_chain=[*cur_chain, c.project_name])

--- a/src/pipdeptree/_render/rich_text.py
+++ b/src/pipdeptree/_render/rich_text.py
@@ -4,7 +4,6 @@ import re
 import sys
 from typing import TYPE_CHECKING
 
-from pipdeptree._computed import ComputedValues
 from pipdeptree._models.package import DistPackage, ReqPackage
 from pipdeptree._render.text import _build_suffix, get_top_level_nodes
 
@@ -119,7 +118,7 @@ def _format_node(
     is_unique = (
         context is not None
         and any(f.startswith("unique-deps") for f in context.computed)
-        and node.key in ComputedValues(parent.key, tree, context.full_tree if context else None).unique_deps
+        and node.key in context.get_computed_values(parent.key, tree).unique_deps
     )
     return _format_branch_node(node_str, node, suffix, is_unique=is_unique, mode=mode)
 

--- a/src/pipdeptree/_render/text.py
+++ b/src/pipdeptree/_render/text.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from itertools import chain
-from typing import TYPE_CHECKING, Any
-
-from pipdeptree._computed import ComputedValues
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from pipdeptree._cli import RenderContext
     from pipdeptree._models import DistPackage, PackageDAG, ReqPackage
     from pipdeptree._models.package import RenderMode
@@ -69,14 +69,14 @@ def _render_text_with_unicode(
         node: DistPackage | ReqPackage,
         parent: DistPackage | ReqPackage | None = None,
         indent: int = 0,
-        cur_chain: list[str] | None = None,
+        cur_chain: set[str] | None = None,
         prefix: str = "",
         depth: int = 0,
         has_grand_parent: bool = False,  # noqa: FBT001, FBT002
         is_last_child: bool = False,  # noqa: FBT001, FBT002
         parent_is_last_child: bool = False,  # noqa: FBT001, FBT002
-    ) -> list[Any]:
-        cur_chain = cur_chain or []
+    ) -> Iterator[str]:
+        cur_chain = cur_chain or set()
         node_str = node.render(parent, frozen=False, mode=mode)
         if context and context.active:
             node_str += _build_suffix(node, context, tree)
@@ -99,29 +99,26 @@ def _render_text_with_unicode(
             next_prefix = prefix
             node_str = prefix + bullet + node_str
 
-        result = [node_str]
-
+        yield node_str
         children = tree.get_children(node.key, node)
-        children_strings = [
-            aux(
-                c,
+        for child in children:
+            if child.project_name in cur_chain or depth + 1 > max_depth:
+                continue
+            cur_chain.add(child.project_name)
+            yield from aux(
+                child,
                 node,
                 indent=next_indent,
-                cur_chain=[*cur_chain, c.project_name],
+                cur_chain=cur_chain,
                 prefix=next_prefix,
                 depth=depth + 1,
                 has_grand_parent=parent is not None,
-                is_last_child=c is children[-1],
+                is_last_child=child is children[-1],
                 parent_is_last_child=is_last_child,
             )
-            for c in children
-            if c.project_name not in cur_chain and depth + 1 <= max_depth
-        ]
+            cur_chain.remove(child.project_name)
 
-        result += list(chain.from_iterable(children_strings))
-        return result
-
-    lines = chain.from_iterable([aux(p) for p in nodes])
+    lines = chain.from_iterable(aux(node) for node in nodes)
     print("\n".join(lines))  # noqa: T201
 
 
@@ -139,25 +136,24 @@ def _render_text_simple(  # noqa: PLR0913
         node: DistPackage | ReqPackage,
         parent: DistPackage | ReqPackage | None = None,
         indent: int = 0,
-        cur_chain: list[str] | None = None,
+        cur_chain: set[str] | None = None,
         depth: int = 0,
-    ) -> list[Any]:
-        cur_chain = cur_chain or []
+    ) -> Iterator[str]:
+        cur_chain = cur_chain or set()
         node_str = node.render(parent, frozen=frozen, mode=mode)
         if context and context.active:
             node_str += _build_suffix(node, context, tree)
         if parent:
             node_str = " " * indent + bullet + node_str
-        result = [node_str]
-        children = [
-            aux(c, node, indent=indent + 2, cur_chain=[*cur_chain, c.project_name], depth=depth + 1)
-            for c in tree.get_children(node.key, node)
-            if c.project_name not in cur_chain and depth + 1 <= max_depth
-        ]
-        result += list(chain.from_iterable(children))
-        return result
+        yield node_str
+        for child in tree.get_children(node.key, node):
+            if child.project_name in cur_chain or depth + 1 > max_depth:
+                continue
+            cur_chain.add(child.project_name)
+            yield from aux(child, node, indent=indent + 2, cur_chain=cur_chain, depth=depth + 1)
+            cur_chain.remove(child.project_name)
 
-    lines = chain.from_iterable([aux(p) for p in nodes])
+    lines = chain.from_iterable(aux(node) for node in nodes)
     print("\n".join(lines))  # noqa: T201
 
 
@@ -172,7 +168,7 @@ def _build_suffix(
     if context.metadata:
         parts.extend(node.get_metadata_values(list(context.metadata)))
     if context.computed:
-        parts.extend(ComputedValues(node.key, tree, context.full_tree).format_display(context.computed, exclude))
+        parts.extend(context.get_computed_values(node.key, tree).format_display(context.computed, exclude))
     return f" ({', '.join(parts)})" if parts else ""
 
 

--- a/tests/render/test_render.py
+++ b/tests/render/test_render.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     "option", [pytest.param(["--json"], id="flag"), pytest.param(["--output", "json"], id="output")]
 )
 def test_json_routing(option: list[str], mocker: MockerFixture) -> None:
-    render = mocker.patch("pipdeptree._render.render_json")
+    render = mocker.patch("pipdeptree._render.json.render_json")
     main(option)
     render.assert_called_once_with(ANY, context=RenderContext(), mode="default")
 
@@ -27,7 +27,7 @@ def test_json_routing(option: list[str], mocker: MockerFixture) -> None:
     [pytest.param(["--json-tree"], id="flag"), pytest.param(["--output", "json-tree"], id="output")],
 )
 def test_json_tree_routing(option: list[str], mocker: MockerFixture) -> None:
-    render = mocker.patch("pipdeptree._render.render_json_tree")
+    render = mocker.patch("pipdeptree._render.json_tree.render_json_tree")
     main(option)
     render.assert_called_once_with(ANY, context=RenderContext(), mode="default")
 
@@ -37,7 +37,7 @@ def test_json_tree_routing(option: list[str], mocker: MockerFixture) -> None:
     [pytest.param(["--mermaid"], id="flag"), pytest.param(["--output", "mermaid"], id="output")],
 )
 def test_mermaid_routing(option: list[str], mocker: MockerFixture) -> None:
-    render = mocker.patch("pipdeptree._render.render_mermaid")
+    render = mocker.patch("pipdeptree._render.mermaid.render_mermaid")
     main(option)
     render.assert_called_once_with(ANY, context=RenderContext())
 
@@ -47,7 +47,7 @@ def test_mermaid_routing(option: list[str], mocker: MockerFixture) -> None:
     [pytest.param(["--graph-output", "dot"], id="flag"), pytest.param(["--output", "graphviz-dot"], id="output")],
 )
 def test_grahpviz_routing(option: list[str], mocker: MockerFixture) -> None:
-    render = mocker.patch("pipdeptree._render.render_graphviz")
+    render = mocker.patch("pipdeptree._render.graphviz.render_graphviz")
     main(option)
     render.assert_called_once_with(ANY, output_format="dot", reverse=False, max_depth=inf, context=RenderContext())
 
@@ -57,7 +57,7 @@ def test_grahpviz_routing(option: list[str], mocker: MockerFixture) -> None:
     [pytest.param([], id="default"), pytest.param(["--output", "text"], id="output")],
 )
 def test_text_routing(option: list[str], mocker: MockerFixture) -> None:
-    render = mocker.patch("pipdeptree._render.render_text")
+    render = mocker.patch("pipdeptree._render.text.render_text")
     main(option)
     render.assert_called_once_with(
         ANY, encoding="utf-8", max_depth=inf, list_all=False, context=RenderContext(), mode="default"
@@ -69,14 +69,14 @@ def test_text_routing(option: list[str], mocker: MockerFixture) -> None:
     [pytest.param(["--freeze"], id="flag"), pytest.param(["--output", "freeze"], id="output")],
 )
 def test_freeze_routing(option: list[str], mocker: MockerFixture) -> None:
-    render = mocker.patch("pipdeptree._render.render_freeze")
+    render = mocker.patch("pipdeptree._render.freeze.render_freeze")
     main(option)
     render.assert_called_once_with(ANY, max_depth=inf, list_all=False)
 
 
 @pytest.mark.parametrize("option", [pytest.param(["--output", "rich"], id="output")])
 def test_rich_routing(option: list[str], mocker: MockerFixture) -> None:
-    render = mocker.patch("pipdeptree._render.render_rich_text")
+    render = mocker.patch("pipdeptree._render.rich_text.render_rich_text")
     main(option)
     render.assert_called_once_with(ANY, max_depth=inf, list_all=False, context=RenderContext(), mode="default")
 
@@ -90,6 +90,6 @@ def test_rich_routing(option: list[str], mocker: MockerFixture) -> None:
     ],
 )
 def test_summary_routing(option: list[str], style: str, mocker: MockerFixture) -> None:
-    render = mocker.patch("pipdeptree._render.render_summary")
+    render = mocker.patch("pipdeptree._render.summary.render_summary")
     main(["--summary", *option])
     render.assert_called_once_with(ANY, mode="default", style=style)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,6 +8,7 @@ import pytest
 import pipdeptree
 from pipdeptree import _RenderResult, _SummaryResult
 from pipdeptree._computed import ComputedValues
+from pipdeptree._models import PackageDAG
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
@@ -130,7 +131,7 @@ def test_render_local_only_passed_through(mocker: MockerFixture, make_mock_dist:
 
 
 def test_render_extras_passed_through(mocker: MockerFixture, make_mock_dist: MockDistMaker) -> None:
-    spy = mocker.spy(pipdeptree.__main__.PackageDAG, "from_pkgs")
+    spy = mocker.spy(PackageDAG, "from_pkgs")
     mocker.patch(
         "pipdeptree.__main__.get_installed_distributions",
         return_value=[make_mock_dist(name="a", version="1.0.0")],
@@ -140,7 +141,7 @@ def test_render_extras_passed_through(mocker: MockerFixture, make_mock_dist: Moc
 
 
 def test_render_extras_mode_passed_through(mocker: MockerFixture, make_mock_dist: MockDistMaker) -> None:
-    spy = mocker.spy(pipdeptree.__main__.PackageDAG, "from_pkgs")
+    spy = mocker.spy(PackageDAG, "from_pkgs")
     mocker.patch(
         "pipdeptree.__main__.get_installed_distributions",
         return_value=[make_mock_dist(name="a", version="1.0.0")],

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import site
 import sys
+from importlib.metadata import Distribution
 from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import Mock
@@ -201,6 +202,15 @@ def test_has_valid_metadata_broken(exc: type[Exception]) -> None:
     dist = Mock()
     type(dist).metadata = property(lambda _: (_ for _ in ()).throw(exc))
     assert has_valid_metadata(dist) is False
+
+
+@pytest.mark.parametrize("exc", [TypeError, FileNotFoundError])
+def test_get_installed_distributions_skips_unreadable_metadata(exc: type[Exception], mocker: MockerFixture) -> None:
+    dist = mocker.create_autospec(Distribution, instance=True)
+    type(dist).metadata = mocker.PropertyMock(side_effect=exc)
+    dist.locate_file.return_value = "/broken"
+    mocker.patch("pipdeptree._discovery.distributions", return_value=[dist])
+    assert get_installed_distributions(supplied_paths=["/packages"]) == []
 
 
 def test_paths_when_in_virtual_env(tmp_path: Path, fake_dist: Path) -> None:


### PR DESCRIPTION
Profiling a 149-distribution environment with 1,208 requirement records found repeated METADATA parsing and eager renderer imports. Each computed-field occurrence triggered another graph walk. The default CLI path parsed METADATA up to 5 times per distribution, while `--help` and `--version` imported graph and renderer modules they did not use.

This change defers command-specific imports and passes a compact metadata snapshot from discovery into graph construction. Reversed nodes reuse parsed package data. Render contexts cache computed values per package, and text traversal streams its lines. Parent counts replace repeated reachability walks for unique-dependency cleanup.

I ran Hyperfine with 4 warmups and 15 measured runs on CPython 3.14.6 for macOS arm64. The workload contained Django and FastAPI alongside Flask, JupyterLab, Matplotlib, pandas, SciPy, scikit-learn. The table reports median wall time.

| Command                        |   Before |    After | Reduction |
| ------------------------------ | -------: | -------: | --------: |
| `--help`                       |  71.6 ms |  36.6 ms |     48.9% |
| full text tree                 | 197.1 ms | 117.2 ms |     40.5% |
| `--packages jupyterlab`        | 168.8 ms | 102.2 ms |     39.4% |
| `--reverse`                    | 271.0 ms | 120.1 ms |     55.7% |
| `--output json`                | 174.2 ms | 107.1 ms |     38.5% |
| `--extras active`              | 212.6 ms | 115.8 ms |     45.5% |
| `--computed unique-deps-count` | 531.6 ms | 106.4 ms |     80.0% |
| `--computed size`              | 971.3 ms | 457.0 ms |     52.9% |

Peak traced allocations stayed below the baseline in the same environment. These figures come from one `tracemalloc` process run per command.

| Command                        |   Before |    After | Reduction |
| ------------------------------ | -------: | -------: | --------: |
| `--help`                       | 10.93 MB |  3.72 MB |     66.0% |
| full text tree                 | 13.81 MB | 12.38 MB |     10.4% |
| `--reverse`                    | 13.78 MB | 12.53 MB |      9.1% |
| `--extras active`              | 13.91 MB | 12.80 MB |      8.0% |
| `--computed unique-deps-count` | 13.81 MB | 12.45 MB |      9.9% |
| `--computed size`              | 16.92 MB | 16.51 MB |      2.4% |

Before-and-after output matched byte for byte for text, filtered JupyterLab, reverse, JSON, JSON tree, extras, unique-dependency, and size modes. The public CLI and programmatic API retain their existing output and error behavior.
