### PR TITLE
⚡ perf: cache rendered metadata

### DIFF
--- a/src/pipdeptree/_models/package.py
+++ b/src/pipdeptree/_models/package.py
@@ -56,17 +56,7 @@ class Package(ABC):
     def licenses(self) -> str:
         if (dist_metadata := self._get_dist_metadata()) is None:
             return self.UNKNOWN_LICENSE_STR
-
-        if license_str := dist_metadata["License-Expression"]:
-            return f"({license_str})"
-
-        license_strs: list[str] = []
-        for classifier in dist_metadata.get_all("Classifier", []):
-            line = str(classifier)
-            if line.startswith("License"):
-                license_strs.append(line.rsplit(":: ", 1)[-1])
-
-        return f"({', '.join(license_strs)})" if license_strs else self.UNKNOWN_LICENSE_STR
+        return _licenses_from_metadata(dist_metadata)
 
     def get_metadata(self, field: str) -> str | list[str]:
         if field == "license":
@@ -168,11 +158,29 @@ class DistPackage(Package):
             self._version = dist_info.version or obj.version
 
     @cached_property
-    def _loaded_metadata(self) -> PackageMetadata:
-        return self._obj.metadata
+    def _metadata_cache(self) -> dict[str, str | list[str]]:
+        return {}
 
-    def _get_dist_metadata(self) -> PackageMetadata:
-        return self._loaded_metadata
+    def licenses(self) -> str:
+        return self._cached_license
+
+    @cached_property
+    def _cached_license(self) -> str:
+        return _licenses_from_metadata(self._obj.metadata)
+
+    def get_metadata(self, field: str) -> str | list[str]:
+        if field == "license":
+            return super().get_metadata(field)
+        if (value := self._metadata_cache.get(field)) is None:
+            values = self._obj.metadata.get_all(field)
+            if not values:
+                value = self.NA
+            elif len(values) == 1:
+                value = str(values[0])
+            else:
+                value = [str(item) for item in values]
+            self._metadata_cache[field] = value
+        return value.copy() if isinstance(value, list) else value
 
     @cached_property
     def _parsed_requires(self) -> list[Requirement | str]:
@@ -318,6 +326,12 @@ class ReqPackage(Package):
         # ``--extras active`` or ``--packages foo[extra]`` stay None. PackageDAG.get_children reads it to gate output.
         self.scoped_extra = scoped_extra
 
+    def licenses(self) -> str:
+        return self.dist.licenses() if self.dist is not None else super().licenses()
+
+    def get_metadata(self, field: str) -> str | list[str]:
+        return self.dist.get_metadata(field) if self.dist is not None else super().get_metadata(field)
+
     def render_as_root(self, *, frozen: bool) -> str:
         if not frozen:
             return f"{self.project_name}=={self.installed_version}"
@@ -409,6 +423,17 @@ def _try_parse_requirement(raw_req: str) -> Requirement | str:
         return Requirement(raw_req)
     except InvalidRequirement:
         return raw_req
+
+
+def _licenses_from_metadata(dist_metadata: PackageMetadata) -> str:
+    if license_str := dist_metadata["License-Expression"]:
+        return f"({license_str})"
+    licenses = [
+        line.rsplit(":: ", 1)[-1]
+        for classifier in dist_metadata.get_all("Classifier", [])
+        if (line := str(classifier)).startswith("License")
+    ]
+    return f"({', '.join(licenses)})" if licenses else Package.UNKNOWN_LICENSE_STR
 
 
 __all__ = [

--- a/tests/_models/test_package.py
+++ b/tests/_models/test_package.py
@@ -148,6 +148,13 @@ def test_licenses_importlib_cant_find_package(mocker: MockerFixture) -> None:
     assert ReqPackage(req).licenses() == Package.UNKNOWN_LICENSE_STR
 
 
+def test_req_package_licenses_use_global_metadata_when_dist_missing(mocker: MockerFixture) -> None:
+    mocker.patch("pipdeptree._models.package.metadata", return_value=_license_msg(license_expression="MIT"))
+    req = MagicMock()
+    req.name = "foo"
+    assert ReqPackage(req).licenses() == "(MIT)"
+
+
 def test_dist_package_key_pep503_normalized() -> None:
     foobar = Mock(metadata={"Name": "foo.bar"}, version="20.4.1")
     dp = DistPackage(foobar)
@@ -484,10 +491,11 @@ def test_dist_package_edge_label_with_extra() -> None:
     assert dp.edge_label == "[signedtoken] >=4.0"
 
 
-def test_get_metadata_license(mocker: MockerFixture) -> None:
-    mocker.patch.object(Package, "licenses", return_value="(MIT)")
-    dist = MagicMock(metadata={"Name": "foo"}, version="1.0")
-    assert DistPackage(dist).get_metadata("license") == "MIT License"
+def test_get_metadata_license() -> None:
+    msg = Message()
+    msg["Name"] = "foo"
+    msg["License-Expression"] = "MIT"
+    assert DistPackage(MagicMock(metadata=msg, version="1.0")).get_metadata("license") == "MIT License"
 
 
 def _make_dist_msg(**fields: str | list[str]) -> MagicMock:
@@ -519,9 +527,8 @@ def test_get_metadata_unknown_package(mocker: MockerFixture) -> None:
     assert ReqPackage(req).get_metadata("Summary") == "N/A"
 
 
-def test_get_metadata_dict(mocker: MockerFixture) -> None:
-    mocker.patch.object(Package, "licenses", return_value="(MIT)")
-    dist = _make_dist_msg(Summary="A package")
+def test_get_metadata_dict() -> None:
+    dist = _make_dist_msg(Summary="A package", Classifier=["License :: OSI Approved :: MIT License"])
     result = DistPackage(dist).get_metadata_dict(["license", "Summary"])
     assert result == {"license": "MIT License", "Summary": "A package"}
 
@@ -541,8 +548,7 @@ def test_get_metadata_multi_value() -> None:
     ]
 
 
-def test_get_metadata_values_with_multi_value(mocker: MockerFixture) -> None:
-    mocker.patch.object(Package, "licenses", return_value="(MIT)")
+def test_get_metadata_values_with_multi_value() -> None:
     dist = _make_dist_msg(
         Classifier=["Development Status :: 5 - Production/Stable", "License :: OSI Approved :: MIT License"],
     )
@@ -565,9 +571,8 @@ def test_get_metadata_dict_with_multi_value() -> None:
     }
 
 
-def test_get_metadata_values(mocker: MockerFixture) -> None:
-    mocker.patch.object(Package, "licenses", return_value="(MIT)")
-    dist = _make_dist_msg()
+def test_get_metadata_values() -> None:
+    dist = _make_dist_msg(Classifier=["License :: OSI Approved :: MIT License"])
     assert DistPackage(dist).get_metadata_values(["license"]) == ["MIT License"]
 
 
@@ -591,6 +596,23 @@ def test_get_metadata_uses_dist_not_global_lookup(mocker: MockerFixture) -> None
     global_metadata.assert_not_called()
 
 
+def test_req_package_get_metadata_uses_dist_not_global_lookup(mocker: MockerFixture) -> None:
+    dist = DistPackage(_make_dist_msg(Summary="From dist"))
+    req = MagicMock()
+    req.name = "foo"
+    global_metadata = mocker.patch("pipdeptree._models.package.metadata", side_effect=PackageNotFoundError("x"))
+    assert ReqPackage(req, dist).get_metadata("Summary") == "From dist"
+    global_metadata.assert_not_called()
+
+
+def test_req_package_get_metadata_dict_uses_dist() -> None:
+    req = MagicMock()
+    req.name = "foo"
+    assert ReqPackage(req, DistPackage(_make_dist_msg(Summary="From dist"))).get_metadata_dict(["Summary"]) == {
+        "Summary": "From dist",
+    }
+
+
 def test_licenses_uses_dist_not_global_lookup(mocker: MockerFixture) -> None:
     msg = Message()
     msg["Name"] = "foo"
@@ -598,4 +620,15 @@ def test_licenses_uses_dist_not_global_lookup(mocker: MockerFixture) -> None:
     dist = MagicMock(metadata=msg, version="1.0")
     global_metadata = mocker.patch("pipdeptree._models.package.metadata", side_effect=PackageNotFoundError("x"))
     assert DistPackage(dist).licenses() == "(MIT)"
+    global_metadata.assert_not_called()
+
+
+def test_req_package_licenses_use_dist_not_global_lookup(mocker: MockerFixture) -> None:
+    msg = Message()
+    msg["Name"] = "foo"
+    msg["License-Expression"] = "MIT"
+    req = MagicMock()
+    req.name = "foo"
+    global_metadata = mocker.patch("pipdeptree._models.package.metadata", side_effect=PackageNotFoundError("x"))
+    assert ReqPackage(req, DistPackage(MagicMock(metadata=msg, version="1.0"))).licenses() == "(MIT)"
     global_metadata.assert_not_called()

--- a/tests/render/test_graphviz.py
+++ b/tests/render/test_graphviz.py
@@ -8,7 +8,7 @@ import pytest
 
 from pipdeptree._cli import RenderContext
 from pipdeptree._models import PackageDAG
-from pipdeptree._models.package import Package
+from pipdeptree._models.package import DistPackage
 from pipdeptree._render.graphviz import dump_graphviz, print_graphviz, render_graphviz
 
 if TYPE_CHECKING:
@@ -203,7 +203,7 @@ def test_render_graphviz_with_metadata(
 ) -> None:
     graph: MockGraph = {("a", "1.0"): [("b", [(">=", "1.0")])], ("b", "1.0"): []}
     dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
-    monkeypatch.setattr(Package, "licenses", lambda _: "(MIT)")
+    monkeypatch.setattr(DistPackage, "licenses", lambda _: "(MIT)")
     ctx = RenderContext(metadata=["license"])
     render_graphviz(dag, output_format="dot", reverse=False, context=ctx)
     output = capsys.readouterr().out
@@ -217,7 +217,7 @@ def test_render_graphviz_reversed_with_metadata(
 ) -> None:
     graph: MockGraph = {("a", "1.0"): [("b", [(">=", "1.0")])], ("b", "1.0"): []}
     dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
-    monkeypatch.setattr(Package, "licenses", lambda _: "(MIT)")
+    monkeypatch.setattr(DistPackage, "licenses", lambda _: "(MIT)")
     ctx = RenderContext(metadata=["license"])
     render_graphviz(dag.reverse(), output_format="dot", reverse=True, context=ctx)
     output = capsys.readouterr().out

--- a/tests/render/test_mermaid.py
+++ b/tests/render/test_mermaid.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 from pipdeptree._cli import RenderContext
 from pipdeptree._models import PackageDAG
-from pipdeptree._models.package import Package
+from pipdeptree._models.package import DistPackage
 from pipdeptree._render.mermaid import render_mermaid
 
 if TYPE_CHECKING:
@@ -115,7 +115,7 @@ def test_mermaid_with_metadata(
 ) -> None:
     graph: MockGraph = {("a", "1.0"): [("b", [(">=", "1.0")])], ("b", "1.0"): []}
     dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
-    monkeypatch.setattr(Package, "licenses", lambda _: "(MIT)")
+    monkeypatch.setattr(DistPackage, "licenses", lambda _: "(MIT)")
     ctx = RenderContext(metadata=["license"])
     render_mermaid(dag, context=ctx)
     output = capsys.readouterr().out
@@ -129,7 +129,7 @@ def test_mermaid_reversed_with_metadata(
 ) -> None:
     graph: MockGraph = {("a", "1.0"): [("b", [(">=", "1.0")])], ("b", "1.0"): []}
     dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
-    monkeypatch.setattr(Package, "licenses", lambda _: "(MIT)")
+    monkeypatch.setattr(DistPackage, "licenses", lambda _: "(MIT)")
     ctx = RenderContext(metadata=["license"])
     render_mermaid(dag.reverse(), context=ctx)
     output = capsys.readouterr().out

--- a/tests/render/test_rich_text.py
+++ b/tests/render/test_rich_text.py
@@ -9,7 +9,7 @@ import pytest
 
 from pipdeptree._cli import RenderContext
 from pipdeptree._models import PackageDAG
-from pipdeptree._models.package import DistPackage, Package
+from pipdeptree._models.package import DistPackage
 from pipdeptree._render.rich_text import render_rich_text
 
 if TYPE_CHECKING:
@@ -74,7 +74,7 @@ def test_render_rich_text_with_license_info(
         ("c", "1.0.0"): [],
     }
     dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
-    monkeypatch.setattr(Package, "licenses", lambda _: "(TEST)")
+    monkeypatch.setattr(DistPackage, "licenses", lambda _: "(TEST)")
 
     render_rich_text(dag, max_depth=float("inf"), context=RenderContext(metadata=["license"]))
     output = capsys.readouterr().out
@@ -187,7 +187,7 @@ def test_render_rich_text_multi_value_metadata(
     msg = Message()
     msg["Classifier"] = "Development Status :: 5 - Production/Stable"
     msg["Classifier"] = "License :: OSI Approved :: MIT License"
-    mocker.patch.object(DistPackage, "_get_dist_metadata", return_value=msg)
+    mocker.patch.object(next(iter(dag)).unwrap(), "metadata", msg)
 
     render_rich_text(dag, max_depth=float("inf"), context=RenderContext(metadata=["Classifier"]))
     output = capsys.readouterr().out
@@ -206,7 +206,7 @@ def test_render_rich_text_multiline_metadata(
     dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
     msg = Message()
     msg["Description"] = "Line one\nLine two\nLine three"
-    mocker.patch.object(DistPackage, "_get_dist_metadata", return_value=msg)
+    mocker.patch.object(next(iter(dag)).unwrap(), "metadata", msg)
 
     render_rich_text(dag, max_depth=float("inf"), context=RenderContext(metadata=["Description"]))
     output = capsys.readouterr().out

--- a/tests/render/test_text.py
+++ b/tests/render/test_text.py
@@ -7,7 +7,7 @@ import pytest
 
 from pipdeptree._cli import RenderContext
 from pipdeptree._models import PackageDAG
-from pipdeptree._models.package import Package
+from pipdeptree._models.package import DistPackage
 from pipdeptree._render.text import render_text
 
 if TYPE_CHECKING:
@@ -512,7 +512,7 @@ def test_render_text_with_license_info(
         ("c", "1.0.0"): [],
     }
     dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
-    monkeypatch.setattr(Package, "licenses", lambda _: "(TEST License)")
+    monkeypatch.setattr(DistPackage, "licenses", lambda _: "(TEST License)")
 
     render_text(dag, max_depth=float("inf"), encoding=encoding, context=RenderContext(metadata=["license"]))
     captured = capsys.readouterr()
@@ -562,7 +562,7 @@ def test_render_text_with_license_info_and_reversed_tree(
     }
     dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
     dag = dag.reverse()
-    monkeypatch.setattr(Package, "licenses", lambda _: "(TEST License)")
+    monkeypatch.setattr(DistPackage, "licenses", lambda _: "(TEST License)")
 
     render_text(dag, max_depth=float("inf"), encoding=encoding, context=RenderContext(metadata=["license"]))
     captured = capsys.readouterr()

--- a/tests/test_computed.py
+++ b/tests/test_computed.py
@@ -221,7 +221,7 @@ def test_build_node_extra_label_metadata(
 ) -> None:
     graph: MockGraph = {("a", "1.0"): []}
     dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
-    mocker.patch("pipdeptree._models.package.Package.get_metadata_values", return_value=["A package"])
+    mocker.patch("pipdeptree._models.package.DistPackage.get_metadata_values", return_value=["A package"])
     ctx = RenderContext(metadata=["Summary"])
     assert ctx.build_node_extra_label("a", dag, ", ") == "A package"
 
@@ -241,7 +241,7 @@ def test_build_node_extra_label_license(
 ) -> None:
     graph: MockGraph = {("a", "1.0"): []}
     dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
-    mocker.patch("pipdeptree._models.package.Package.licenses", return_value="(MIT)")
+    mocker.patch("pipdeptree._models.package.DistPackage.licenses", return_value="(MIT)")
     ctx = RenderContext(metadata=["license"])
     assert ctx.build_node_extra_label("a", dag, ", ") == "MIT License"
 
@@ -251,7 +251,7 @@ def test_build_node_extra_label_missing_metadata_field(
 ) -> None:
     graph: MockGraph = {("a", "1.0"): []}
     dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
-    mocker.patch("pipdeptree._models.package.Package.get_metadata_values", return_value=[])
+    mocker.patch("pipdeptree._models.package.DistPackage.get_metadata_values", return_value=[])
     ctx = RenderContext(metadata=["Author"])
     assert not ctx.build_node_extra_label("a", dag, ", ")
 


### PR DESCRIPTION
`--metadata Summary` reparsed installed distribution metadata for each appearance in the tree. In a 149-distribution environment with 1,208 requirement records, repeated metadata reads and parsing used 216.0 ms of CPU.

This change caches each requested field on its distribution so requirement nodes reuse it. The cache exists only after a renderer requests metadata; commands without metadata allocate no field cache. I removed the marker, child-index, and parent-count experiments because their total-command CPU gains stayed below 5%.

I compared the tree merged by #611 with this branch on CPython 3.14.6 for macOS arm64. The environment included Django and FastAPI alongside Flask, JupyterLab, Matplotlib, pandas, SciPy, scikit-learn. Each wall and CPU value is the median of 12 runs with alternating order after one warmup; RSS is the median peak from 5 fresh processes. CPU is user plus system time from `getrusage`; RSS is resident memory from the same API. Lower is better.

| Command              | Wall before | Wall after | CPU before | CPU after | RSS before | RSS after |
| -------------------- | ----------: | ---------: | ---------: | --------: | ---------: | --------: |
| full text tree       |    102.9 ms |   102.6 ms |   100.9 ms |  100.9 ms |   36.96 MB |  36.96 MB |
| `--metadata Summary` |    217.7 ms |   118.6 ms |   216.0 ms |  117.0 ms |   38.26 MB |  37.45 MB |

The metadata command used 45.8% less CPU and 45.5% less wall time; peak RSS fell 0.81 MB. The default text command stayed unchanged. Before-and-after output matched byte for byte for text and reverse trees plus JSON and JSON tree. Mermaid and active extras matched, as did metadata and license output plus unique dependencies. The CLI and programmatic API retain their output and error behavior.
