### PR TITLE
⚡ perf: cache frozen package specifiers

### DIFF
--- a/src/pipdeptree/_models/package.py
+++ b/src/pipdeptree/_models/package.py
@@ -247,8 +247,12 @@ class DistPackage(Package):
         """Exposes the internal `importlib.metadata.Distribution` object."""
         return self._obj
 
+    @cached_property
+    def _frozen_repr(self) -> str:
+        return self.as_frozen_repr(self._obj)
+
     def render_as_root(self, *, frozen: bool) -> str:
-        return self.as_frozen_repr(self._obj) if frozen else f"{self.project_name}=={self.version}"
+        return self._frozen_repr if frozen else f"{self.project_name}=={self.version}"
 
     def render_as_branch(self, *, frozen: bool, mode: RenderMode = "default") -> str:  # noqa: ARG002
         # resolved mode only relabels ReqPackage branches; a DistPackage branch appears in reverse mode
@@ -336,7 +340,7 @@ class ReqPackage(Package):
         if not frozen:
             return f"{self.project_name}=={self.installed_version}"
         if self.dist:
-            return self.as_frozen_repr(self.dist.unwrap())
+            return self.dist.render_as_root(frozen=True)
         return self.project_name
 
     def render_as_branch(self, *, frozen: bool, mode: RenderMode = "default") -> str:

--- a/tests/_models/test_package.py
+++ b/tests/_models/test_package.py
@@ -65,12 +65,11 @@ def test_dist_package_render_as_branch() -> None:
     assert dp.render_as_branch(frozen=False) == "foo==20.4.1 [requires: bar>=4.0]"
 
 
-def test_dist_package_render_as_root_with_frozen(mocker: MockerFixture) -> None:
+def test_dist_package_render_as_root_with_frozen_caches_specifier(mocker: MockerFixture) -> None:
     foo = Mock(metadata={"Name": "foo"}, version="1.2.3")
     dp = DistPackage(foo)
-    expected = "test"
-    mocker.patch("pipdeptree._models.package.distribution_to_specifier", Mock(return_value=expected))
-    assert dp.render_as_root(frozen=True) == expected
+    specifier = mocker.patch("pipdeptree._models.package.distribution_to_specifier", return_value="test")
+    assert ([dp.render_as_root(frozen=True) for _ in range(2)], specifier.call_count) == (["test", "test"], 1)
 
 
 def test_dist_package_as_parent_of() -> None:
@@ -176,15 +175,17 @@ def test_req_package_render_as_root() -> None:
     assert rp.render_as_root(frozen=False) == "bar==4.1.0"
 
 
-def test_req_package_render_as_root_with_frozen(mocker: MockerFixture) -> None:
+def test_req_package_render_as_root_with_frozen_uses_dist_cache(mocker: MockerFixture) -> None:
     bar = Mock(metadata={"Name": "bar"}, version="4.1.0")
     dp = DistPackage(bar)
     bar_req = MagicMock(specifier=[">=4.0"])
     bar_req.name = "bar"
     rp = ReqPackage(bar_req, dp)
-    expected = "test"
-    mocker.patch("pipdeptree._models.package.distribution_to_specifier", Mock(return_value=expected))
-    assert rp.render_as_root(frozen=True) == expected
+    specifier = mocker.patch("pipdeptree._models.package.distribution_to_specifier", return_value="test")
+    assert ([rp.render_as_root(frozen=True), dp.render_as_root(frozen=True)], specifier.call_count) == (
+        ["test", "test"],
+        1,
+    )
 
 
 def test_req_package_render_as_branch() -> None:


### PR DESCRIPTION
Freeze output rebuilds a package specifier every time a distribution appears on a dependency path. The 149-distribution benchmark environment emits 822 forward-tree lines and 1,277 reverse-tree lines, so repeated metadata parsing and editable-install probing dominate these commands.

Cache each distribution's frozen specifier on first use and route requirement nodes through the same distribution wrapper. The cache stays lazy, so other render modes do not pay the formatting cost or retain another value per package.

Measurements ran each command in a fresh Python 3.14 process, with one warm-up, 15 order-balanced wall/CPU samples, and five order-balanced peak-RSS samples. Values are medians for `--python .tox/dev/bin/python --warn silence --freeze`, with `--reverse` added for the reverse case.

| Command | Wall before | Wall after | Change | CPU before | CPU after | Change | Peak RSS before | Peak RSS after |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| freeze | 442.0 ms | 185.6 ms | -58.0% | 438.5 ms | 180.5 ms | -58.8% | 37.21 MB | 37.45 MB |
| reverse freeze | 854.3 ms | 296.5 ms | -65.3% | 850.3 ms | 293.2 ms | -65.5% | 37.26 MB | 37.34 MB |

Both commands produced byte-for-byte identical output before and after the change.
