### PR TITLE
⚡ perf: reuse computed package sizes

### DIFF
--- a/src/pipdeptree/_cli.py
+++ b/src/pipdeptree/_cli.py
@@ -63,6 +63,7 @@ class RenderContext:
         repr=False,
         compare=False,
     )
+    _size_cache: dict[str, int | None] = field(default_factory=dict, init=False, repr=False, compare=False)
 
     @property
     def active(self) -> bool:
@@ -84,13 +85,17 @@ class RenderContext:
 
         cache_key = (id(tree), id(self.full_tree), key)
         if (computed := self._computed_cache.get(cache_key)) is None:
-            computed = self._computed_cache[cache_key] = ComputedValues(key, tree, self.full_tree)
+            size_cache = self._size_cache if "unique-deps-size" in self.computed else None
+            computed = self._computed_cache[cache_key] = ComputedValues(
+                key, tree, self.full_tree, _size_cache=size_cache
+            )
         return computed
 
     def with_metadata(self, metadata: list[str]) -> RenderContext:
         """Return a copy with a different metadata field list."""
         context = RenderContext(metadata=metadata, computed=self.computed, full_tree=self.full_tree)
         context._computed_cache = self._computed_cache
+        context._size_cache = self._size_cache
         return context
 
     @staticmethod

--- a/src/pipdeptree/_computed.py
+++ b/src/pipdeptree/_computed.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pathlib
 from dataclasses import dataclass
+from dataclasses import field as dataclass_field
 from functools import cached_property
 from importlib.metadata import distribution
 from typing import TYPE_CHECKING, Any
@@ -17,6 +18,7 @@ class ComputedValues:
     key: str
     tree: PackageDAG
     full_tree: PackageDAG | None = None
+    _size_cache: dict[str, int | None] | None = dataclass_field(default=None, repr=False, compare=False, kw_only=True)
 
     def as_dict(self, fields: Sequence[str]) -> dict[str, Any]:
         return {
@@ -52,14 +54,20 @@ class ComputedValues:
 
     @cached_property
     def size_bytes(self) -> int | None:
+        size_cache = self._size_cache
+        if size_cache is not None and self.key in size_cache:
+            return size_cache[self.key]
         dist = distribution(self.key)
         if record := dist.read_text("RECORD"):
             from csv import reader  # noqa: PLC0415  # Other computed fields do not read package file lists.
 
             files = (row[0] for row in reader(record.splitlines()))
-        elif not (files := dist.files):
-            return None
-        return sum(self._file_size(str(dist.locate_file(f))) for f in files)
+        else:
+            files = dist.files
+        result = sum(self._file_size(str(dist.locate_file(f))) for f in files) if files else None
+        if size_cache is not None:
+            size_cache[self.key] = result
+        return result
 
     @staticmethod
     def _file_size(path: str) -> int:
@@ -86,7 +94,10 @@ class ComputedValues:
 
     @cached_property
     def unique_deps_size(self) -> str:
-        total = sum(ComputedValues(dep, self.tree, self.full_tree).size_raw for dep in self.unique_deps)
+        size_cache = self._size_cache if self._size_cache is not None else {}
+        total = sum(
+            ComputedValues(dep, self.tree, self.full_tree, _size_cache=size_cache).size_raw for dep in self.unique_deps
+        )
         return self.format_size(total)
 
     @cached_property

--- a/tests/test_computed.py
+++ b/tests/test_computed.py
@@ -128,6 +128,27 @@ def test_unique_deps_size(mock_pkgs: Callable[[MockGraph], Iterator[Mock]], mock
     assert ComputedValues("a", dag).unique_deps_size == "2.0 KB"
 
 
+def test_render_context_reuses_unique_dependency_sizes(
+    mock_pkgs: Callable[[MockGraph], Iterator[Mock]], mocker: MockerFixture
+) -> None:
+    graph: MockGraph = {
+        ("a", "1.0"): [("b", [(">=", "1.0")])],
+        ("b", "1.0"): [("c", [(">=", "1.0")])],
+        ("c", "1.0"): [],
+    }
+    dag = PackageDAG.from_pkgs(list(mock_pkgs(graph)))
+    mocker.patch(
+        "pipdeptree._computed.distribution",
+        return_value=MagicMock(files=["f"], locate_file=lambda _: "/dev/null", read_text=lambda _: None),
+    )
+    file_size = mocker.patch.object(ComputedValues, "_file_size", return_value=1024)
+    context = RenderContext(computed=["unique-deps-size"])
+    assert (
+        [context.get_computed_values(key, dag).unique_deps_size for key in ("a", "b")],
+        file_size.call_count,
+    ) == (["2.0 KB", "1.0 KB"], 2)
+
+
 def test_unique_deps_count_matches_names(mock_pkgs: Callable[[MockGraph], Iterator[Mock]]) -> None:
     dag = PackageDAG.from_pkgs(list(mock_pkgs({("a", "1.0"): [("b", [(">=", "1.0")])], ("b", "1.0"): []})))
     cv = ComputedValues("a", dag)


### PR DESCRIPTION
Computing unique dependency sizes measures the same transitive package once for every ancestor that can remove it. In the 149-distribution benchmark environment, one render requested 222 package-size calculations while touching only 115 distinct packages.

Share a lazy package-size cache across computed values only when `unique-deps-size` is active. Plain `size` rendering keeps its existing uncached path, and the cache retains at most one integer or `None` per measured package for the life of one render context.

Measurements ran each command in a fresh Python 3.14 process, with one warm-up, 15 order-balanced wall/CPU samples, and five order-balanced peak-RSS samples. Values are medians for `--python .tox/dev/bin/python --warn silence --computed FIELD`; `computed all` requests all five computed fields. The plain `size` case is a regression control.

| Command | Wall before | Wall after | Change | CPU before | CPU after | Change | Peak RSS before | Peak RSS after |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| size (control) | 306.4 ms | 304.9 ms | -0.5% | 305.0 ms | 303.5 ms | -0.5% | 38.67 MB | 38.62 MB |
| unique dependency size | 372.3 ms | 221.2 ms | -40.6% | 370.4 ms | 219.8 ms | -40.7% | 38.76 MB | 38.58 MB |
| all computed fields | 570.2 ms | 311.5 ms | -45.4% | 568.5 ms | 310.1 ms | -45.5% | 38.62 MB | 38.63 MB |

Both affected commands produced byte-for-byte identical 822-line output before and after the change.
