### PR TITLE
♻️ refactor(deps): move test extra to a dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,16 +57,6 @@ optional-dependencies.index = [
 optional-dependencies.rich = [
   "rich>=14.3.3",
 ]
-optional-dependencies.test = [
-  "covdefaults>=2.3",
-  "diff-cover>=9.7.1",
-  "pipdeptree[index]",
-  "pytest>=8.4.2",
-  "pytest-cov>=7",
-  "pytest-mock>=3.15.1",
-  "pytest-subprocess>=1.5",
-  "virtualenv<21,>=20.34",
-]
 urls.Changelog = "https://github.com/tox-dev/pipdeptree/releases"
 urls.Documentation = "https://pipdeptree.readthedocs.io"
 urls.Homepage = "https://github.com/tox-dev/pipdeptree"
@@ -82,6 +72,16 @@ docs = [
   "sphinx-copybutton>=0.5.2",
   "sphinx-inline-tabs>=2023.4.21",
   "sphinxcontrib-mermaid>=2",
+]
+test = [
+  "covdefaults>=2.3",
+  "diff-cover>=9.7.1",
+  "pipdeptree[index]",
+  "pytest>=8.4.2",
+  "pytest-cov>=7",
+  "pytest-mock>=3.15.1",
+  "pytest-subprocess>=1.5",
+  "virtualenv<21,>=20.34",
 ]
 
 [tool.hatch]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,14 +65,6 @@ urls.Tracker = "https://github.com/tox-dev/pipdeptree/issues"
 scripts.pipdeptree = "pipdeptree.__main__:main"
 
 [dependency-groups]
-docs = [
-  "furo>=2024.8.6",
-  "sphinx>=7.4",
-  "sphinx-argparse-cli>=1.18",
-  "sphinx-copybutton>=0.5.2",
-  "sphinx-inline-tabs>=2023.4.21",
-  "sphinxcontrib-mermaid>=2",
-]
 test = [
   "covdefaults>=2.3",
   "diff-cover>=9.7.1",
@@ -82,6 +74,14 @@ test = [
   "pytest-mock>=3.15.1",
   "pytest-subprocess>=1.5",
   "virtualenv<21,>=20.34",
+]
+docs = [
+  "furo>=2024.8.6",
+  "sphinx>=7.4",
+  "sphinx-argparse-cli>=1.18",
+  "sphinx-copybutton>=0.5.2",
+  "sphinx-inline-tabs>=2023.4.21",
+  "sphinxcontrib-mermaid>=2",
 ]
 
 [tool.hatch]

--- a/tox.toml
+++ b/tox.toml
@@ -16,7 +16,8 @@ skip_missing_interpreters = true
 description = "run the unit tests with pytest under {base_python}"
 package = "wheel"
 wheel_build_env = ".pkg"
-extras = [ "graphviz", "rich", "test" ]
+extras = [ "graphviz", "rich" ]
+dependency_groups = [ "test" ]
 pass_env = [ "DIFF_AGAINST", "PYTEST_*" ]
 set_env.COVERAGE_FILE = "{work_dir}/.coverage.{env_name}"
 commands = [
@@ -104,5 +105,6 @@ commands = [ [ "ty", "check", "--python-platform", "all", "--output-format", "co
 [env.dev]
 description = "generate a DEV environment"
 package = "editable"
-extras = [ "graphviz", "rich", "test" ]
+extras = [ "graphviz", "rich" ]
+dependency_groups = [ "test" ]
 commands = [ [ "uv", "pip", "tree" ], [ "python", "-c", "import sys; print(sys.executable)" ] ]

--- a/tox.toml
+++ b/tox.toml
@@ -16,8 +16,8 @@ skip_missing_interpreters = true
 description = "run the unit tests with pytest under {base_python}"
 package = "wheel"
 wheel_build_env = ".pkg"
-extras = [ "graphviz", "rich" ]
 dependency_groups = [ "test" ]
+extras = [ "graphviz", "rich" ]
 pass_env = [ "DIFF_AGAINST", "PYTEST_*" ]
 set_env.COVERAGE_FILE = "{work_dir}/.coverage.{env_name}"
 commands = [
@@ -105,6 +105,6 @@ commands = [ [ "ty", "check", "--python-platform", "all", "--output-format", "co
 [env.dev]
 description = "generate a DEV environment"
 package = "editable"
-extras = [ "graphviz", "rich" ]
 dependency_groups = [ "test" ]
+extras = [ "graphviz", "rich" ]
 commands = [ [ "uv", "pip", "tree" ], [ "python", "-c", "import sys; print(sys.executable)" ] ]


### PR DESCRIPTION
The `test` extra bundled development dependencies into `[project.optional-dependencies]`, next to the feature extras `graphviz`, `index`, and `rich`. Publishing test tooling as an installable extra lets end users run `pip install pipdeptree[test]` and pull `pytest`, `covdefaults`, or `virtualenv` they have no use for. PEP 735 `[dependency-groups]` covers this local development need, and the project already keeps its `docs` requirements there.

This drops `optional-dependencies.test` and recreates it as a `test` group under `[dependency-groups]`. Two tox envs consumed it. Both now split the reference: feature extras stay in `extras`, and the dev dependencies arrive through `dependency_groups = [ "test" ]`, once in the `env_run_base` test matrix and once in the `dev` env. 🧹

The `graphviz`, `index`, and `rich` extras stay put, so nothing changes for anyone installing pipdeptree's optional features. `tox run -e 3.13` installs the group and the suite passes.
