### PR TITLE
👷 ci(release): enable pypy wheels and disable fail-fast

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,7 @@ permissions:
 jobs:
   wheels:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
@@ -34,6 +35,7 @@ jobs:
           CIBW_BEFORE_ALL_LINUX: >-
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
           CIBW_BUILD: cp310-* pp311-*
+          CIBW_ENABLE: pypy
           CIBW_ENVIRONMENT_LINUX: PATH=$HOME/.cargo/bin:$PATH
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.15
           CIBW_TEST_COMMAND: pipdeptree --version


### PR DESCRIPTION
All four wheel jobs in the [4.0.0 release run](https://github.com/tox-dev/pipdeptree/actions/runs/29763839642) failed before building anything. cibuildwheel 4 gates PyPy behind an opt-in group, so it rejects the `pp311-*` selector in `CIBW_BUILD` with `Invalid build selector: 'pp311-*'. This selector matches a group that wasn't enabled.` The selector itself is right. PyPy is a supported target, since `meson.build` branches on `sys.implementation.name` to build a non-abi3 extension for it, so only the opt-in went missing and `CIBW_ENABLE: pypy` restores it.

The same run exposed a second problem. With fail-fast at its default, the Linux failure canceled the macOS arm64, macOS x86_64, and Windows jobs mid-build, and their only annotation read `The operation was canceled`, which hid whatever they would have reported. Setting `fail-fast: false` lets each platform finish and report on its own, so a release that loses one wheel still shows the state of the rest.

This workflow runs on tag pushes alone, so the next release tag is the first chance to confirm the fix.
