### PR TITLE
👷 ci: build dists on every check run

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -13,6 +13,8 @@ concurrency:
 permissions:
   contents: read
 jobs:
+  dist:
+    uses: ./.github/workflows/dist.yaml
   rust:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/dist.yaml
+++ b/.github/workflows/dist.yaml
@@ -1,0 +1,65 @@
+name: dist
+on:
+  workflow_call:
+permissions:
+  contents: read
+jobs:
+  wheels:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            arch: x86_64
+          - os: windows-latest
+            arch: AMD64
+          - os: macos-15-intel
+            arch: x86_64
+          - os: macos-latest
+            arch: arm64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Install Rust
+        if: runner.os != 'Linux'
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          cache: false
+      - name: Build wheels
+        uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
+        env:
+          CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_BEFORE_ALL_LINUX: >-
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+          CIBW_BUILD: cp310-* pp311-*
+          CIBW_ENABLE: pypy
+          # musl targets default to a static CRT, which makes Cargo drop the cdylib crate type
+          CIBW_ENVIRONMENT_LINUX: PATH=$HOME/.cargo/bin:$PATH RUSTFLAGS="-C target-feature=-crt-static"
+          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.15
+          CIBW_TEST_COMMAND: pipdeptree --version
+        with:
+          output-dir: dist
+      - name: Store wheels
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: dists-${{ matrix.os }}
+          path: dist/*
+  sdist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          enable-cache: false
+      - name: Build source distribution
+        run: uv build --sdist --out-dir dist
+      - name: Store source distribution
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: dists-sdist
+          path: dist/*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,8 @@ jobs:
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
           CIBW_BUILD: cp310-* pp311-*
           CIBW_ENABLE: pypy
-          CIBW_ENVIRONMENT_LINUX: PATH=$HOME/.cargo/bin:$PATH
+          # musl targets default to a static CRT, which makes Cargo drop the cdylib crate type
+          CIBW_ENVIRONMENT_LINUX: PATH=$HOME/.cargo/bin:$PATH RUSTFLAGS="-C target-feature=-crt-static"
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.15
           CIBW_TEST_COMMAND: pipdeptree --version
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,69 +5,10 @@ on:
 permissions:
   contents: read
 jobs:
-  wheels:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            arch: x86_64
-          - os: windows-latest
-            arch: AMD64
-          - os: macos-15-intel
-            arch: x86_64
-          - os: macos-latest
-            arch: arm64
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-      - name: Install Rust
-        if: runner.os != 'Linux'
-        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
-        with:
-          cache: false
-      - name: Build wheels
-        uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
-        env:
-          CIBW_ARCHS: ${{ matrix.arch }}
-          CIBW_BEFORE_ALL_LINUX: >-
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
-          CIBW_BUILD: cp310-* pp311-*
-          CIBW_ENABLE: pypy
-          # musl targets default to a static CRT, which makes Cargo drop the cdylib crate type
-          CIBW_ENVIRONMENT_LINUX: PATH=$HOME/.cargo/bin:$PATH RUSTFLAGS="-C target-feature=-crt-static"
-          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.15
-          CIBW_TEST_COMMAND: pipdeptree --version
-        with:
-          output-dir: dist
-      - name: Store wheels
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: dists-${{ matrix.os }}
-          path: dist/*
-  sdist:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-      - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
-        with:
-          enable-cache: false
-      - name: Build source distribution
-        run: uv build --sdist --out-dir dist
-      - name: Store source distribution
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: dists-sdist
-          path: dist/*
+  dist:
+    uses: ./.github/workflows/dist.yaml
   release:
-    needs:
-      - sdist
-      - wheels
+    needs: dist
     runs-on: ubuntu-latest
     environment:
       name: release


### PR DESCRIPTION
The cibuildwheel matrix only ran on tag pushes. That meant the manylinux and musllinux containers, the macOS cross builds and the PyPy wheels first executed during a release, and the `4.0.0` tag duly failed on `x86_64-unknown-linux-musl`, where the static CRT default makes Cargo drop the `cdylib` crate type and the meson build then finds no `lib_pipdeptree.so`. Cargo warns and exits `0`. The only visible symptom is a missing artifact. 🔍

I moved the wheel and sdist jobs into a reusable `dist.yaml` that both `check.yaml` and `release.yaml` call, so one copy of the cibuildwheel config serves both and a musl fix cannot land in one workflow while missing the other. `RUSTFLAGS=-C target-feature=-crt-static` covers every Linux build and does nothing on the gnu targets. The `CIBW_ENABLE` and `fail-fast` settings from #624 move across untouched.

Every PR now builds the four-OS wheel matrix and the sdist, adding around six minutes of wall clock to `check`. The release job pulls the same artifacts through `needs: dist`, so its `dists-*` download pattern stays as it was.
