### PR TITLE
📦 pkg: ship a free-threaded wheel

### DIFF
--- a/.github/workflows/dist.yaml
+++ b/.github/workflows/dist.yaml
@@ -33,7 +33,10 @@ jobs:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_BEFORE_ALL_LINUX: >-
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
-          CIBW_BUILD: cp310-* pp311-*
+          # cp310 carries the abi3 wheel every GIL build shares; a free-threaded interpreter cannot use the
+          # limited API, so it takes one wheel of its own. 3.15t waits for a final release rather than
+          # shipping against a beta ABI.
+          CIBW_BUILD: cp310-* cp314t-* pp311-*
           CIBW_ENABLE: pypy
           # musl targets default to a static CRT, which makes Cargo drop the cdylib crate type
           CIBW_ENVIRONMENT_LINUX: PATH=$HOME/.cargo/bin:$PATH RUSTFLAGS="-C target-feature=-crt-static"

--- a/meson.build
+++ b/meson.build
@@ -33,7 +33,15 @@ if host_machine.system() == 'windows'
 else
   rust_artifact = 'lib_pipdeptree.' + (host_machine.system() == 'darwin' ? 'dylib' : 'so')
 endif
-if run_command(py, '-c', 'import sys; print(sys.implementation.name)', check: true).stdout().strip() == 'pypy'
+# PyPy has no stable ABI, and a free-threaded build cannot use the limited API at all, so both take a wheel per
+# interpreter named by its own extension suffix.
+per_interpreter = run_command(
+  py,
+  '-c',
+  'import sys, sysconfig; print(sys.implementation.name == "pypy" or bool(sysconfig.get_config_var("Py_GIL_DISABLED")))',
+  check: true,
+).stdout().strip() == 'True'
+if per_interpreter
   rust_extension = '_rust' + run_command(
     py,
     '-c',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,13 @@ docs = [
 [tool.meson-python]
 limited-api = true
 
+[tool.cibuildwheel]
+overrides = [
+  # meson-python refuses the limited API on a free-threaded interpreter, and the package asks for it by
+  # default, so this build opts out.
+  { select = "cp3*t-*", config-settings.setup-args = "-Dpython.allow_limited_api=false" },
+]
+
 [tool.ruff]
 line-length = 120
 format.preview = true


### PR DESCRIPTION
`pipdeptree` publishes an abi3 wheel built on cp310 plus a PyPy wheel, and the build selector named only those two. A free-threaded interpreter matches neither, so those users fall back to the sdist and need a Rust toolchain to install.

The limited API is unavailable to a free-threaded build, so it cannot share the abi3 wheel. It now takes one of its own: the selector adds `cp314t`, the meson build gives it the per-interpreter extension suffix PyPy already used instead of the abi3 one, and a cibuildwheel override turns off the limited API for that build so meson-python stops refusing it.

`cp315t` waits. cibuildwheel can build it today only with `cpython-prerelease`, which would publish a wheel against a beta ABI.

Published wheels for comparison: `turbohtml`, `pyproject-fmt` and `tox-toml-fmt` already carry `cp314t`; `pipdeptree` was the one C-extension package in the fleet without it.