### PR TITLE
🐛 fix(rust): derive version tests from VERSION file

### DIFF
--- a/rust/tests/public_api/cli.rs
+++ b/rust/tests/public_api/cli.rs
@@ -1,7 +1,8 @@
 use rstest::rstest;
 
 use super::common::{
-    PackageSite, execute, execute_in, execute_with_runner, package_site, stdout, with_python,
+    PackageSite, VERSION, execute, execute_in, execute_with_runner, package_site, stdout,
+    with_python,
 };
 
 #[rstest]
@@ -151,10 +152,11 @@ fn renders_informational_flags(#[case] flag: &str, #[case] expected: &str) {
 #[case::long("--version")]
 fn prints_bare_version(#[case] flag: &str) {
     let output = execute(&[flag]);
+    let expected = format!("{VERSION}\n");
 
     assert_eq!(
         (output.code, stdout(&output), output.stderr.as_str()),
-        (0, "4.0.0\n", "")
+        (0, expected.as_str(), "")
     );
 }
 

--- a/rust/tests/public_api/common.rs
+++ b/rust/tests/public_api/common.rs
@@ -16,6 +16,9 @@ use tempfile::{TempDir, tempdir};
 static PYTHON_LOCK: Mutex<()> = Mutex::new(());
 static RESOLVER: Once = Once::new();
 
+pub const VERSION: &str =
+    include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/VERSION")).trim_ascii_end();
+
 mockall::mock! {
     pub Processes {}
 

--- a/rust/tests/public_api/python.rs
+++ b/rust/tests/public_api/python.rs
@@ -2,7 +2,7 @@ use _pipdeptree::install_python_module;
 use pyo3::types::{PyAnyMethods as _, PyDict, PyDictMethods as _, PyList, PyModule};
 use pyo3::{Bound, PyResult, Python};
 
-use super::common::{PackageSite, with_python};
+use super::common::{PackageSite, VERSION, with_python};
 
 #[test]
 fn reports_python_extension_metadata() {
@@ -26,7 +26,7 @@ fn reports_python_extension_metadata() {
                     .extract::<String>()
                     .unwrap(),
             ),
-            ("rust".to_string(), "4.0.0".to_string())
+            ("rust".to_string(), VERSION.to_string())
         );
     });
 }


### PR DESCRIPTION
The `🔖 release: 4.1.0` commit bumped the `VERSION` file to `4.1.0` but left the CLI and Python metadata assertions pinned to the old `4.0.0` literal, so the `rust` job fails on `main` and on every open pull request, #630 included, even for changes unrelated to the version.

The binary already reads its version from the `VERSION` file through `build.rs`, which exports `PIPDEPTREE_VERSION` for `env!`. The tests now read the same file with `include_str!` at compile time, so the expected value comes from that one source instead of a hand-copied literal.

A later release bump touches only `VERSION`, and the assertions match it without a manual edit.
