### PR TITLE
docs: limit supported versions to latest major and minor release

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -2,8 +2,8 @@
 
 ## Supported Versions
 
-Software updates are provided only for the latest major and minor release.
-Previous major and minor versions are not supported.
+Software updates are provided only for the latest major and minor release. Previous major and minor versions are not
+supported.
 
 ## Reporting a Vulnerability
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -2,10 +2,8 @@
 
 ## Supported Versions
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 2.3.1 + | :white_check_mark: |
-| < 2.3.1 | :x:                |
+Software updates are provided only for the latest major and minor release.
+Previous major and minor versions are not supported.
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
Update SECURITY.md to state that only the latest major and minor version receives updates, replacing the version table that implied an open-ended range of supported releases.