### PR TITLE
🐛 ci(dist): build Linux aarch64 wheels

### DIFF
--- a/.github/workflows/dist.yaml
+++ b/.github/workflows/dist.yaml
@@ -11,6 +11,8 @@ jobs:
         include:
           - os: ubuntu-latest
             arch: x86_64
+          - os: ubuntu-24.04-arm
+            arch: aarch64
           - os: windows-latest
             arch: AMD64
           - os: macos-15-intel


### PR DESCRIPTION
Installing `pipdeptree` 4.1.0 on an ARM64 Linux host fails to build because the release ships no prebuilt `aarch64` wheel. 🐛 `pip` and `uv` fall back to the source distribution, whose Rust extension needs `cargo` and a C toolchain on the target machine, so the build stops at `ERROR: Program 'cargo' not found or not executable` unless the user installs a full compiler chain first.

The wheel matrix in `dist.yaml` covered Linux only on `x86_64`. This adds the GitHub-hosted `ubuntu-24.04-arm` runner so `cibuildwheel` produces native `aarch64` manylinux and musllinux wheels alongside the existing targets. The runner already picks up the shared Rust setup, so `RUSTFLAGS="-C target-feature=-crt-static"` keeps the musl build emitting a `cdylib`.

ARM64 Linux users get a wheel that installs without a build step. The upload artifact name stays keyed on the OS, so the release job's `dists-*` download pattern picks it up unchanged.

Fixes #638
