### PR TITLE
🐛 fix(build): allow free-threaded source builds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,11 @@
+# The limited API stays off by default so a source build on any interpreter, free-threaded ones included,
+# never trips meson-python's refusal to pair the limited API with a free-threaded CPython. The abi3 wheel
+# turns it back on through cibuildwheel.
 project(
   'pipdeptree',
   version: files('VERSION'),
   meson_version: '>=1.11.2',
+  default_options: ['python.allow_limited_api=false'],
 )
 
 py = import('python').find_installation(pure: false)
@@ -33,15 +37,17 @@ if host_machine.system() == 'windows'
 else
   rust_artifact = 'lib_pipdeptree.' + (host_machine.system() == 'darwin' ? 'dylib' : 'so')
 endif
-# PyPy has no stable ABI, and a free-threaded build cannot use the limited API at all, so both take a wheel per
-# interpreter named by its own extension suffix.
+# PyPy has no stable ABI, a free-threaded build cannot use the limited API, and a source build leaves the
+# limited API off (see the project default above), so each of those takes a wheel per interpreter named by its
+# own extension suffix; only an abi3 wheel keeps the stable-ABI name.
 per_interpreter = run_command(
   py,
   '-c',
   'import sys, sysconfig; print(sys.implementation.name == "pypy" or bool(sysconfig.get_config_var("Py_GIL_DISABLED")))',
   check: true,
 ).stdout().strip() == 'True'
-if per_interpreter
+use_limited_api = get_option('python.allow_limited_api') and not per_interpreter
+if not use_limited_api
   rust_extension = '_rust' + run_command(
     py,
     '-c',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,9 +76,9 @@ limited-api = true
 
 [tool.cibuildwheel]
 overrides = [
-  # meson-python refuses the limited API on a free-threaded interpreter, and the package asks for it by
-  # default, so this build opts out.
-  { select = "cp3*t-*", config-settings.setup-args = "-Dpython.allow_limited_api=false" },
+  # The limited API is off by default so every source build works; the single GIL wheel opts back in to ship
+  # one abi3 wheel across CPython versions.
+  { select = "cp310-*", config-settings.setup-args = "-Dpython.allow_limited_api=true" },
 ]
 
 [tool.ruff]


### PR DESCRIPTION
Installing pipdeptree from source on a free-threaded interpreter failed with `meson-python: error: The package targets Python's Limited API, which is not supported by free-threaded CPython`. This hit anyone on a free-threaded build with no matching wheel, such as 3.15t, which [discussion #642](https://github.com/tox-dev/pipdeptree/discussions/642) reported, since we publish `cp314t` but not `cp315t` wheels. The released `meson-python` 0.20.0 refuses the limited API on any free-threaded interpreter, and `limited-api = true` in `pyproject.toml` requested it unconditionally, so the sdist build never got a chance.

The build now leaves `python.allow_limited_api` off by default, so a source build on any interpreter produces a per-interpreter extension that `meson-python` accepts. The `cp310` wheel opts back in through a cibuildwheel override, so the released abi3 wheel that covers every GIL CPython version is unchanged. The earlier free-threaded override that disabled the limited API is now redundant and gone.

Verified locally: a source install on 3.15t and 3.14t now builds a per-interpreter `_rust.cpython-3XXt-*.so` and imports; a regular 3.13 source build produces a version-tagged wheel; and the `cp310` build with `-Dpython.allow_limited_api=true` still yields a `cp310-abi3` wheel carrying `_rust.abi3.so`.
