### PR TITLE
👷 ci(dist): publish free-threaded 3.15t wheels

### DIFF
--- a/.github/workflows/dist.yaml
+++ b/.github/workflows/dist.yaml
@@ -36,10 +36,10 @@ jobs:
           CIBW_BEFORE_ALL_LINUX: >-
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
           # cp310 carries the abi3 wheel every GIL build shares; a free-threaded interpreter cannot use the
-          # limited API, so it takes one wheel of its own. 3.15t waits for a final release rather than
-          # shipping against a beta ABI.
-          CIBW_BUILD: cp310-* cp314t-* pp311-*
-          CIBW_ENABLE: pypy
+          # limited API, so each takes a wheel of its own. 3.15 is still a prerelease, so cpython-prerelease
+          # enables its free-threaded build.
+          CIBW_BUILD: cp310-* cp314t-* cp315t-* pp311-*
+          CIBW_ENABLE: pypy cpython-prerelease
           # musl targets default to a static CRT, which makes Cargo drop the cdylib crate type
           CIBW_ENVIRONMENT_LINUX: PATH=$HOME/.cargo/bin:$PATH RUSTFLAGS="-C target-feature=-crt-static"
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.15


### PR DESCRIPTION
The test matrix runs against `3.15t`, but the wheel matrix published `cp314t` and no `cp315t`, so free-threaded 3.15 users had no wheel and fell back to a source build that needs a Rust toolchain. This adds `cp315t` to `CIBW_BUILD` and enables the `cpython-prerelease` group, which in cibuildwheel 4.1 is the only gate on `cp315*` builds since 3.15 has not had a final release. Free-threading itself is no longer gated, so `cp314t` keeps building as before, and the GIL `cp315` wheel stays unbuilt because the `cp310` abi3 wheel already covers every GIL CPython.

3.15 is still a prerelease, so the wheel is built against a beta ABI (currently 3.15.0b3). If the final 3.15.0 changes the free-threaded ABI, the wheel would need a rebuild, which the release workflow already does on every tag.

Verified locally: a `cp315t` wheel built with `uv build --python 3.15t` tags as `cp315-cp315t`, carries `_rust.cpython-315t-darwin.so`, installs into a clean 3.15t environment, and renders a dependency tree.
