### PR TITLE
👷 ci(dist): pre-install Rust toolchain for aarch64 wheels

### DIFF
--- a/.github/workflows/dist.yaml
+++ b/.github/workflows/dist.yaml
@@ -33,8 +33,11 @@ jobs:
         uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
+          # Install the pinned toolchain and its components up front. Left to rust-toolchain.toml, the first
+          # cargo call in each container provisions them on demand, which races and conflicts on the
+          # cargo-clippy hardlink on aarch64. Keep the channel and components in sync with rust-toolchain.toml.
           CIBW_BEFORE_ALL_LINUX: >-
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.97 --component clippy --component llvm-tools-preview --component rustfmt
           # cp310 carries the abi3 wheel every GIL build shares; a free-threaded interpreter cannot use the
           # limited API, so each takes a wheel of its own. 3.15 is still a prerelease, so cpython-prerelease
           # enables its free-threaded build.


### PR DESCRIPTION
The aarch64 wheel jobs fail intermittently while building the Rust extension, with `error: failed to install component: 'clippy-preview-aarch64-unknown-linux-{gnu,musl}', detected conflict: 'bin/cargo-clippy'`. `rust-toolchain.toml` declares the `clippy`, `rustfmt`, and `llvm-tools-preview` components, so the first `cargo` call in each manylinux and musllinux container provisions the toolchain on demand, and that incremental component install races and conflicts on the `cargo-clippy` hardlink inside the aarch64 containers. Those components exist for the Rust CI job, not the wheel build, which only needs `cargo` and `rustc`.

The cibuildwheel Linux setup now installs the pinned `1.97` toolchain together with its components in the single rustup-init call, so every build finds a complete toolchain and never triggers the on-demand reinstall that conflicts. The channel and component list mirror `rust-toolchain.toml`; a comment flags that they must stay in sync.

This only touches `CIBW_BEFORE_ALL_LINUX`, so the macOS and Windows toolchain setup is unchanged.
