### PR TITLE
👷 ci(release): derive the version from git tags

### DIFF
--- a/.github/workflows/dist.yaml
+++ b/.github/workflows/dist.yaml
@@ -23,12 +23,17 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 0 # The build reads the version off the tags.
           persist-credentials: false
       - name: Install Rust
         if: runner.os != 'Linux'
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           cache: false
+      - name: Resolve the version
+        id: version
+        shell: bash
+        run: echo "value=$(python3 tools/version.py)" >> "$GITHUB_OUTPUT"
       - name: Build wheels
         uses: pypa/cibuildwheel@4726cd35bb13f7bde50cf2761f2499ac7b3aa32c # v4.1.1
         env:
@@ -43,9 +48,12 @@ jobs:
           # enables its free-threaded build.
           CIBW_BUILD: cp310-* cp314t-* cp315t-* pp311-*
           CIBW_ENABLE: pypy cpython-prerelease
+          # The Linux builds run as root in a container over a checkout owned by the runner user, and git
+          # refuses to read the tags there, so the runner resolves the version once for every build.
+          CIBW_ENVIRONMENT: PIPDEPTREE_VERSION=${{ steps.version.outputs.value }}
           # musl targets default to a static CRT, which makes Cargo drop the cdylib crate type
-          CIBW_ENVIRONMENT_LINUX: PATH=$HOME/.cargo/bin:$PATH RUSTFLAGS="-C target-feature=-crt-static"
-          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.15
+          CIBW_ENVIRONMENT_LINUX: PIPDEPTREE_VERSION=${{ steps.version.outputs.value }} PATH=$HOME/.cargo/bin:$PATH RUSTFLAGS="-C target-feature=-crt-static"
+          CIBW_ENVIRONMENT_MACOS: PIPDEPTREE_VERSION=${{ steps.version.outputs.value }} MACOSX_DEPLOYMENT_TARGET=10.15
           CIBW_TEST_COMMAND: pipdeptree --version
         with:
           output-dir: dist
@@ -59,6 +67,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 0 # The build reads the version off the tags.
           persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0

--- a/.github/workflows/dist.yaml
+++ b/.github/workflows/dist.yaml
@@ -34,6 +34,28 @@ jobs:
         id: version
         shell: bash
         run: echo "value=$(python3 tools/version.py)" >> "$GITHUB_OUTPUT"
+      # cibuildwheel pulls its container inside docker create, and a slow quay.io response there fails the job.
+      # It skips that pull when the image is already on the runner, so fetch the image here with retries and point
+      # cibuildwheel at the same tag rather than at the digest it pins itself.
+      - name: Pull the build containers
+        if: runner.os == 'Linux'
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          manylinux="quay.io/pypa/manylinux_2_28_$ARCH"
+          musllinux="quay.io/pypa/musllinux_1_2_$ARCH"
+          for image in "$manylinux" "$musllinux"; do
+            for attempt in 1 2 3; do
+              docker pull "$image" && break
+              if [ "$attempt" -eq 3 ]; then
+                echo "::error::could not pull $image"
+                exit 1
+              fi
+              sleep 15
+            done
+          done
+          echo "CIBW_MANYLINUX_${ARCH^^}_IMAGE=$manylinux" >> "$GITHUB_ENV"
+          echo "CIBW_MUSLLINUX_${ARCH^^}_IMAGE=$musllinux" >> "$GITHUB_ENV"
       - name: Build wheels
         uses: pypa/cibuildwheel@4726cd35bb13f7bde50cf2761f2499ac7b3aa32c # v4.1.1
         env:

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -14,6 +14,8 @@ jobs:
   prepare-release:
     runs-on: ubuntu-latest
     environment: release-auth
+    permissions:
+      contents: write # the release commit and its tag go straight to main
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -1,0 +1,37 @@
+name: Prepare release
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: Version bump over the latest tag
+        required: true
+        type: choice
+        options: [patch, minor, major]
+        default: patch
+permissions:
+  contents: read
+jobs:
+  prepare-release:
+    runs-on: ubuntu-latest
+    environment: release-auth
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0 # The next version comes from the tags.
+          # A tag pushed with the workflow token starts no workflow, so the publish run needs this PAT.
+          token: ${{ secrets.RELEASE_PAT }}
+          persist-credentials: true
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: false
+      # The annotated tag needs a committer identity.
+      - name: Configure git
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+      - name: Tag the release
+        env:
+          BUMP: ${{ inputs.bump }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        run: uvx --with tox-uv tox run -e release -- --bump "$BUMP"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,16 @@ jobs:
           merge-multiple: true
           pattern: dists-*
           path: dist/
+      - name: Check the dists carry the tag version
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          for path in dist/*; do
+            case "${path#dist/}" in
+              pipdeptree-"$TAG"-*.whl | pipdeptree-"$TAG".tar.gz) ;;
+              *) echo "::error::$path is not version $TAG"; exit 1 ;;
+            esac
+          done
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
         with:

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,12 @@
 fn main() {
-    let version_file = format!("{}/VERSION", env!("CARGO_MANIFEST_DIR"));
-    let version = std::fs::read_to_string(&version_file).expect("VERSION must be readable");
+    // Meson passes the version it derived from the git tags; a bare cargo build falls back to the VERSION file.
+    println!("cargo:rerun-if-env-changed=PIPDEPTREE_VERSION");
+    let version = std::env::var("PIPDEPTREE_VERSION").unwrap_or_else(|_| {
+        let version_file = format!("{}/VERSION", env!("CARGO_MANIFEST_DIR"));
+        println!("cargo:rerun-if-changed={version_file}");
+        std::fs::read_to_string(&version_file).expect("VERSION must be readable")
+    });
     println!("cargo:rustc-env=PIPDEPTREE_VERSION={}", version.trim());
-    println!("cargo:rerun-if-changed={version_file}");
     if std::env::var_os("CARGO_FEATURE_EXTENSION_MODULE").is_some()
         && std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos")
     {

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,10 @@
+###########
+ Changelog
+###########
+
+.. towncrier-draft-entries:: Unreleased
+
+.. towncrier release notes start
+
+Releases up to 4.1.0 are recorded on the `GitHub releases page
+<https://github.com/tox-dev/pipdeptree/releases>`_.

--- a/docs/changelog/640.bugfix.rst
+++ b/docs/changelog/640.bugfix.rst
@@ -1,0 +1,2 @@
+Publish Linux ``aarch64`` wheels. 4.1.0 shipped none, so ``pip`` and ``uv`` fell back to the source distribution on
+ARM64 hosts, where building the Rust extension needs a local ``cargo`` and C toolchain.

--- a/docs/changelog/643.bugfix.rst
+++ b/docs/changelog/643.bugfix.rst
@@ -1,0 +1,2 @@
+Build from source on a free-threaded interpreter. The package asked for the limited API unconditionally and
+meson-python refuses to pair it with a free-threaded CPython, so the source build stopped before it started.

--- a/docs/changelog/644.feature.rst
+++ b/docs/changelog/644.feature.rst
@@ -1,0 +1,1 @@
+Publish ``cp315t`` wheels, so a free-threaded 3.15 installs a wheel instead of compiling the Rust extension.

--- a/docs/changelog/647.packaging.rst
+++ b/docs/changelog/647.packaging.rst
@@ -1,0 +1,2 @@
+Take the released version from the git tag rather than from a file in the tree, so a release can no longer ship
+artifacts labeled with the previous version. 4.1.1 and 4.1.2 were tagged that way and reached no index.

--- a/docs/changelog/template.jinja2
+++ b/docs/changelog/template.jinja2
@@ -1,0 +1,22 @@
+{% set top_underline = "*" %}
+{% set underline = "=" %}
+{{ top_underline * ((versiondata.version + versiondata.date)|length + 4) }}
+ {{ versiondata.version }} ({{ versiondata.date }})
+{{ top_underline * ((versiondata.version + versiondata.date)|length + 4) }}
+
+{% for section, _ in sections.items() %}
+{% if sections[section] %}
+{% for category, val in definitions.items() if category in sections[section] %}
+{{ definitions[category]['name'] }} - {{ versiondata.version }}
+{{ underline * ((definitions[category]['name'] + versiondata.version)|length + 3) }}
+
+{% for text, values in sections[section][category].items() %}
+- {{ text }} ({{ values|join(', ') }})
+{% endfor %}
+
+{% endfor %}
+{% else %}
+No significant changes.
+
+{% endif %}
+{% endfor %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from pathlib import Path
 
 from pipdeptree.version import __version__
 
@@ -20,6 +21,7 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_inline_tabs",
     "sphinxcontrib.mermaid",
+    "sphinxcontrib.towncrier.ext",  # render the unreleased news fragments as a draft section
 ]
 
 intersphinx_mapping = {
@@ -31,7 +33,7 @@ autosectionlabel_prefix_document = True
 templates_path = []
 unused_docs = []
 source_suffix = ".rst"
-exclude_patterns = ["_build"]
+exclude_patterns = ["_build", "changelog/*"]  # towncrier assembles the fragments; they are not pages
 
 main_doc = "index"
 pygments_style = "default"
@@ -49,6 +51,10 @@ html_theme_options = {
     "dark_logo": "pipdeptree.svg",
 }
 html_show_sourcelink = False
+
+towncrier_draft_autoversion_mode = "draft"
+towncrier_draft_include_empty = True
+towncrier_draft_working_directory = Path(__file__).parent.parent
 
 extlinks = {
     "issue": ("https://github.com/tox-dev/pipdeptree/issues/%s", "#%s"),

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -103,6 +103,21 @@ Building documentation
 
 Sphinx writes ``.tox/docs_out/html/index.html``.
 
+Releasing
+---------
+
+``tools/version.py`` derives the version from the release tags, so the tag a release carries is the version its wheels
+and sdist report. Nothing in the tree names the version, and the ``VERSION`` file exists for builds with no tags to
+read, such as one from an unpacked sdist.
+
+Cut a release by running the ``Prepare release`` workflow and choosing a bump. It tags the upstream ``main`` branch and
+opens the GitHub release, and that tag push starts the publish workflow. The same steps run from a checkout against
+the upstream remote:
+
+.. code-block:: bash
+
+    tox run -e release -- --bump minor
+
 Contributing
 ------------
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -110,9 +110,13 @@ Releasing
 and sdist report. Nothing in the tree names the version, and the ``VERSION`` file exists for builds with no tags to
 read, such as one from an unpacked sdist.
 
-Cut a release by running the ``Prepare release`` workflow and choosing a bump. It tags the upstream ``main`` branch and
-opens the GitHub release, and that tag push starts the publish workflow. The same steps run from a checkout against
-the upstream remote:
+Every user-visible change brings a news fragment under ``docs/changelog``, named ``<issue>.<type>.rst`` with one of the
+types ``breaking``, ``feature``, ``bugfix``, ``doc`` or ``packaging``. The unreleased fragments render as a draft
+section at the top of :doc:`changelog`, and the release folds them into it.
+
+Cut a release by running the ``Prepare release`` workflow and choosing a bump. It builds the changelog, commits it on
+the upstream ``main`` branch, tags that commit and opens the GitHub release, and that tag push starts the publish
+workflow. The same steps run from a checkout against the upstream remote:
 
 .. code-block:: bash
 
@@ -123,5 +127,6 @@ Contributing
 
 1. Fork the repository.
 2. Create a feature branch.
-3. Run the Rust tests, ``tox run -e 3.14,type,docs,pkg_meta`` and ``prek run --all-files``.
-4. Submit a pull request.
+3. Add a news fragment under ``docs/changelog`` when the change is user-visible.
+4. Run the Rust tests, ``tox run -e 3.14,type,docs,pkg_meta`` and ``prek run --all-files``.
+5. Submit a pull request.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -123,3 +123,4 @@ Beyond visualization, ``pipdeptree`` can:
     :caption: Project
 
     development
+    changelog

--- a/meson.build
+++ b/meson.build
@@ -3,10 +3,13 @@
 # turns it back on through cibuildwheel.
 project(
   'pipdeptree',
-  version: files('VERSION'),
+  version: run_command(['tools/version.py'], check: true).stdout().strip(),
   meson_version: '>=1.11.2',
   default_options: ['python.allow_limited_api=false'],
 )
+
+# Freeze the git-derived version into the sdist so a wheel built from it needs no git history.
+meson.add_dist_script('tools/version.py', '--write')
 
 py = import('python').find_installation(pure: false)
 py.install_sources(
@@ -28,7 +31,6 @@ cargo = find_program('cargo')
 rust_inputs = files(
   'Cargo.lock',
   'Cargo.toml',
-  'VERSION',
   'build.rs',
   'rust-toolchain.toml',
 )
@@ -77,6 +79,7 @@ custom_target(
     rust_artifact,
     rust_features,
     '@DEPFILE@',
+    meson.project_version(),
   ],
   install: true,
   install_dir: py.get_install_dir(pure: false) / 'pipdeptree',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
   "nab-index>=0.0.11",
   "nab-python>=0.0.11",
 ]
-urls.Changelog = "https://github.com/tox-dev/pipdeptree/releases"
+urls.Changelog = "https://pipdeptree.readthedocs.io/en/latest/changelog.html"
 urls.Documentation = "https://pipdeptree.readthedocs.io"
 urls.Homepage = "https://github.com/tox-dev/pipdeptree"
 urls.Source = "https://github.com/tox-dev/pipdeptree"
@@ -69,6 +69,8 @@ docs = [
   "sphinx-copybutton>=0.5.2",
   "sphinx-inline-tabs>=2025.12.21.14",
   "sphinxcontrib-mermaid>=2.1",
+  "sphinxcontrib-towncrier>=0.5.0a0",
+  "towncrier>=25.8",
 ]
 
 [tool.meson-python]
@@ -152,3 +154,17 @@ report.fail_under = 100
 html.show_contexts = true
 html.skip_covered = false
 subtract_omit = "*/__main__.py"
+
+[tool.towncrier]
+directory = "docs/changelog"
+filename = "docs/changelog.rst"
+template = "docs/changelog/template.jinja2"
+title_format = false
+issue_format = ":issue:`{issue}`"
+type = [
+  { directory = "breaking", name = "Backward incompatible changes", showcontent = true },
+  { directory = "feature", name = "Features", showcontent = true },
+  { directory = "bugfix", name = "Bug fixes", showcontent = true },
+  { directory = "doc", name = "Improved documentation", showcontent = true },
+  { directory = "packaging", name = "Packaging updates", showcontent = true },
+]

--- a/tools/build_rust.py
+++ b/tools/build_rust.py
@@ -11,10 +11,10 @@ from typing import Final
 
 
 def main() -> None:
-    cargo, source, destination, artifact, features, depfile = sys.argv[1:]
+    cargo, source, destination, artifact, features, depfile, version = sys.argv[1:]
     output = Path(destination)
     target = output.parent / "cargo-target"
-    environment = {**os.environ, "CARGO_TARGET_DIR": str(target)}
+    environment = {**os.environ, "CARGO_TARGET_DIR": str(target), "PIPDEPTREE_VERSION": version}
     command = [
         cargo,
         "build",

--- a/tools/release.py
+++ b/tools/release.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""
+Cut a release by tagging the upstream main branch and opening the GitHub release for it.
+
+The tag push triggers the publish workflow, and the build reads its version from that tag, so tagging is the whole
+release. The script deletes the tag again when opening the GitHub release fails.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess  # ruff:ignore[suspicious-subprocess-import]  # Tagging and the release API need git and gh.
+from pathlib import Path
+from typing import Final
+
+_ROOT: Final = Path(__file__).resolve().parent.parent
+_UPSTREAM_SLUG: Final = "tox-dev/pipdeptree"
+_RELEASE_TAG: Final = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(prog="release", description=__doc__)
+    target = parser.add_mutually_exclusive_group()
+    target.add_argument("--bump", choices=["major", "minor", "patch"], default="patch", help="how to pick the version")
+    target.add_argument("--version", help="release this exact version instead of bumping")
+    args = parser.parse_args()
+
+    upstream = _upstream()
+    _run("git", "fetch", "--tags", "--force", upstream)
+    tags = _capture("git", "tag").splitlines()
+    version = args.version or _next(tags, args.bump)
+    if version in tags:
+        msg = f"tag {version} already exists"
+        raise RuntimeError(msg)
+    _release(upstream, version)
+
+
+def _upstream() -> str:
+    remotes = _capture("git", "remote").splitlines()
+    # A fork's origin points at the fork, so go by the slug rather than by remote name.
+    for remote in remotes:
+        if _UPSTREAM_SLUG in _capture("git", "remote", "get-url", remote):
+            return remote
+    msg = f"no remote points at {_UPSTREAM_SLUG}, found {remotes}"
+    raise RuntimeError(msg)
+
+
+def _next(tags: list[str], bump: str) -> str:
+    releases = [(int(found[1]), int(found[2]), int(found[3])) for tag in tags if (found := _RELEASE_TAG.match(tag))]
+    major, minor, patch = max(releases, default=(0, 0, 0))
+    if bump == "major":
+        return f"{major + 1}.0.0"
+    if bump == "minor":
+        return f"{major}.{minor + 1}.0"
+    return f"{major}.{minor}.{patch + 1}"
+
+
+def _release(upstream: str, version: str) -> None:
+    _run("git", "tag", "--annotate", "--message", f"release {version}", version, f"{upstream}/main")
+    _run("git", "push", upstream, f"refs/tags/{version}")
+    try:
+        _run("gh", "release", "create", version, "--title", version, "--generate-notes", "--verify-tag")
+    except subprocess.CalledProcessError:
+        # The rollback has to show in the job log.
+        print(f"opening the release failed, dropping the {version} tag again")  # ruff:ignore[print]
+        _run("git", "push", upstream, f":refs/tags/{version}", check=False)
+        raise
+
+
+def _run(*command: str, check: bool = True) -> None:
+    subprocess.run(  # ruff:ignore[subprocess-without-shell-equals-true]  # Fixed argument list.
+        command,
+        cwd=_ROOT,
+        check=check,
+    )
+
+
+def _capture(*command: str) -> str:
+    result = subprocess.run(  # ruff:ignore[subprocess-without-shell-equals-true]  # Fixed argument list.
+        command,
+        cwd=_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+if __name__ == "__main__":
+    main()
+
+
+__all__: Final = []

--- a/tools/release.py
+++ b/tools/release.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """
-Cut a release by tagging the upstream main branch and opening the GitHub release for it.
+Cut a release: build the changelog, commit it on the upstream main branch, and tag it.
 
-The tag push triggers the publish workflow, and the build reads its version from that tag, so tagging is the whole
-release. The script deletes the tag again when opening the GitHub release fails.
+The tag push triggers the publish workflow, and the build reads its version from that tag, so nothing in the tree
+names the version. Each step lands upstream only once the ones before it went through.
 """
 
 from __future__ import annotations
@@ -25,6 +25,10 @@ def main() -> None:
     target.add_argument("--bump", choices=["major", "minor", "patch"], default="patch", help="how to pick the version")
     target.add_argument("--version", help="release this exact version instead of bumping")
     args = parser.parse_args()
+
+    if _capture("git", "status", "--porcelain"):
+        msg = "the working tree is dirty; commit or stash before releasing"
+        raise RuntimeError(msg)
 
     upstream = _upstream()
     _run("git", "fetch", "--tags", "--force", upstream)
@@ -57,15 +61,13 @@ def _next(tags: list[str], bump: str) -> str:
 
 
 def _release(upstream: str, version: str) -> None:
-    _run("git", "tag", "--annotate", "--message", f"release {version}", version, f"{upstream}/main")
+    _run("git", "switch", "--force-create", f"release-{version}", f"{upstream}/main")
+    _run("towncrier", "build", "--yes", "--version", version)
+    _run("git", "commit", "--all", "--message", f"release {version}")
+    _run("git", "push", upstream, "HEAD:main")
+    _run("git", "tag", "--annotate", "--message", f"release {version}", version)
     _run("git", "push", upstream, f"refs/tags/{version}")
-    try:
-        _run("gh", "release", "create", version, "--title", version, "--generate-notes", "--verify-tag")
-    except subprocess.CalledProcessError:
-        # The rollback has to show in the job log.
-        print(f"opening the release failed, dropping the {version} tag again")  # ruff:ignore[print]
-        _run("git", "push", upstream, f":refs/tags/{version}", check=False)
-        raise
+    _run("gh", "release", "create", version, "--title", version, "--generate-notes", "--verify-tag")
 
 
 def _run(*command: str, check: bool = True) -> None:

--- a/tools/version.py
+++ b/tools/version.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""
+Derive the version from the git tags for the Meson build.
+
+Meson calls this at configure time and uses the printed string as the project version, the way setuptools-scm derives
+one from the latest tag. ``meson dist`` calls it again with ``--write`` to freeze the resolved version into the sdist's
+VERSION file, so a wheel built from that sdist reports the right version without git history.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess  # ruff:ignore[suspicious-subprocess-import]  # Reading the tags needs the git executable.
+import sys
+from pathlib import Path
+from typing import Final
+
+_ROOT: Final = Path(__file__).resolve().parent.parent
+_VERSION_FILE: Final = "VERSION"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(prog="version", description=__doc__)
+    parser.add_argument("--write", action="store_true", help=f"write the version to {_VERSION_FILE} in the dist root")
+    args = parser.parse_args()
+    version = _resolve()
+    if args.write:
+        (Path(os.environ["MESON_DIST_ROOT"]) / _VERSION_FILE).write_text(f"{version}\n", encoding="utf-8")
+    print(version)  # ruff:ignore[print]  # Meson reads the version off this output.
+
+
+def _resolve() -> str:
+    if (pretend := os.environ.get("PIPDEPTREE_VERSION")) is not None:
+        return pretend  # A build with no history of its own, such as one cibuildwheel runs inside a container.
+    if (from_git := _from_git()) is not None:
+        return from_git
+    if (_ROOT / ".git").exists():
+        print(  # ruff:ignore[print]  # A stale version has to show in the build log.
+            f"warning: no release tag reachable from HEAD, falling back to {_VERSION_FILE}; "
+            "run git fetch --tags in a shallow clone",
+            file=sys.stderr,
+        )
+    return (_ROOT / _VERSION_FILE).read_text(encoding="utf-8").strip()
+
+
+def _from_git() -> str | None:
+    if (described := _git("describe", "--tags", "--long", "--match", "[0-9]*")) is None:
+        return None
+    tag, distance, commit = described.rsplit("-", 2)
+    return tag if int(distance) == 0 else f"{tag}.dev{distance}+{commit}"  # The commit already carries the leading g.
+
+
+def _git(*args: str) -> str | None:
+    try:
+        completed = subprocess.run(  # ruff:ignore[subprocess-without-shell-equals-true]  # Fixed argument list.
+            ["git", *args],  # ruff:ignore[start-process-with-partial-path]  # Git comes off PATH, as for any build.
+            capture_output=True,
+            text=True,
+            cwd=_ROOT,
+            check=False,
+        )
+    except FileNotFoundError:  # Git is absent, as in a container building from an unpacked sdist.
+        return None
+    return completed.stdout.strip() if completed.returncode == 0 else None
+
+
+if __name__ == "__main__":
+    main()
+
+
+__all__: Final = []

--- a/tox.toml
+++ b/tox.toml
@@ -127,8 +127,9 @@ commands = [
 ]
 
 [env.release]
-description = "tag the next release and open its GitHub release"
+description = "build the changelog for the next release, then commit and tag it"
 skip_install = true
+deps = [ "towncrier>=25.8" ]
 pass_env = [ "GH_TOKEN" ]
 commands = [ [ "python", "{tox_root}{/}tools{/}release.py", { replace = "posargs", extend = true } ] ]
 

--- a/tox.toml
+++ b/tox.toml
@@ -126,6 +126,12 @@ commands = [
   ],
 ]
 
+[env.release]
+description = "tag the next release and open its GitHub release"
+skip_install = true
+pass_env = [ "GH_TOKEN" ]
+commands = [ [ "python", "{tox_root}{/}tools{/}release.py", { replace = "posargs", extend = true } ] ]
+
 [env."3.15t"]
 skip_install = true
 # meson-python refuses the limited API on a free-threaded interpreter, and the package asks for it by default, so


### PR DESCRIPTION
The 4.1.1 and 4.1.2 releases built without error and never reached PyPI. Both tags left `VERSION` at `4.1.0`, so every wheel and the sdist repeated the release PyPI already held, and PyPI rejected the upload. The tag and the version compiled into the artifacts were two independent facts, and no step compared them, which is what turned a forgotten one-line bump into two burnt version numbers.

Meson now takes the project version from `tools/version.py`, which describes `HEAD` against the release tags the way setuptools-scm does, and `meson.add_dist_script` freezes the resolved string into the sdist's `VERSION` so a wheel built from that sdist needs no history. Cargo receives the same string through `tools/build_rust.py`, and `build.rs` falls back to the file for a bare `cargo build`. The Linux wheels get the version handed to them in `CIBW_ENVIRONMENT` rather than deriving it themselves, since cibuildwheel's containers run as root over a checkout owned by the runner user and cannot read its git history; that keeps every artifact of a release on one string.

Tagging is now the whole bump, so `tools/release.py` and the `Prepare release` workflow do it: pick the next version off the tags, build the changelog, commit it on upstream `main`, tag that commit, push, and open the GitHub release. The publish job refuses to upload dists whose filenames disagree with `github.ref_name`, so a hand-pushed tag that resolves wrong fails in the release job instead of at PyPI. 🔖

Release notes used to be whatever GitHub generated from merged PR titles, which left 4.1.1 and 4.1.2 with no record of what they carried. Changes now land with a news fragment under `docs/changelog`, towncrier folds them into `docs/changelog.rst`, and the docs render the pending ones as a draft section. The four fragments here cover everything since 4.1.0 and ship under 4.2.0: the `aarch64` and `cp315t` wheels, the free-threaded source build, and this versioning change.

The last commit fixes what killed the first CI run on this branch. cibuildwheel pulls its container from inside `docker create`, so a slow quay.io response fails the wheel job outright; it skips that pull when the image already sits on the runner, so the workflow pulls it beforehand with three attempts and names the image so both sides agree on one reference.

Two things need you before this helps. The workflow reads `secrets.RELEASE_PAT` from a `release-auth` environment, which has to exist on the repository, because a tag pushed with the workflow token starts no publish run. And the 4.1.1 and 4.1.2 tags still point at commits whose artifacts claim 4.1.0, so they and their GitHub releases go away once this lands, and the next release goes out as 4.2.0.
