### PR TITLE
👷 ci(dist): build the wheels beside each other

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -101,3 +101,12 @@ jobs:
         env:
           PYTEST_ADDOPTS: "-vv --durations=20"
           DIFF_AGAINST: HEAD
+  # The one context branch protection requires, so a matrix that grows or renames its cells needs no ruleset edit.
+  check:
+    needs: [dist, rust, test]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail when a job this one waited on did
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1

--- a/.github/workflows/dist.yaml
+++ b/.github/workflows/dist.yaml
@@ -24,11 +24,20 @@ jobs:
           - os: windows-latest
             arch: AMD64
         include:
-          - build: every
+          # The Intel runner takes about twice as long as the arm one for the same work, so it splits its four
+          # builds over two jobs; three macOS jobs stay well inside the cap that made a job per interpreter queue.
+          - build: gil
+            identifiers: cp310-* pp311-*
+            platform:
+              os: macos-15-intel
+              arch: x86_64
+          - build: free-threaded
+            identifiers: cp314t-* cp315t-*
             platform:
               os: macos-15-intel
               arch: x86_64
           - build: every
+            identifiers: cp310-* cp314t-* cp315t-* pp311-*
             platform:
               os: macos-latest
               arch: arm64
@@ -84,7 +93,7 @@ jobs:
           CIBW_BEFORE_ALL_LINUX: >-
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.97 --component clippy --component llvm-tools-preview --component rustfmt
           # 3.15 is still a prerelease, so cpython-prerelease enables its free-threaded build.
-          CIBW_BUILD: ${{ matrix.build == 'every' && 'cp310-* cp314t-* cp315t-* pp311-*' || format('{0}-*', matrix.build) }}
+          CIBW_BUILD: ${{ matrix.identifiers || format('{0}-*', matrix.build) }}
           CIBW_ENABLE: pypy cpython-prerelease
           # The Linux builds run as root in a container over a checkout owned by the runner user, and git
           # refuses to read the tags there, so the runner resolves the version once for every build.

--- a/.github/workflows/dist.yaml
+++ b/.github/workflows/dist.yaml
@@ -4,9 +4,10 @@ on:
 permissions:
   contents: read
 jobs:
-  # One job per interpreter and platform. cibuildwheel builds the identifiers it is given one after another, and
-  # each recompiles the Rust dependency graph for about a minute, so a job that carried all four ran for a quarter of
-  # an hour on the slowest runner while the rest of the matrix sat idle.
+  # cibuildwheel builds the identifiers it is handed one after another and each recompiles the Rust dependency
+  # graph, so the interpreter joins the matrix and those builds run beside each other. macOS is the exception: its
+  # runners are capped and shared across the org, so a job per interpreter there only queues, and the four builds
+  # stay in one job that reuses a single Cargo target directory instead.
   wheels:
     name: wheels ${{ matrix.build }} ${{ matrix.platform.os }}
     strategy:
@@ -22,10 +23,15 @@ jobs:
             arch: aarch64
           - os: windows-latest
             arch: AMD64
-          - os: macos-15-intel
-            arch: x86_64
-          - os: macos-latest
-            arch: arm64
+        include:
+          - build: every
+            platform:
+              os: macos-15-intel
+              arch: x86_64
+          - build: every
+            platform:
+              os: macos-latest
+              arch: arm64
     runs-on: ${{ matrix.platform.os }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -78,14 +84,15 @@ jobs:
           CIBW_BEFORE_ALL_LINUX: >-
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.97 --component clippy --component llvm-tools-preview --component rustfmt
           # 3.15 is still a prerelease, so cpython-prerelease enables its free-threaded build.
-          CIBW_BUILD: ${{ matrix.build }}-*
+          CIBW_BUILD: ${{ matrix.build == 'every' && 'cp310-* cp314t-* cp315t-* pp311-*' || format('{0}-*', matrix.build) }}
           CIBW_ENABLE: pypy cpython-prerelease
           # The Linux builds run as root in a container over a checkout owned by the runner user, and git
           # refuses to read the tags there, so the runner resolves the version once for every build.
           CIBW_ENVIRONMENT: PIPDEPTREE_VERSION=${{ steps.version.outputs.value }}
           # musl targets default to a static CRT, which makes Cargo drop the cdylib crate type
           CIBW_ENVIRONMENT_LINUX: PIPDEPTREE_VERSION=${{ steps.version.outputs.value }} PATH=$HOME/.cargo/bin:$PATH RUSTFLAGS="-C target-feature=-crt-static"
-          CIBW_ENVIRONMENT_MACOS: PIPDEPTREE_VERSION=${{ steps.version.outputs.value }} MACOSX_DEPLOYMENT_TARGET=10.15
+          # One target directory across the four builds leaves the dependency graph compiled after the first
+          CIBW_ENVIRONMENT_MACOS: PIPDEPTREE_VERSION=${{ steps.version.outputs.value }} MACOSX_DEPLOYMENT_TARGET=10.15 CARGO_TARGET_DIR=$HOME/cargo-target
           CIBW_TEST_COMMAND: pipdeptree --version
         with:
           output-dir: dist

--- a/.github/workflows/dist.yaml
+++ b/.github/workflows/dist.yaml
@@ -4,11 +4,18 @@ on:
 permissions:
   contents: read
 jobs:
+  # One job per interpreter and platform. cibuildwheel builds the identifiers it is given one after another, and
+  # each recompiles the Rust dependency graph for about a minute, so a job that carried all four ran for a quarter of
+  # an hour on the slowest runner while the rest of the matrix sat idle.
   wheels:
+    name: wheels ${{ matrix.build }} ${{ matrix.platform.os }}
     strategy:
       fail-fast: false
       matrix:
-        include:
+        # cp310 carries the abi3 wheel every GIL build shares; a free-threaded interpreter cannot use the limited
+        # API, so each takes a wheel of its own.
+        build: [cp310, cp314t, cp315t, pp311]
+        platform:
           - os: ubuntu-latest
             arch: x86_64
           - os: ubuntu-24.04-arm
@@ -19,7 +26,7 @@ jobs:
             arch: x86_64
           - os: macos-latest
             arch: arm64
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.platform.os }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -40,11 +47,16 @@ jobs:
       - name: Pull the build containers
         if: runner.os == 'Linux'
         env:
-          ARCH: ${{ matrix.arch }}
+          ARCH: ${{ matrix.platform.arch }}
+          BUILD: ${{ matrix.build }}
         run: |
           manylinux="quay.io/pypa/manylinux_2_28_$ARCH"
           musllinux="quay.io/pypa/musllinux_1_2_$ARCH"
-          for image in "$manylinux" "$musllinux"; do
+          images="$manylinux"
+          if [ "$BUILD" != pp311 ]; then # PyPy publishes no musllinux wheel, so that container stays unused
+            images="$images $musllinux"
+          fi
+          for image in $images; do
             for attempt in 1 2 3; do
               docker pull "$image" && break
               if [ "$attempt" -eq 3 ]; then
@@ -59,16 +71,14 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@4726cd35bb13f7bde50cf2761f2499ac7b3aa32c # v4.1.1
         env:
-          CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_ARCHS: ${{ matrix.platform.arch }}
           # Install the pinned toolchain and its components up front. Left to rust-toolchain.toml, the first
           # cargo call in each container provisions them on demand, which races and conflicts on the
           # cargo-clippy hardlink on aarch64. Keep the channel and components in sync with rust-toolchain.toml.
           CIBW_BEFORE_ALL_LINUX: >-
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.97 --component clippy --component llvm-tools-preview --component rustfmt
-          # cp310 carries the abi3 wheel every GIL build shares; a free-threaded interpreter cannot use the
-          # limited API, so each takes a wheel of its own. 3.15 is still a prerelease, so cpython-prerelease
-          # enables its free-threaded build.
-          CIBW_BUILD: cp310-* cp314t-* cp315t-* pp311-*
+          # 3.15 is still a prerelease, so cpython-prerelease enables its free-threaded build.
+          CIBW_BUILD: ${{ matrix.build }}-*
           CIBW_ENABLE: pypy cpython-prerelease
           # The Linux builds run as root in a container over a checkout owned by the runner user, and git
           # refuses to read the tags there, so the runner resolves the version once for every build.
@@ -82,7 +92,7 @@ jobs:
       - name: Store wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: dists-${{ matrix.os }}
+          name: dists-${{ matrix.platform.os }}-${{ matrix.build }}
           path: dist/*
   sdist:
     runs-on: ubuntu-latest

--- a/docs/changelog/648.packaging.rst
+++ b/docs/changelog/648.packaging.rst
@@ -1,3 +1,2 @@
-Build each interpreter's wheel in its own CI job. cibuildwheel worked through the four identifiers one after another
-and every one recompiled the Rust dependency graph, so the wheel matrix held a pull request for 17 minutes while most
-of the runners sat idle.
+Build the wheels for each interpreter beside each other in CI, rather than one after another in a single job, and let
+the macOS builds share one Cargo target directory. The wheel matrix used to hold a pull request for 17 minutes.

--- a/docs/changelog/648.packaging.rst
+++ b/docs/changelog/648.packaging.rst
@@ -1,0 +1,3 @@
+Build each interpreter's wheel in its own CI job. cibuildwheel worked through the four identifiers one after another
+and every one recompiled the Rust dependency graph, so the wheel matrix held a pull request for 17 minutes while most
+of the runners sat idle.

--- a/tools/build_rust.py
+++ b/tools/build_rust.py
@@ -13,7 +13,8 @@ from typing import Final
 def main() -> None:
     cargo, source, destination, artifact, features, depfile, version = sys.argv[1:]
     output = Path(destination)
-    target = output.parent / "cargo-target"
+    # A caller that points CARGO_TARGET_DIR somewhere shared keeps the dependency graph compiled between builds
+    target = Path(os.environ.get("CARGO_TARGET_DIR", output.parent / "cargo-target"))
     environment = {**os.environ, "CARGO_TARGET_DIR": str(target), "PIPDEPTREE_VERSION": version}
     command = [
         cargo,


### PR DESCRIPTION
Every review waits on the wheel matrix. On the last run of #647 the whole `check` workflow took 17m42s, of which `dist / wheels (macos-15-intel, x86_64)` alone accounted for 16m43s, while every test cell finished inside 4 minutes.

The time goes to repeated compilation. cibuildwheel works through its identifiers one after another, each in a fresh build directory, so `cp310`, `cp314t`, `cp315t` and `pp311` each rebuilt the whole Rust dependency graph:

```
Finished `release` profile [optimized] target(s) in 1m 21s   ✓ cp310-macosx_arm64  finished in 2 minutes
Finished `release` profile [optimized] target(s) in 1m 06s   ✓ cp314t-macosx_arm64 finished in 2 minutes
Finished `release` profile [optimized] target(s) in 1m 02s   ✓ cp315t-macosx_arm64 finished in 2 minutes
```

The first attempt gave every interpreter its own job, and the wall clock did not move at all. The org shares one small pool of macOS runners, so those eight jobs queued for up to 12m42s each while Linux and Windows started within 6 seconds. Splitting macOS raised contention rather than parallelism.

So the layout follows the runners. Linux and Windows take one job per interpreter, where jobs are plentiful. macOS keeps few jobs and makes each one cheaper: the arm runner builds all four identifiers in one job, the Intel runner splits its four over two jobs because it takes about twice as long for the same work, and all of them point `CARGO_TARGET_DIR` at one directory so only a job's first build pays that compilation cost. That cut the arm job from 8m to 4m18s and the two Intel jobs to 6m54s and 6m, which is where the run now ends. ⚡

A review now waits 7m6s rather than 17m42s, and coverage does not change anywhere: the same four identifiers on the same five platforms, and a release publishes the same 27 files.

| layout | wall clock |
| --- | --- |
| today: 5 jobs, identifiers in sequence | 17m42s |
| 20 jobs, one per interpreter | 17m42s, macOS queued 12m42s |
| 14 jobs, macOS sharing a target directory | 11m36s |
| 15 jobs, Intel macOS split in two | 7m6s |

The last commit is for branch protection rather than speed. The ruleset names all 28 contexts, five of them wheel jobs whose names this PR changes, so those five would sit as "expected" forever on a pull request from anyone without bypass. A `check` job that waits on `dist`, `rust` and `test` gives protection one stable name, and the ruleset can then require `check`, `docs/readthedocs.org:pipdeptree` and `pre-commit.ci - pr` instead. That swap happens once this lands, since `check` cannot report on `main` before then.

Artifact names carry the interpreter now (`dists-<os>-<build>`), which the release job already collects through its `dists-*` pattern, and the PyPy jobs skip the musllinux container pull, since PyPy publishes no musllinux wheel.
