### PR TITLE
🐛 fix(env): accept git-built interpreter versions

### DIFF
--- a/docs/changelog/656.bugfix.rst
+++ b/docs/changelog/656.bugfix.rst
@@ -1,0 +1,4 @@
+Run under an interpreter built from a git checkout. Such a build reports its version with a trailing plus
+(``3.13.5+``), which PEP 440 reads as an empty local segment and rejects, so every run stopped with ``found a `+`
+indicating the start of a local component in a version``. The trailing plus is now dropped, and a marker value that
+still fails to parse names the interpreter versions it came from.

--- a/rust/src/environment.rs
+++ b/rust/src/environment.rs
@@ -145,6 +145,9 @@ impl Runtime {
 
 impl MarkerValues {
     fn as_environment(&self) -> Result<MarkerEnvironment, Error> {
+        // An interpreter built from a git checkout reports its version with a trailing plus
+        // (3.13.5+), which PEP 440 reads as the start of an empty local segment and rejects.
+        let python_full_version = self.python_full_version.trim_end_matches('+');
         MarkerEnvironment::try_from(MarkerEnvironmentBuilder {
             implementation_name: &self.implementation_name,
             implementation_version: &self.implementation_version,
@@ -154,11 +157,17 @@ impl MarkerValues {
             platform_release: &self.platform_release,
             platform_system: &self.platform_system,
             platform_version: &self.platform_version,
-            python_full_version: &self.python_full_version,
+            python_full_version,
             python_version: &self.python_version,
             sys_platform: &self.sys_platform,
         })
-        .map_err(|error| Error::message(error.to_string()))
+        .map_err(|error| {
+            Error::message(format!(
+                "Failed to read the interpreter version markers (implementation_version={}, \
+                 python_full_version={}, python_version={}): {error}",
+                self.implementation_version, self.python_full_version, self.python_version
+            ))
+        })
     }
 }
 

--- a/rust/tests/public_api/environment.rs
+++ b/rust/tests/public_api/environment.rs
@@ -399,6 +399,50 @@ fn detects_environment_variables(#[case] variable: &str) {
 }
 
 #[test]
+fn accepts_development_interpreter_versions() {
+    let site = PackageSite::new();
+    site.write(
+        "demo-1.dist-info",
+        "Name: demo\nVersion: 1\nRequires-Dist: child; python_full_version >= '3.13.5'\n",
+    );
+    site.write("child-1.dist-info", "Name: child\nVersion: 1\n");
+    let interpreter = site.path().join("python");
+    let mut info = serde_json::from_slice::<serde_json::Value>(&interpreter_info(
+        &[site.path()],
+        &interpreter,
+        site.path(),
+        site.path(),
+        site.path(),
+    ))
+    .unwrap();
+    info["marker"]["python_full_version"] = "3.13.5+".into();
+    info["marker"]["python_version"] = "3.13".into();
+    let mut processes = MockProcesses::new();
+    processes
+        .expect_run()
+        .return_once(move |_| Ok(process_output(serde_json::to_vec(&info).unwrap())));
+
+    with_python(|python| {
+        let output = execute_with_runner(
+            &processes,
+            python,
+            &[
+                "--python",
+                interpreter.to_str().unwrap(),
+                "--encoding",
+                "ascii",
+            ],
+            false,
+        );
+
+        assert_eq!(
+            (output.code, stdout(&output), output.stderr.as_str()),
+            (0, "demo==1\n  - child [required: Any, installed: 1]\n", "")
+        );
+    });
+}
+
+#[test]
 fn rejects_invalid_marker_environment() {
     let site = PackageSite::new();
     let interpreter = site.path().join("python");
@@ -424,7 +468,17 @@ fn rejects_invalid_marker_environment() {
             false,
         );
 
-        assert_eq!((output.code, output.stderr.is_empty()), (1, false));
+        assert_eq!(
+            (
+                output.code,
+                output.stderr.contains(
+                    "Failed to read the interpreter version markers \
+                     (implementation_version=3.14.0, python_full_version=3.14.0, \
+                     python_version=invalid)"
+                ),
+            ),
+            (1, true)
+        );
     });
 }
 


### PR DESCRIPTION
A `pipdeptree` run under a CPython built from a maintenance branch fails with ``found a `+` indicating the start of a local component in a version, but did not find any alphanumeric ASCII segment following the `+` `` before it reads a single package. Closes [#656](https://github.com/tox-dev/pipdeptree/issues/656) reports this against 4.2.0. Those builds set `PY_VERSION` to a value like `3.13.15+`, `platform.python_version()` returns it unchanged, and PEP 440 rejects the empty local segment that the trailing `+` opens.

Trim that trailing `+` off `python_full_version` before building the marker environment. Markers compare releases, so `3.13.15+` and `3.13.15` satisfy the same ones, and the empty segment holds nothing a marker could read. When a marker value still fails to parse, the error now names `implementation_version`, `python_full_version` and `python_version`, so you can tell which of the three broke.

I built a CPython from `upstream/3.13` that reports `3.13.15+`. Against it 4.2.0 exits 1 with the reported error, while this branch renders the tree in process and through `--python`.
