### PR TITLE
ci: run Cargo and Rust toolchain Dependabot updates weekly

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,14 +6,12 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 7
-
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
       time: "14:00"
-
   - package-ecosystem: "rust-toolchain"
     directory: "/"
     schedule:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,3 +6,17 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 7
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "14:00"
+
+  - package-ecosystem: "rust-toolchain"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "14:00"


### PR DESCRIPTION
Adds cargo and rust-toolchain ecosystems for dependabot to create updates for.