### PR TITLE
📄 docs: publish llms.txt from the docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -14,6 +15,7 @@ release = __version__
 globals()["copyright"] = f"2014-{datetime.now(tz=timezone.utc).year}, {company}"
 
 extensions = [
+    "sphinx_llm.txt",
     "sphinx.ext.autosectionlabel",
     "sphinx.ext.doctest",
     "sphinx.ext.extlinks",
@@ -62,3 +64,5 @@ extlinks = {
     "user": ("https://github.com/%s", "@%s"),
     "pypi": ("https://pypi.org/project/%s", "%s"),
 }
+
+markdown_http_base = os.environ.get("READTHEDOCS_CANONICAL_URL", "")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ docs = [
   "sphinx>=9.1",
   "sphinx-copybutton>=0.5.2",
   "sphinx-inline-tabs>=2025.12.21.14",
+  "sphinx-llm>=0.4.1",
   "sphinxcontrib-mermaid>=2.1",
   "sphinxcontrib-towncrier>=0.5.0a0",
   "towncrier>=25.8",


### PR DESCRIPTION
The [sphinx-llm](https://github.com/NVIDIA/sphinx-llm) extension emits `llms.txt` ([llmstxt.org](https://llmstxt.org/)), `llms-full.txt`, and a markdown twin of each page during the HTML build; Read the Docs serves `llms.txt` from the docs domain root ([announcement](https://about.readthedocs.com/blog/2026/02/llms-txt-support/)). Plain markdown lets agents read the docs without rendering themed, JavaScript-dependent HTML. `markdown_http_base` keeps the sitemap links absolute so they resolve from the domain root.
