### PR TITLE
🐛 fix(metadata): warn only on real archive search paths

### DIFF
--- a/docs/changelog/669.bugfix.rst
+++ b/docs/changelog/669.bugfix.rst
@@ -1,0 +1,3 @@
+Stop warning about the console-script launcher on Windows. Python puts the running ``pipdeptree.exe`` on
+``sys.path``, and every file on the search path counted as an archive, so each run reported ``unsupported archives on
+the search path``. Only files whose suffix is ``.egg``, ``.pyz``, ``.pyzw``, ``.whl`` or ``.zip`` are now reported.

--- a/rust/src/metadata.rs
+++ b/rust/src/metadata.rs
@@ -23,6 +23,7 @@ use editable::{EggLinks, file_url_to_path};
 pub use vcs::reset_caches as reset_vcs_caches;
 
 const MAX_LICENSE_NAME: usize = 64;
+const ARCHIVE_SUFFIXES: [&str; 5] = ["egg", "pyz", "pyzw", "whl", "zip"];
 
 #[derive(Debug)]
 pub struct Package {
@@ -392,7 +393,7 @@ fn discover_with_fields(
         let Ok(entries) = fs::read_dir(path) else {
             // Nonexistent sys.path entries are routine; a file (zipped egg, zipapp) held
             // packages the old importlib-based discovery listed, so losing it deserves a warning.
-            if path.is_file() {
+            if is_archive(path) {
                 archive_paths.insert(path.clone());
             }
             continue;
@@ -434,6 +435,16 @@ fn discover_with_fields(
         packages,
         warnings: path_warnings(&archive_paths, &invalid_paths, duplicates),
     })
+}
+
+// Windows puts the console-script launcher itself on sys.path[0] (a zip appended to an .exe), and it
+// never holds installed distributions; only a recognized archive suffix is worth warning about.
+fn is_archive(path: &Path) -> bool {
+    path.extension().is_some_and(|suffix| {
+        ARCHIVE_SUFFIXES
+            .iter()
+            .any(|known| suffix.eq_ignore_ascii_case(known))
+    }) && path.is_file()
 }
 
 enum Found {

--- a/rust/tests/public_api/metadata.rs
+++ b/rust/tests/public_api/metadata.rs
@@ -72,18 +72,25 @@ fn renders_selected_metadata_and_size() {
     );
 }
 
-#[test]
-fn warns_about_archive_search_paths() {
+#[rstest]
+#[case::archive("bundle.zip", 1, true)]
+#[case::uppercase_archive("bundle.ZIP", 1, true)]
+#[case::console_script_launcher("pipdeptree.exe", 0, false)]
+fn warns_only_about_archive_search_paths(
+    #[case] name: &str,
+    #[case] code: i32,
+    #[case] warns: bool,
+) {
     let site = PackageSite::new();
     site.write("demo-1.dist-info", "Name: demo\nVersion: 1\n");
-    let archive = site.path().join("bundle.zip");
-    fs::write(&archive, "not a directory").unwrap();
+    let file = site.path().join(name);
+    fs::write(&file, "not a directory").unwrap();
 
     let output = execute(&[
         "--path",
         site.path().to_str().unwrap(),
         "--path",
-        archive.to_str().unwrap(),
+        file.to_str().unwrap(),
         "--warn",
         "fail",
     ]);
@@ -93,9 +100,9 @@ fn warns_about_archive_search_paths() {
             output.code,
             stdout(&output).contains("demo==1"),
             output.stderr.contains("unsupported archives"),
-            output.stderr.contains("bundle.zip"),
+            output.stderr.contains(name),
         ),
-        (1, true, true, true)
+        (code, true, warns, warns)
     );
 }
 


### PR DESCRIPTION
Running `pipdeptree.exe` on Windows has printed `Warning: unsupported archives on the search path; the packages inside are not listed: C:\Python314\Scripts\pipdeptree.exe` since 4.0.0 ([#669](https://github.com/tox-dev/pipdeptree/issues/669)). Python puts the console-script launcher on `sys.path`, and pipdeptree counted any search-path entry it could not read as a directory as an archive whose packages it had to skip.

The warning now covers entries suffixed `.egg`, `.pyz`, `.pyzw`, `.whl` or `.zip`, the forms `zipimport` serves installed distributions from. Checking the file header instead would misjudge both directions. A zipapp can start with a shebang line ahead of the zip magic, and the launcher does carry a zip of its entry point while holding no distributions.

Zipped eggs and zipapps on the search path warn as before. Other files on `sys.path` stay silent.
