### PR TITLE
👷 ci: retry the Windows Graphviz install

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -78,7 +78,13 @@ jobs:
         run: sudo apt-get install graphviz -y
       - name: Install OS dependencies (Windows)
         if: runner.os == 'Windows'
-        run: choco install graphviz -y
+        run: |
+          foreach ($attempt in 1..3) {
+            choco install graphviz -y --no-progress --fail-on-unfound
+            if ($LASTEXITCODE -eq 0) { break }
+            Start-Sleep -Seconds (30 * $attempt)
+          }
+          dot -V
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0


### PR DESCRIPTION
On https://github.com/tox-dev/pipdeptree/actions/runs/31786377448 the `windows-latest` job hit a Chocolatey feed `504`, `choco install graphviz -y` logged `Unable to find package 'Graphviz'` and `installed 0/0 packages` yet exited 0, so every `test_cli_graphviz_binary*` test failed with no `dot` on `PATH`. The step now passes `--fail-on-unfound` so a missing package is an error, retries the install up to three times with a growing pause, and ends with `dot -V` so a broken install fails the step instead of the test suite.
