### PR TITLE
👷 ci: derive the wheel toolchain from rust-toolchain.toml

### DIFF
--- a/.github/workflows/dist.yaml
+++ b/.github/workflows/dist.yaml
@@ -85,6 +85,7 @@ jobs:
           echo "CIBW_MUSLLINUX_${ARCH^^}_IMAGE=$musllinux" >> "$GITHUB_ENV"
       - name: Read the toolchain rustup should install
         id: rust
+        shell: bash
         run: |
           python3 - <<'EOF' >> "$GITHUB_OUTPUT"
           import tomllib

--- a/.github/workflows/dist.yaml
+++ b/.github/workflows/dist.yaml
@@ -83,15 +83,27 @@ jobs:
           done
           echo "CIBW_MANYLINUX_${ARCH^^}_IMAGE=$manylinux" >> "$GITHUB_ENV"
           echo "CIBW_MUSLLINUX_${ARCH^^}_IMAGE=$musllinux" >> "$GITHUB_ENV"
+      - name: Read the toolchain rustup should install
+        id: rust
+        run: |
+          python3 - <<'EOF' >> "$GITHUB_OUTPUT"
+          import tomllib
+          from pathlib import Path
+
+          toolchain = tomllib.loads(Path("rust-toolchain.toml").read_text())["toolchain"]
+          flags = ["--default-toolchain", toolchain["channel"]]
+          flags += [word for name in toolchain["components"] for word in ("--component", name)]
+          print("flags=" + " ".join(flags))
+          EOF
       - name: Build wheels
         uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
         env:
           CIBW_ARCHS: ${{ matrix.platform.arch }}
-          # Install the pinned toolchain and its components up front. Left to rust-toolchain.toml, the first
-          # cargo call in each container provisions them on demand, which races and conflicts on the
-          # cargo-clippy hardlink on aarch64. Keep the channel and components in sync with rust-toolchain.toml.
+          # Install the toolchain and its components up front. Left to rust-toolchain.toml, the first cargo
+          # call in each container provisions them on demand, which races and conflicts on the cargo-clippy
+          # hardlink on aarch64.
           CIBW_BEFORE_ALL_LINUX: >-
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.98 --component clippy --component llvm-tools-preview --component rustfmt
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal ${{ steps.rust.outputs.flags }}
           # 3.15 is still a prerelease, so cpython-prerelease enables its free-threaded build.
           CIBW_BUILD: ${{ matrix.identifiers || format('{0}-*', matrix.build) }}
           CIBW_ENABLE: pypy cpython-prerelease


### PR DESCRIPTION
The wheel build pins the Rust channel and components in `CIBW_BEFORE_ALL_LINUX`, and `rust-toolchain.toml` states them again; the comment above the pin asks whoever edits one to keep the other in sync. Dependabot owns the toml file and cannot reach the workflow, so [#686](https://github.com/tox-dev/pipdeptree/pull/686) moved the channel to 1.98 while the pin stayed at 1.97. Each container then provisioned 1.98 on demand during the parallel ninja build, raced, and the aarch64 musl wheel died with `recovering from a partially installed toolchain` then `detected conflict: 'bin/cargo-clippy'`. 👷

A step now reads `rust-toolchain.toml` and hands rustup the flags, so the two cannot disagree and the next toolchain bump needs no workflow edit. Running the step as GitHub composes it emits `flags=--default-toolchain 1.97 --component clippy --component llvm-tools-preview --component rustfmt`.
