### PR TITLE
👷 ci(release): report a missing release token

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -17,6 +17,15 @@ jobs:
     permissions:
       contents: write # the release commit and its tag go straight to main
     steps:
+      # An expired or revoked PAT otherwise surfaces as checkout's "Input required and not supplied: token".
+      - name: Check the release token is set
+        env:
+          RELEASE_PAT: ${{ secrets.RELEASE_PAT }}
+        run: |
+          if [ -z "$RELEASE_PAT" ]; then
+            echo "::error::RELEASE_PAT is unset; add it to the release-auth environment"
+            exit 1
+          fi
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0 # The next version comes from the tags.


### PR DESCRIPTION
Every dispatch of [Prepare release](https://github.com/tox-dev/pipdeptree/actions/workflows/prepare-release.yaml) has failed at the checkout step with `Input required and not supplied: token`, on 2026-08-08, 2026-08-13 and 2026-08-20. The message names neither the missing secret nor the environment it belongs in, and reaching it costs a dispatch and a look at the log. `RELEASE_PAT` is absent from the `release-auth` environment, and the same failure returns whenever the token expires or gets revoked.

A guard ahead of the checkout now reads the secret and stops with `RELEASE_PAT is unset; add it to the release-auth environment`, which shows up on the run summary as an annotation. Supplying the token stays a separate step, done in the repository settings.
