### PR TITLE
👷 ci(dist): build Windows arm64 wheels

### DIFF
--- a/.github/workflows/dist.yaml
+++ b/.github/workflows/dist.yaml
@@ -23,6 +23,14 @@ jobs:
             arch: aarch64
           - os: windows-latest
             arch: AMD64
+          - os: windows-11-arm
+            arch: ARM64
+        exclude:
+          # PyPy ships no Windows arm64 interpreter, and cibuildwheel stops a job whose selector matches nothing.
+          - build: pp311
+            platform:
+              os: windows-11-arm
+              arch: ARM64
         include:
           # The Intel runner takes about twice as long as the arm one for the same work, so it splits its four
           # builds over two jobs; three macOS jobs stay well inside the cap that made a job per interpreter queue.

--- a/docs/changelog/693.feature.rst
+++ b/docs/changelog/693.feature.rst
@@ -1,0 +1,4 @@
+Publish Windows ``arm64`` wheels. Every Windows wheel was built for ``AMD64``, so ``pip`` and ``uv`` fell back to the
+source distribution on Windows on ARM, where building the Rust extension needs a local ``cargo`` and MSVC toolchain.
+The ``cp310`` abi3 wheel and the free-threaded ``cp314t`` and ``cp315t`` wheels now ship for that platform too; PyPy
+publishes no Windows ``arm64`` interpreter, so ``pp311`` stays ``AMD64`` only.


### PR DESCRIPTION
Jens asked for a Windows ARM64 distribution in [discussion #693](https://github.com/tox-dev/pipdeptree/discussions/693). The wheel matrix builds Windows on `AMD64` alone, so `pip` and `uv` fall back to the sdist on Windows on ARM, and since 4.0.0 that means compiling the Rust extension against a local `cargo` and MSVC toolchain. Before 4.0.0 the single `py3-none-any` wheel covered the platform for free.

The `windows-11-arm` runner builds ARM64 natively, so the platform joins the matrix as one more entry rather than through cross-compilation. `cibuildwheel` offers `cp310-win_arm64`, `cp314t-win_arm64` and `cp315t-win_arm64`, which lines up with the interpreters already in the matrix, so the `cp310` job produces the shared abi3 wheel and the two free-threaded jobs produce theirs. PyPy publishes no Windows `arm64` interpreter and `cibuildwheel` stops a job whose selector matches nothing, so `pp311` is excluded for that platform alone.

Three build jobs join every dist run, and they run beside the existing ones. The runner image carries Rust 1.98.0, which is what `rust-toolchain.toml` pins, and Visual Studio 2022. Worth watching: `actions/runner-images` [moves the `windows-11-arm` label to a Visual Studio 2026 image in September 2026](https://github.com/actions/runner-images/issues/14602).
